### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-npm-binaries.yml
+++ b/.github/workflows/build-npm-binaries.yml
@@ -181,6 +181,8 @@ jobs:
 
   build:
     needs: [compile, version]
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -7,6 +7,9 @@ on:
   release:
     types: [published, edited]
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     name: Publish to crates.io


### PR DESCRIPTION
Potential fix for [https://github.com/tishlang/tish/security/code-scanning/9](https://github.com/tishlang/tish/security/code-scanning/9)

In general, the fix is to add an explicit `permissions` block to the workflow (either at the root or inside the `publish` job) that grants only the scopes actually required. This documents the workflow’s needs and prevents it from inheriting broader repository defaults.

For this specific workflow:

- `actions/checkout@v4` only needs `contents: read`.
- The `curl` calls using `GITHUB_TOKEN` patch the release description, which is part of repository contents/releases and requires `contents: write`.
- No other GitHub resources (issues, pull requests, etc.) are modified.

The single best fix without changing behavior is to add a workflow‑level `permissions` block (so it applies to all jobs) immediately after the `on:` block, with:

```yaml
permissions:
  contents: write
```

This gives read/write access to repository contents (including releases) but nothing else. No additional imports or methods are needed; it’s a pure YAML configuration change within `.github/workflows/crates-release.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
