### PR TITLE
Enable iOS & MacOS build targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ tish_hello
 *.swo
 .DS_Store
 target/*
-
+target-gpu/*
 
 dist/
 debug_out.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3409,7 +3409,9 @@ name = "tishlang_wasm_runtime"
 version = "0.1.0"
 dependencies = [
  "getrandom 0.4.2",
+ "js-sys",
  "tishlang_bytecode",
+ "tishlang_core",
  "tishlang_vm",
  "wasm-bindgen",
 ]

--- a/crates/tish/src/cli_help.rs
+++ b/crates/tish/src/cli_help.rs
@@ -530,6 +530,12 @@ pub(crate) struct BuildArgs {
         help_heading = "Options"
     )]
     pub features: Vec<String>,
+    /// Cross-compile to an Apple iOS triple (e.g. `aarch64-apple-ios-sim`). Implies `--crate-type staticlib`.
+    #[arg(long, value_name = "TRIPLE", help_heading = "Options")]
+    pub ios_triple: Option<String>,
+    /// Output artifact for `--target native` (default: `bin`; use `staticlib` for embedded iOS).
+    #[arg(long, value_name = "TYPE", default_value = "bin", help_heading = "Options")]
+    pub crate_type: String,
     #[arg(long, help_heading = "Options")]
     pub no_optimize: bool,
     /// For `--target js` project builds: emit `OUTPUT.js.map` and `//# sourceMappingURL=…` so JS/TS tools can jump to original `.tish` (implies `--no-optimize` for that build).

--- a/crates/tish/src/cli_help.rs
+++ b/crates/tish/src/cli_help.rs
@@ -405,6 +405,8 @@ pub fn build_after_help() -> String {
           WebAssembly (.tish project; .js source supported on some paths)
   {t}wasi{r}
           WASI WebAssembly
+  {t}bytecode{r}
+          Raw serialized bytecode chunk (no VM binary/JS/HTML); for hosts that already ship the runtime
 
 {oh}Native backends{r} (--native-backend, only with --target native, default: rust):
   {t}rust{r}
@@ -506,7 +508,7 @@ pub(crate) struct BuildArgs {
         help_heading = "Options"
     )]
     pub output: String,
-    /// `native`, `js`, `wasm`, or `wasi` (see long help below).
+    /// `native`, `js`, `wasm`, `wasi`, or `bytecode` (see long help below).
     #[arg(
         long,
         default_value = "native",

--- a/crates/tish/src/main.rs
+++ b/crates/tish/src/main.rs
@@ -627,9 +627,26 @@ fn build_file(
         .map_err(|e| e.to_string());
     }
 
+    if target == "bytecode" {
+        let project_root = input_path.parent().and_then(|p| {
+            if p.file_name().and_then(|n| n.to_str()) == Some("src") {
+                p.parent()
+            } else {
+                Some(p)
+            }
+        });
+        return tishlang_wasm::compile_to_bytecode(
+            &input_path,
+            project_root,
+            Path::new(output_path),
+            optimize,
+        )
+        .map_err(|e| e.to_string());
+    }
+
     if target != "native" {
         return Err(format!(
-            "Unknown target: {}. Use 'native', 'js', 'wasm', or 'wasi'.",
+            "Unknown target: {}. Use 'native', 'js', 'wasm', 'wasi', or 'bytecode'.",
             target
         ));
     }

--- a/crates/tish/src/main.rs
+++ b/crates/tish/src/main.rs
@@ -111,6 +111,8 @@ fn main() {
             &a.features,
             a.no_optimize || no_opt_env,
             a.source_map,
+            a.ios_triple.as_deref(),
+            &a.crate_type,
         ),
         Some(Commands::DumpAst { file }) => dump_ast(&file),
         None => {
@@ -568,6 +570,8 @@ fn build_file(
     cli_features: &[String],
     no_optimize: bool,
     source_map: bool,
+    ios_triple: Option<&str>,
+    crate_type: &str,
 ) -> Result<(), String> {
     let optimize = !no_optimize;
     let input_path = Path::new(input_path)
@@ -639,9 +643,31 @@ fn build_file(
     });
     let features: Vec<String> = native_build_features_from_cli(cli_features);
 
+    let build_config = if let Some(triple) = ios_triple {
+        tishlang_native::NativeBuildConfig::ios_staticlib(triple)
+    } else if crate_type == "staticlib" {
+        tishlang_native::NativeBuildConfig {
+            artifact: tishlang_native::NativeArtifact::StaticLib,
+            cargo_target: None,
+            emit_mode: tishlang_compile::NativeEmitMode::EmbeddedLib,
+        }
+    } else if crate_type != "bin" {
+        return Err(format!(
+            "Unknown --crate-type: {}. Use 'bin' or 'staticlib'.",
+            crate_type
+        ));
+    } else {
+        tishlang_native::NativeBuildConfig::desktop()
+    };
+
     if is_js {
         let source = fs::read_to_string(&input_path).map_err(|e| format!("{}", e))?;
         let program = tishlang_js_to_tish::convert(&source).map_err(|e| format!("{}", e))?;
+        if build_config.artifact != tishlang_native::NativeArtifact::Bin {
+            return Err(
+                "--crate-type staticlib / --ios-triple require a .tish entry file.".to_string(),
+            );
+        }
         tishlang_native::compile_program_to_native(
             &program,
             project_root,
@@ -652,13 +678,14 @@ fn build_file(
         )
         .map_err(|e| e.to_string())?;
     } else {
-        tishlang_native::compile_to_native(
+        tishlang_native::compile_to_native_with_config(
             &input_path,
             project_root,
             Path::new(output_path),
             &features,
             native_backend,
             optimize,
+            &build_config,
         )
         .map_err(|e| e.to_string())?;
     }
@@ -667,7 +694,15 @@ fn build_file(
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("tish_out");
-    let built_path = if output_path.ends_with('/') || Path::new(output_path).is_dir() {
+    let built_path = if build_config.artifact == tishlang_native::NativeArtifact::StaticLib {
+        if output_path.ends_with('/') || Path::new(output_path).is_dir() {
+            Path::new(output_path).join(format!("lib{out_name}.a"))
+        } else if output_path.ends_with(".a") {
+            Path::new(output_path).to_path_buf()
+        } else {
+            Path::new(output_path).with_extension("a")
+        }
+    } else if output_path.ends_with('/') || Path::new(output_path).is_dir() {
         Path::new(output_path).join(out_name)
     } else {
         Path::new(output_path).to_path_buf()

--- a/crates/tish_build_utils/src/lib.rs
+++ b/crates/tish_build_utils/src/lib.rs
@@ -338,6 +338,11 @@ pub fn find_crate_path(crate_name: &str) -> Result<PathBuf, String> {
     Ok(crate_path)
 }
 
+/// Sanitize a user-chosen output stem for Cargo `[lib]` / `[[bin]]` target names.
+pub fn cargo_target_name(stem: &str) -> String {
+    stem.replace('-', "_")
+}
+
 /// Create a temp build directory with src subdir.
 pub fn create_build_dir(prefix: &str, out_name: &str) -> Result<PathBuf, String> {
     let build_dir =
@@ -380,8 +385,12 @@ fn protoc_for_nested_cargo() -> Option<PathBuf> {
 }
 
 /// Run cargo build in the given directory.
-/// If target_dir is Some, use that for --target-dir (e.g. workspace target for caching).
-pub fn run_cargo_build(build_dir: &Path, target_dir: Option<&Path>) -> Result<(), String> {
+/// If `cross_target` is Some, passes `--target` and skips `-C target-cpu=native`.
+pub fn run_cargo_build(
+    build_dir: &Path,
+    target_dir: Option<&Path>,
+    cross_target: Option<&str>,
+) -> Result<(), String> {
     let _nested_guard = NESTED_CARGO_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
 
     let target_dir = target_dir
@@ -389,11 +398,10 @@ pub fn run_cargo_build(build_dir: &Path, target_dir: Option<&Path>) -> Result<()
         .unwrap_or_else(|| build_dir.join("target"));
     let fast_native = std::env::var("TISH_FAST_NATIVE_BUILD").as_deref() == Ok("1");
 
-    // Default to target-cpu=native so the emitted binary uses every SIMD / ISA
-    // extension the build host supports. Callers can override by pre-setting
-    // RUSTFLAGS in the environment. Skipped for fast nested builds (integration tests).
     let mut merged_rustflags = std::env::var("RUSTFLAGS").unwrap_or_default();
-    if fast_native {
+    if cross_target.is_some() {
+        // Cross-compiling (e.g. iOS): do not use host target-cpu.
+    } else if fast_native {
         if cfg!(target_os = "linux")
             && mold_available()
             && !merged_rustflags.contains("fuse-ld=mold")
@@ -407,10 +415,6 @@ pub fn run_cargo_build(build_dir: &Path, target_dir: Option<&Path>) -> Result<()
         merged_rustflags = format!("{} -C target-cpu=native", merged_rustflags);
     }
 
-    // Nested `cargo build` (e.g. `tish build --native-backend rust`) inherits the parent
-    // environment. CI often sets `RUSTC_WRAPPER=sccache`; wrapping this inner compile too can
-    // cause flaky or failed builds (LTO / temp-crate paths). Use plain rustc here; the main
-    // workspace build still benefits from the wrapper.
     let mut cmd = Command::new("cargo");
     cmd.args(["build", "--release", "--target-dir"])
         .arg(&target_dir)
@@ -421,6 +425,9 @@ pub fn run_cargo_build(build_dir: &Path, target_dir: Option<&Path>) -> Result<()
         .env_remove("CARGO_BUILD_RUSTC_WRAPPER")
         .env("CARGO_TERM_PROGRESS", "always")
         .env("RUSTFLAGS", &merged_rustflags);
+    if let Some(triple) = cross_target {
+        cmd.arg("--target").arg(triple);
+    }
     if fast_native {
         cmd.env("CARGO_INCREMENTAL", "1");
     } else {
@@ -449,12 +456,28 @@ mod protoc_tests {
     use super::*;
 
     #[test]
+    fn cargo_target_name_replaces_hyphens() {
+        assert_eq!(cargo_target_name("hello-ios"), "hello_ios");
+        assert_eq!(cargo_target_name("tish_out"), "tish_out");
+    }
+
+    #[test]
     fn protoc_for_nested_cargo_without_env_uses_vendored_or_path() {
         let _lock = std::sync::Mutex::new(());
         let _guard = _lock.lock().unwrap();
         std::env::remove_var("PROTOC");
         let p = protoc_for_nested_cargo().expect("expected vendored or PATH protoc");
         assert!(p.exists(), "resolved protoc should exist: {}", p.display());
+    }
+}
+
+/// Find the built static library in target/release (or target/$TRIPLE/release).
+pub fn find_release_staticlib(binary_dir: &Path, lib_name: &str) -> Result<PathBuf, String> {
+    let path = binary_dir.join(format!("lib{lib_name}.a"));
+    if path.exists() {
+        Ok(path)
+    } else {
+        Err(format!("Static library not found at {}", path.display()))
     }
 }
 

--- a/crates/tish_builtins/src/math.rs
+++ b/crates/tish_builtins/src/math.rs
@@ -80,3 +80,10 @@ pub fn hypot(args: &[Value]) -> Value {
     let y = extract_num(args.get(1)).unwrap_or(0.0);
     Value::Number(x.hypot(y))
 }
+
+/// ES6 `Math.imul`: 32-bit integer multiply (used by xmur3 PRNG in juke-cards).
+pub fn imul(args: &[Value]) -> Value {
+    let a = extract_num(args.first()).unwrap_or(0.0) as i32;
+    let b = extract_num(args.get(1)).unwrap_or(0.0) as i32;
+    Value::Number(a.wrapping_mul(b) as f64)
+}

--- a/crates/tish_builtins/src/string.rs
+++ b/crates/tish_builtins/src/string.rs
@@ -189,6 +189,32 @@ pub fn substring(s: &Value, start: &Value, end: &Value) -> Value {
     }
 }
 
+/// JS `String.prototype.substr(start, length)`.
+pub fn substr(s: &Value, start: &Value, length: &Value) -> Value {
+    if let Value::String(s) = s {
+        let chars: Vec<char> = s.chars().collect();
+        let len = chars.len();
+        let mut start_idx = match start {
+            Value::Number(n) => *n as i64,
+            _ => 0,
+        };
+        if start_idx < 0 {
+            start_idx = (len as i64 + start_idx).max(0);
+        }
+        let start_idx = (start_idx as usize).min(len);
+        let count = match length {
+            Value::Null => len - start_idx,
+            Value::Number(n) => (*n as i64).max(0) as usize,
+            _ => len - start_idx,
+        };
+        let end_idx = (start_idx + count).min(len);
+        let result: String = chars[start_idx..end_idx].iter().collect();
+        Value::String(result.into())
+    } else {
+        Value::Null
+    }
+}
+
 pub fn split(s: &Value, sep: &Value) -> Value {
     if let Value::String(s) = s {
         let separator = match sep {

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -582,11 +582,17 @@ pub fn compile_project_full_emit(
         message: e,
         span: None,
     })?;
-    let native_modules =
+    let mut native_modules =
         resolve::resolve_native_modules(&merged.program, root).map_err(|e| CompileError {
             message: e,
             span: None,
         })?;
+    if resolve::program_uses_document(&merged.program) {
+        resolve::ensure_tish_canvas_module(&mut native_modules, root).map_err(|e| CompileError {
+            message: e,
+            span: None,
+        })?;
+    }
     let native_build =
         resolve::compute_native_build_artifacts(&merged.program, root, &native_modules).map_err(
             |e| CompileError {
@@ -741,6 +747,8 @@ struct Codegen {
     emit_mode: crate::NativeEmitMode,
     /// Program links `tish:macos` / `tish:ios` — skip HeadlessHost install.
     has_native_ui_host: bool,
+    /// Program references browser global `document` — inject tish-canvas.
+    program_uses_document: bool,
 }
 
 impl Codegen {
@@ -773,6 +781,17 @@ impl Codegen {
             value_fn_depth: 0,
             emit_mode: crate::NativeEmitMode::DesktopBin,
             has_native_ui_host: false,
+            program_uses_document: false,
+        }
+    }
+
+    /// In async `run()` bodies, propagate runtime op errors with `?`; in sync
+    /// `Value::native` closures use `.unwrap_or(Value::Null)`.
+    fn ops_result_suffix(&self) -> &'static str {
+        if self.is_async && self.async_context_stack.last().copied().unwrap_or(false) {
+            "?"
+        } else {
+            ".unwrap_or(Value::Null)"
         }
     }
 
@@ -1284,11 +1303,12 @@ impl Codegen {
         self.is_async = program_uses_async(program);
         self.program_has_jsx = tishlang_ui::jsx::program_contains_jsx(program);
         self.program_fun_decl_names = tishlang_ui::jsx::collect_fun_decl_names(program);
+        self.program_uses_document = crate::resolve::program_uses_document(program);
         self.write("#![allow(unused, non_snake_case)]\n\n");
         self.write("use std::cell::RefCell;\n");
         self.write("use std::rc::Rc;\n");
         self.write("use std::sync::Arc;\n");
-        self.write("use tishlang_runtime::{console_debug as tish_console_debug, console_info as tish_console_info, console_log as tish_console_log, console_warn as tish_console_warn, console_error as tish_console_error, boolean as tish_boolean, decode_uri as tish_decode_uri, encode_uri as tish_encode_uri, string_escape_html_impl as tish_escape_html, in_operator as tish_in_operator, is_finite as tish_is_finite, is_nan as tish_is_nan, json_parse as tish_json_parse, json_stringify as tish_json_stringify, math_abs as tish_math_abs, math_ceil as tish_math_ceil, math_floor as tish_math_floor, math_max as tish_math_max, math_min as tish_math_min, math_round as tish_math_round, math_sqrt as tish_math_sqrt, parse_float as tish_parse_float, parse_int as tish_parse_int, math_random as tish_math_random, math_pow as tish_math_pow, math_sin as tish_math_sin, math_cos as tish_math_cos, math_tan as tish_math_tan, math_log as tish_math_log, math_exp as tish_math_exp, math_sign as tish_math_sign, math_trunc as tish_math_trunc, date_now as tish_date_now, array_is_array as tish_array_is_array, string_from_char_code as tish_string_from_char_code, object_assign as tish_object_assign, object_keys as tish_object_keys, object_values as tish_object_values, object_entries as tish_object_entries, object_from_entries as tish_object_from_entries, symbol_object as tish_symbol_object, tish_construct, tish_uint8_array_constructor, tish_audio_context_constructor, register_static_route as tish_register_static_route, ObjectMap, TishError, Value, VmRef};\n");
+        self.write("use tishlang_runtime::{console_debug as tish_console_debug, console_info as tish_console_info, console_log as tish_console_log, console_warn as tish_console_warn, console_error as tish_console_error, boolean as tish_boolean, decode_uri as tish_decode_uri, encode_uri as tish_encode_uri, string_escape_html_impl as tish_escape_html, in_operator as tish_in_operator, is_finite as tish_is_finite, is_nan as tish_is_nan, json_parse as tish_json_parse, json_stringify as tish_json_stringify, math_abs as tish_math_abs, math_ceil as tish_math_ceil, math_floor as tish_math_floor, math_max as tish_math_max, math_min as tish_math_min, math_round as tish_math_round, math_sqrt as tish_math_sqrt, parse_float as tish_parse_float, parse_int as tish_parse_int, math_random as tish_math_random, math_pow as tish_math_pow, math_sin as tish_math_sin, math_cos as tish_math_cos, math_tan as tish_math_tan, math_log as tish_math_log, math_exp as tish_math_exp, math_sign as tish_math_sign, math_trunc as tish_math_trunc, math_imul as tish_math_imul, date_now as tish_date_now, array_is_array as tish_array_is_array, string_from_char_code as tish_string_from_char_code, object_assign as tish_object_assign, object_keys as tish_object_keys, object_values as tish_object_values, object_entries as tish_object_entries, object_from_entries as tish_object_from_entries, symbol_object as tish_symbol_object, tish_construct, tish_uint8_array_constructor, tish_audio_context_constructor, register_static_route as tish_register_static_route, ObjectMap, TishError, Value, VmRef};\n");
         if self.program_has_jsx {
             self.write("use tishlang_ui::{fragment_value, install_thread_local_host, native_create_root, native_use_state, ui_h, ui_text, HeadlessHost};\n");
         }
@@ -1314,6 +1334,9 @@ impl Codegen {
         if self.has_feature("regex") {
             self.write("use tishlang_runtime::regexp_new;\n");
         }
+        if self.program_uses_document {
+            self.write("use tish_canvas::document_value as tish_canvas_document;\n");
+        }
         self.write("\n");
 
         // Collect every `type Foo = { ... }` declaration in the program
@@ -1329,7 +1352,7 @@ impl Codegen {
         // and `x.field` becomes a direct field access.
         self.emit_named_struct_decls();
 
-        if self.is_async {
+        if self.is_async && self.emit_mode == crate::NativeEmitMode::DesktopBin {
             self.writeln("#[tokio::main]");
             self.writeln("async fn main() {");
         } else if self.emit_mode == crate::NativeEmitMode::DesktopBin {
@@ -1417,6 +1440,9 @@ impl Codegen {
         self.writeln(
             "(Arc::from(\"trunc\"), Value::native(|args: &[Value]| tish_math_trunc(args))),",
         );
+        self.writeln(
+            "(Arc::from(\"imul\"), Value::native(|args: &[Value]| tish_math_imul(args))),",
+        );
         self.writeln("(Arc::from(\"PI\"), Value::Number(std::f64::consts::PI)),");
         self.writeln("(Arc::from(\"E\"), Value::Number(std::f64::consts::E)),");
         self.indent -= 1;
@@ -1472,6 +1498,14 @@ impl Codegen {
 
         self.writeln("let Uint8Array = tish_uint8_array_constructor();");
         self.writeln("let AudioContext = tish_audio_context_constructor();");
+        if self.program_uses_document {
+            self.writeln("let document = VmRef::new(tish_canvas_document());");
+            self.refcell_wrapped_vars.insert("document".to_string());
+            self.rc_cell_storage_define("document");
+            if let Some(scope) = self.outer_vars_stack.last_mut() {
+                scope.push("document".to_string());
+            }
+        }
 
         if self.has_feature("process") {
             self.writeln("let process = Value::object({");
@@ -2308,6 +2342,10 @@ impl Codegen {
                     for v in &mutable_outer_vars {
                         self.refcell_wrapped_vars.insert(v.clone());
                     }
+                    // Read-only captures are plain Value bindings inside the closure.
+                    for v in &read_only_outer_vars {
+                        self.refcell_wrapped_vars.remove(v);
+                    }
 
                     // Pre-scan body for nested functions (handles function body as Block)
                     if let Statement::Block { statements, .. } = body.as_ref() {
@@ -2568,7 +2606,12 @@ impl Codegen {
                         // Convert native type to Value for compatibility with existing code
                         var_type.to_value_expr(&escaped)
                     } else {
-                        escaped.into_owned()
+                        let s = escaped.into_owned();
+                        if self.value_fn_depth > 0 || !self.loop_stack.is_empty() {
+                            format!("({}).clone()", s)
+                        } else {
+                            s
+                        }
                     }
                 }
             }
@@ -2824,6 +2867,14 @@ impl Codegen {
                             return Ok(format!(
                                 "tishlang_runtime::string_substring(&{}, &{}, &{})",
                                 obj_expr, start, end
+                            ));
+                        }
+                        "substr" => {
+                            let start = arg_exprs.first().cloned().unwrap_or_else(|| "Value::Number(0.0)".to_string());
+                            let length = arg_exprs.get(1).cloned().unwrap_or_else(|| "Value::Null".to_string());
+                            return Ok(format!(
+                                "tishlang_runtime::string_substr(&{}, &{}, &{})",
+                                obj_expr, start, length
                             ));
                         }
                         "split" => {
@@ -3467,10 +3518,11 @@ impl Codegen {
                     CompoundOp::Div => "div",
                     CompoundOp::Mod => "modulo",
                 };
+                let op_suffix = self.ops_result_suffix();
                 if is_refcell {
                     format!(
-                        "{{ let _lhs_v = (*{}.borrow()).clone(); let _rhs = ({}).clone(); let _new = tishlang_runtime::ops::{}(&_lhs_v, &_rhs)?; *{}.borrow_mut() = _new; (*{}.borrow()).clone() }}",
-                        n, val, op_fn, n, n
+                        "{{ let _lhs_v = (*{}.borrow()).clone(); let _rhs = ({}).clone(); let _new = tishlang_runtime::ops::{}(&_lhs_v, &_rhs){}; *{}.borrow_mut() = _new; (*{}.borrow()).clone() }}",
+                        n, val, op_fn, op_suffix, n, n
                     )
                 } else if var_type.is_native() {
                     // Wrap native lhs as Value, run ops::, unbox result back to native
@@ -3478,13 +3530,13 @@ impl Codegen {
                     let result_native = var_type.from_value_expr("_result");
                     let n_as_value2 = var_type.to_value_expr(&n);
                     format!(
-                        "{{ let _lhs = {}; let _rhs = ({}).clone(); let _result = tishlang_runtime::ops::{}(&_lhs, &_rhs)?; {} = {}; {} }}",
-                        n_as_value, val, op_fn, n, result_native, n_as_value2
+                        "{{ let _lhs = {}; let _rhs = ({}).clone(); let _result = tishlang_runtime::ops::{}(&_lhs, &_rhs){}; {} = {}; {} }}",
+                        n_as_value, val, op_fn, op_suffix, n, result_native, n_as_value2
                     )
                 } else {
                     format!(
-                        "{{ let _rhs = ({}).clone(); {} = tishlang_runtime::ops::{}(&{}, &_rhs)?; {}.clone() }}",
-                        val, n, op_fn, n, n
+                        "{{ let _rhs = ({}).clone(); {} = tishlang_runtime::ops::{}(&{}, &_rhs){}; {}.clone() }}",
+                        val, n, op_fn, n, op_suffix, n
                     )
                 }
             }
@@ -4776,6 +4828,41 @@ impl Codegen {
             ));
         }
 
+        // Locals from an enclosing Value::native (e.g. captured helper fns) are not on
+        // outer_vars_stack but must not move into multiple sibling closures.
+        const BUILTINS: &[&str] = &[
+            "Boolean", "console", "Math", "JSON", "Date", "Object", "process",
+            "setTimeout", "clearTimeout", "setInterval", "clearInterval", "Promise",
+            "Symbol", "RegExp", "Polars", "Infinity", "NaN", "serve",
+        ];
+        let mut already_captured: HashSet<String> = outer_vars
+            .iter()
+            .chain(outer_params.iter())
+            .chain(referenced_funcs.iter())
+            .cloned()
+            .collect();
+        already_captured.extend(BUILTINS.iter().map(|s| s.to_string()));
+        let implicit_env_captures: Vec<String> = if self.value_fn_depth > 0 {
+            referenced
+                .iter()
+                .filter(|name| {
+                    !param_names.contains(name.as_str())
+                        && !local_var_names.contains(name.as_str())
+                        && !already_captured.contains(name.as_str())
+                })
+                .cloned()
+                .collect()
+        } else {
+            Vec::new()
+        };
+        for name in &implicit_env_captures {
+            let escaped = Self::escape_ident(name);
+            code.push_str(&format!(
+                "    let {}_ref = VmRef::new({}.clone());\n",
+                escaped, escaped
+            ));
+        }
+
         code.push_str("    Value::native(move |args: &[Value]| {\n");
         self.value_fn_depth += 1;
 
@@ -4801,6 +4888,13 @@ impl Codegen {
             code.push_str(&format!(
                 "        let {} = (*{}_ref.borrow()).clone();\n",
                 var_escaped, var_escaped
+            ));
+        }
+        for name in &implicit_env_captures {
+            let escaped = Self::escape_ident(name);
+            code.push_str(&format!(
+                "        let {} = (*{}_ref.borrow()).clone();\n",
+                escaped, escaped
             ));
         }
 
@@ -4854,6 +4948,12 @@ impl Codegen {
         let saved_refcell_vars = self.refcell_wrapped_vars.clone();
         for v in &cell_capture_outer_vars {
             self.refcell_wrapped_vars.insert(v.clone());
+        }
+        for v in &read_only_outer_vars {
+            self.refcell_wrapped_vars.remove(v);
+        }
+        for v in &implicit_env_captures {
+            self.refcell_wrapped_vars.remove(v);
         }
 
         self.type_context.push_fun_param_scope(params, None);

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -541,6 +541,33 @@ pub fn compile_project_full(
     ),
     CompileError,
 > {
+    compile_project_full_emit(
+        entry_path,
+        project_root,
+        features,
+        optimize,
+        crate::NativeEmitMode::DesktopBin,
+        None,
+    )
+}
+
+/// Like [`compile_project_full`], with emit mode and optional feature cap (e.g. iOS sandbox).
+pub fn compile_project_full_emit(
+    entry_path: &Path,
+    project_root: Option<&Path>,
+    features: &[String],
+    optimize: bool,
+    emit_mode: crate::NativeEmitMode,
+    feature_cap: Option<&std::collections::HashSet<String>>,
+) -> Result<
+    (
+        String,
+        Vec<crate::resolve::ResolvedNativeModule>,
+        Vec<String>,
+        crate::resolve::NativeBuildArtifacts,
+    ),
+    CompileError,
+> {
     use crate::resolve;
     let root = project_root.unwrap_or_else(|| entry_path.parent().unwrap_or(Path::new(".")));
     let modules = resolve::resolve_project(entry_path, project_root).map_err(|e| CompileError {
@@ -573,13 +600,17 @@ pub fn compile_project_full(
             all_features.push(f);
         }
     }
-    let rust = compile_with_native_modules(
+    if let Some(cap) = feature_cap {
+        all_features.retain(|f| cap.contains(f));
+    }
+    let rust = compile_with_native_modules_emit(
         &merged.program,
         project_root,
         &all_features,
         &native_modules,
         &native_build.native_init,
         optimize,
+        emit_mode,
     )?;
     Ok((rust, native_modules, all_features, native_build))
 }
@@ -603,6 +634,26 @@ pub fn compile_with_native_modules(
     native_modules: &[crate::resolve::ResolvedNativeModule],
     native_init: &std::collections::HashMap<String, crate::resolve::NativeModuleInit>,
     optimize: bool,
+) -> Result<String, CompileError> {
+    compile_with_native_modules_emit(
+        program,
+        project_root,
+        features,
+        native_modules,
+        native_init,
+        optimize,
+        crate::NativeEmitMode::DesktopBin,
+    )
+}
+
+pub fn compile_with_native_modules_emit(
+    program: &Program,
+    project_root: Option<&Path>,
+    features: &[String],
+    native_modules: &[crate::resolve::ResolvedNativeModule],
+    native_init: &std::collections::HashMap<String, crate::resolve::NativeModuleInit>,
+    optimize: bool,
+    emit_mode: crate::NativeEmitMode,
 ) -> Result<String, CompileError> {
     let program = if optimize {
         tishlang_opt::optimize(program)
@@ -630,6 +681,13 @@ pub fn compile_with_native_modules(
             native_init.clone()
         };
     let mut g = Codegen::new_with_native_modules(project_root, features, map);
+    g.emit_mode = emit_mode;
+    g.has_native_ui_host = native_modules.iter().any(|m| {
+        m.package_name == "tish-macos"
+            || m.package_name == "tish-ios"
+            || m.crate_name == "tishlang_macos"
+            || m.crate_name == "tishlang_ios"
+    });
     g.emit_program(&program)?;
     Ok(g.output)
 }
@@ -680,6 +738,9 @@ struct Codegen {
     /// `try`/`throw` lowering uses `return Err` only at depth 0 (e.g. `run()`); inside native
     /// closures it must not return a `Result` from a `Value`-returning closure.
     value_fn_depth: u32,
+    emit_mode: crate::NativeEmitMode,
+    /// Program links `tish:macos` / `tish:ios` — skip HeadlessHost install.
+    has_native_ui_host: bool,
 }
 
 impl Codegen {
@@ -710,6 +771,8 @@ impl Codegen {
             program_has_jsx: false,
             program_fun_decl_names: std::collections::HashSet::new(),
             value_fn_depth: 0,
+            emit_mode: crate::NativeEmitMode::DesktopBin,
+            has_native_ui_host: false,
         }
     }
 
@@ -1269,25 +1332,29 @@ impl Codegen {
         if self.is_async {
             self.writeln("#[tokio::main]");
             self.writeln("async fn main() {");
-        } else {
+        } else if self.emit_mode == crate::NativeEmitMode::DesktopBin {
             self.writeln("fn main() {");
         }
-        self.indent += 1;
-        if self.is_async {
-            self.writeln("if let Err(e) = run().await {");
-        } else {
-            self.writeln("if let Err(e) = run() {");
+        if self.emit_mode == crate::NativeEmitMode::DesktopBin {
+            self.indent += 1;
+            if self.is_async {
+                self.writeln("if let Err(e) = run().await {");
+            } else {
+                self.writeln("if let Err(e) = run() {");
+            }
+            self.indent += 1;
+            self.writeln("eprintln!(\"Error: {}\", e);");
+            self.writeln("std::process::exit(1);");
+            self.indent -= 1;
+            self.writeln("}");
+            self.indent -= 1;
+            self.writeln("}");
+            self.writeln("");
         }
-        self.indent += 1;
-        self.writeln("eprintln!(\"Error: {}\", e);");
-        self.writeln("std::process::exit(1);");
-        self.indent -= 1;
-        self.writeln("}");
-        self.indent -= 1;
-        self.writeln("}");
-        self.writeln("");
         if self.is_async {
             self.writeln("async fn run() -> Result<(), Box<dyn std::error::Error>> {");
+        } else if self.emit_mode == crate::NativeEmitMode::EmbeddedLib {
+            self.writeln("pub fn run() -> Result<(), Box<dyn std::error::Error>> {");
         } else {
             self.writeln("fn run() -> Result<(), Box<dyn std::error::Error>> {");
         }
@@ -1489,7 +1556,7 @@ impl Codegen {
             self.writeln("let RegExp = Value::native(|args: &[Value]| regexp_new(args));");
         }
 
-        if self.program_has_jsx {
+        if self.program_has_jsx && !self.has_native_ui_host {
             self.writeln("install_thread_local_host(Box::new(HeadlessHost::default()));");
             self.writeln("let Fragment = fragment_value();");
             self.writeln("let h = Value::native(|args: &[Value]| ui_h(args));");
@@ -1537,6 +1604,20 @@ impl Codegen {
         self.writeln("Ok(())");
         self.indent -= 1;
         self.writeln("}");
+        if self.emit_mode == crate::NativeEmitMode::EmbeddedLib {
+            self.writeln("");
+            self.writeln("#[no_mangle]");
+            self.writeln("pub extern \"C\" fn tish_ios_launch() {");
+            self.indent += 1;
+            if self.is_async {
+                self.writeln("let rt = tokio::runtime::Runtime::new().expect(\"tokio runtime\");");
+                self.writeln("let _ = rt.block_on(run());");
+            } else {
+                self.writeln("let _ = run();");
+            }
+            self.indent -= 1;
+            self.writeln("}");
+        }
         Ok(())
     }
 

--- a/crates/tish_compile/src/lib.rs
+++ b/crates/tish_compile/src/lib.rs
@@ -23,13 +23,13 @@ pub use codegen::{
     compile_with_project_root,
 };
 pub use resolve::{
-    cargo_export_fn_name, compute_native_build_artifacts, detect_cycles, export_name_to_rust_ident,
-    extract_native_import_features, format_rust_dependencies_toml, generate_native_wrapper_rs,
-    has_external_native_imports, has_native_imports, infer_native_module_exports,
-    is_builtin_native_spec, is_cargo_native_spec, is_native_import, merge_modules,
-    normalize_builtin_spec, read_project_tish_config, resolve_bare_spec, resolve_native_modules,
-    resolve_project, resolve_project_from_stdin, MergedProgram, NativeBuildArtifacts,
-    NativeModuleInit, ResolvedNativeModule,
+    cargo_export_fn_name, compute_native_build_artifacts, detect_cycles, ensure_tish_canvas_module,
+    export_name_to_rust_ident, extract_native_import_features, format_rust_dependencies_toml,
+    generate_native_wrapper_rs, has_external_native_imports, has_native_imports,
+    infer_native_module_exports, is_builtin_native_spec, is_cargo_native_spec, is_native_import,
+    merge_modules, normalize_builtin_spec, program_uses_document, read_project_tish_config,
+    resolve_bare_spec, resolve_native_modules, resolve_project, resolve_project_from_stdin,
+    MergedProgram, NativeBuildArtifacts, NativeModuleInit, ResolvedNativeModule,
 };
 pub use types::{RustType, TypeContext};
 

--- a/crates/tish_compile/src/lib.rs
+++ b/crates/tish_compile/src/lib.rs
@@ -7,10 +7,20 @@ mod infer;
 mod resolve;
 mod types;
 
+/// How generated Rust is linked (desktop binary vs embedded iOS staticlib).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NativeEmitMode {
+    #[default]
+    DesktopBin,
+    /// `[lib] crate-type = ["staticlib"]` — no `fn main()`, host calls `tish_ios_launch`.
+    EmbeddedLib,
+}
+
 pub use codegen::CompileError;
 pub use codegen::{
-    compile, compile_project, compile_project_full, compile_with_features,
-    compile_with_native_modules, compile_with_project_root,
+    compile, compile_project, compile_project_full, compile_project_full_emit,
+    compile_with_features, compile_with_native_modules, compile_with_native_modules_emit,
+    compile_with_project_root,
 };
 pub use resolve::{
     cargo_export_fn_name, compute_native_build_artifacts, detect_cycles, export_name_to_rust_ident,

--- a/crates/tish_compile/src/resolve.rs
+++ b/crates/tish_compile/src/resolve.rs
@@ -4,7 +4,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tishlang_ast::{ExportDeclaration, Expr, ImportSpecifier, Program, Statement};
+use tishlang_ast::{ExportDeclaration, Expr, ImportSpecifier, MemberProp, Program, Statement, CallArg};
 
 /// Resolved native module: crate path and init expression.
 #[derive(Debug, Clone)]
@@ -112,6 +112,188 @@ pub fn resolve_native_modules(
         }
     }
     Ok(modules)
+}
+
+/// True when merged Tish source references the browser global `document` (e.g. juke-cards).
+pub fn program_uses_document(program: &Program) -> bool {
+    use tishlang_ast::{ArrayElement, ArrowBody, JsxAttrValue, JsxChild, JsxProp, ObjectProp};
+
+    fn expr_uses_document(e: &Expr) -> bool {
+        match e {
+            Expr::Ident { name, .. } => name.as_ref() == "document",
+            Expr::Literal { .. } | Expr::NativeModuleLoad { .. } => false,
+            Expr::Binary { left, right, .. } => {
+                expr_uses_document(left) || expr_uses_document(right)
+            }
+            Expr::Unary { operand, .. } | Expr::TypeOf { operand, .. } => {
+                expr_uses_document(operand)
+            }
+            Expr::Call { callee, args, .. } => {
+                expr_uses_document(callee)
+                    || args.iter().any(|a| match a {
+                        CallArg::Expr(e) | CallArg::Spread(e) => expr_uses_document(e),
+                    })
+            }
+            Expr::New { callee, args, .. } => {
+                expr_uses_document(callee)
+                    || args.iter().any(|a| match a {
+                        CallArg::Expr(e) | CallArg::Spread(e) => expr_uses_document(e),
+                    })
+            }
+            Expr::Member { object, prop, .. } => {
+                expr_uses_document(object)
+                    || if let MemberProp::Expr(e) = prop {
+                        expr_uses_document(e)
+                    } else {
+                        false
+                    }
+            }
+            Expr::Index { object, index, .. } => {
+                expr_uses_document(object) || expr_uses_document(index)
+            }
+            Expr::Conditional {
+                cond,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                expr_uses_document(cond)
+                    || expr_uses_document(then_branch)
+                    || expr_uses_document(else_branch)
+            }
+            Expr::NullishCoalesce { left, right, .. } => {
+                expr_uses_document(left) || expr_uses_document(right)
+            }
+            Expr::Array { elements, .. } => elements.iter().any(|el| match el {
+                ArrayElement::Expr(e) | ArrayElement::Spread(e) => expr_uses_document(e),
+            }),
+            Expr::Object { props, .. } => props.iter().any(|p| match p {
+                ObjectProp::KeyValue(_, e) | ObjectProp::Spread(e) => expr_uses_document(e),
+            }),
+            Expr::Assign { value, .. }
+            | Expr::CompoundAssign { value, .. }
+            | Expr::LogicalAssign { value, .. }
+            | Expr::MemberAssign { value, .. }
+            | Expr::IndexAssign { value, .. } => expr_uses_document(value),
+            Expr::PostfixInc { .. }
+            | Expr::PostfixDec { .. }
+            | Expr::PrefixInc { .. }
+            | Expr::PrefixDec { .. } => false,
+            Expr::ArrowFunction { body, .. } => match body {
+                ArrowBody::Expr(e) => expr_uses_document(e),
+                ArrowBody::Block(s) => stmt_uses_document(s),
+            },
+            Expr::TemplateLiteral { exprs, .. } => exprs.iter().any(expr_uses_document),
+            Expr::Await { operand, .. } => expr_uses_document(operand),
+            Expr::JsxElement { props, children, .. } => {
+                props.iter().any(|p| match p {
+                    JsxProp::Attr { value, .. } => match value {
+                        JsxAttrValue::Expr(e) => expr_uses_document(e),
+                        JsxAttrValue::String(_) | JsxAttrValue::ImplicitTrue => false,
+                    },
+                    JsxProp::Spread(e) => expr_uses_document(e),
+                }) || children.iter().any(|c| match c {
+                    JsxChild::Expr(e) => expr_uses_document(e),
+                    JsxChild::Text(_) => false,
+                })
+            }
+            Expr::JsxFragment { children, .. } => children.iter().any(|c| match c {
+                JsxChild::Expr(e) => expr_uses_document(e),
+                JsxChild::Text(_) => false,
+            }),
+        }
+    }
+
+    fn stmt_uses_document(s: &Statement) -> bool {
+        match s {
+            Statement::VarDecl { init, .. } => init.as_ref().is_some_and(|e| expr_uses_document(e)),
+            Statement::VarDeclDestructure { init, .. } => expr_uses_document(init),
+            Statement::ExprStmt { expr, .. } => expr_uses_document(expr),
+            Statement::Return { value, .. } => value.as_ref().is_some_and(|e| expr_uses_document(e)),
+            Statement::Throw { value, .. } => expr_uses_document(value),
+            Statement::If {
+                cond,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                expr_uses_document(cond)
+                    || stmt_uses_document(then_branch)
+                    || else_branch
+                        .as_ref()
+                        .is_some_and(|b| stmt_uses_document(b.as_ref()))
+            }
+            Statement::While { cond, body, .. }
+            | Statement::DoWhile { cond, body, .. } => {
+                expr_uses_document(cond) || stmt_uses_document(body)
+            }
+            Statement::For { init, cond, update, body, .. } => {
+                init.as_ref().is_some_and(|s| stmt_uses_document(s.as_ref()))
+                    || cond.as_ref().is_some_and(|e| expr_uses_document(e))
+                    || update.as_ref().is_some_and(|e| expr_uses_document(e))
+                    || stmt_uses_document(body)
+            }
+            Statement::ForOf { iterable, body, .. } => {
+                expr_uses_document(iterable) || stmt_uses_document(body)
+            }
+            Statement::Switch {
+                expr,
+                cases,
+                default_body,
+                ..
+            } => {
+                expr_uses_document(expr)
+                    || cases.iter().any(|(e, stmts)| {
+                        e.as_ref().is_some_and(|e| expr_uses_document(e))
+                            || stmts.iter().any(stmt_uses_document)
+                    })
+                    || default_body
+                        .as_ref()
+                        .is_some_and(|stmts| stmts.iter().any(stmt_uses_document))
+            }
+            Statement::Block { statements, .. } => statements.iter().any(stmt_uses_document),
+            Statement::FunDecl { body, .. } => stmt_uses_document(body),
+            Statement::Try {
+                body,
+                catch_body,
+                finally_body,
+                ..
+            } => {
+                stmt_uses_document(body)
+                    || catch_body
+                        .as_ref()
+                        .is_some_and(|b| stmt_uses_document(b.as_ref()))
+                    || finally_body
+                        .as_ref()
+                        .is_some_and(|b| stmt_uses_document(b.as_ref()))
+            }
+            Statement::Import { .. }
+            | Statement::Export { .. }
+            | Statement::Break { .. }
+            | Statement::Continue { .. }
+            | Statement::TypeAlias { .. }
+            | Statement::DeclareVar { .. }
+            | Statement::DeclareFun { .. } => false,
+        }
+    }
+
+    program.statements.iter().any(stmt_uses_document)
+}
+
+/// When Tish uses bare `document`, link `tish-canvas` even without `import from 'tish:canvas'`.
+pub fn ensure_tish_canvas_module(
+    native_modules: &mut Vec<ResolvedNativeModule>,
+    project_root: &Path,
+) -> Result<(), String> {
+    if native_modules
+        .iter()
+        .any(|m| m.crate_name == "tish_canvas" || m.package_name == "tish-canvas")
+    {
+        return Ok(());
+    }
+    let m = resolve_native_module("tish:canvas", project_root)?;
+    native_modules.push(m);
+    Ok(())
 }
 
 /// True for `cargo:…` specs (Cargo-backed imports; Rust native backend only).
@@ -725,11 +907,11 @@ fn load_module_recursive(
 /// - fs, http, timers, process, ws (Node-compatible aliases for tish:*)
 /// - tish:egui, tish:polars, etc.
 /// - cargo:… (Cargo `rustDependencies` + generated wrapper; Rust native backend)
-/// - @scope/package (npm-style)
+///
+/// Scoped npm packages (`@scope/pkg`) are merged as Tish source unless imported via `tish:…`.
 pub fn is_native_import(spec: &str) -> bool {
     spec.starts_with("tish:")
         || spec.starts_with("cargo:")
-        || spec.starts_with('@')
         || matches!(spec, "fs" | "http" | "timers" | "process" | "ws")
 }
 

--- a/crates/tish_core/src/value.rs
+++ b/crates/tish_core/src/value.rs
@@ -70,7 +70,28 @@ pub type NativeFn = std::rc::Rc<dyn Fn(&[Value]) -> Value>;
 
 /// Trait for opaque Rust types exposed to Tish (e.g. Polars DataFrame).
 /// Implementors provide method dispatch so Tish can call methods on the value.
+///
+/// The `Send + Sync` supertrait bound is conditional on the `send-values`
+/// feature. When `send-values` is off (single-threaded VMs: wasm browser /
+/// wasi / interpreter / cranelift), `NativeFn` is already `Rc<dyn Fn>`, so
+/// `Value` is `!Send` anyway — dropping the bound here loses nothing and lets
+/// `!Send` opaques like `JsHandle(wasm_bindgen::JsValue)` be stored in a
+/// `Value::Opaque` on the browser runtime.
+#[cfg(feature = "send-values")]
 pub trait TishOpaque: Send + Sync {
+    /// Display name for the type (e.g. "DataFrame").
+    fn type_name(&self) -> &'static str;
+
+    /// Get a method by name. Returns a native function if the method exists.
+    fn get_method(&self, name: &str) -> Option<NativeFn>;
+
+    /// For downcasting `Arc<dyn TishOpaque>` in native crates (e.g. Polars → `DataFrame`).
+    fn as_any(&self) -> &dyn std::any::Any;
+}
+
+/// Single-threaded variant (no `Send + Sync` bound); see the `send-values` doc above.
+#[cfg(not(feature = "send-values"))]
+pub trait TishOpaque {
     /// Display name for the type (e.g. "DataFrame").
     fn type_name(&self) -> &'static str;
 

--- a/crates/tish_cranelift/src/link.rs
+++ b/crates/tish_cranelift/src/link.rs
@@ -103,7 +103,7 @@ fn main() {{
         message: format!("Cannot write build.rs: {}", e),
     })?;
 
-    tishlang_build_utils::run_cargo_build(&build_dir, None)
+    tishlang_build_utils::run_cargo_build(&build_dir, None, None)
         .map_err(|e| CraneliftError { message: e })?;
 
     let binary_dir = build_dir.join("target").join("release");

--- a/crates/tish_native/src/build.rs
+++ b/crates/tish_native/src/build.rs
@@ -5,6 +5,8 @@ use std::path::Path;
 
 use tishlang_compile::ResolvedNativeModule;
 
+use crate::config::{NativeArtifact, NativeBuildConfig};
+
 /// `tishlang_runtime` Cargo feature names (subset of CLI / compile feature names).
 const RUNTIME_CARGO_FEATURES: &[&str] = &[
     "http",
@@ -78,11 +80,34 @@ pub fn build_via_cargo(
     generated_native_rs: Option<&str>,
     project_root: Option<&Path>,
 ) -> Result<(), String> {
-    let out_name = output_path
+    build_via_cargo_with_config(
+        rust_code,
+        native_modules,
+        output_path,
+        features,
+        extra_dependencies_toml,
+        generated_native_rs,
+        project_root,
+        &NativeBuildConfig::desktop(),
+    )
+}
+
+pub fn build_via_cargo_with_config(
+    rust_code: &str,
+    native_modules: Vec<ResolvedNativeModule>,
+    output_path: &Path,
+    features: &[String],
+    extra_dependencies_toml: &str,
+    generated_native_rs: Option<&str>,
+    project_root: Option<&Path>,
+    build_config: &NativeBuildConfig,
+) -> Result<(), String> {
+    let out_stem = output_path
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("tish_out");
-    let build_dir = tishlang_build_utils::create_build_dir("tish_build", out_name)?;
+    let cargo_name = tishlang_build_utils::cargo_target_name(out_stem);
+    let build_dir = tishlang_build_utils::create_build_dir("tish_build", out_stem)?;
 
     let runtime_path = tishlang_build_utils::find_runtime_path_for_project(project_root)?;
 
@@ -139,22 +164,42 @@ pub fn build_via_cargo(
     };
 
     let profile = nested_release_profile_toml();
+    let src_file = if build_config.artifact == NativeArtifact::StaticLib {
+        "lib.rs"
+    } else {
+        "main.rs"
+    };
+    let crate_section = if build_config.artifact == NativeArtifact::StaticLib {
+        format!(
+            r#"[lib]
+name = "{}"
+crate-type = ["staticlib"]
+path = "src/lib.rs"
+
+"#,
+            cargo_name
+        )
+    } else {
+        format!(
+            r#"[[bin]]
+name = "{}"
+path = "src/main.rs"
+
+"#,
+            cargo_name
+        )
+    };
     let cargo_toml = format!(
         r#"[package]
 name = "tish_output"
 version = "0.1.0"
 edition = "2021"
 
-[[bin]]
-name = "{}"
-path = "src/main.rs"
-
-{}
-
+{}{}
 [dependencies]
 tishlang_runtime = {{ path = {:?}{} }}
 {}{}"#,
-        out_name, profile, runtime_path, features_str, more_deps, ui_dep
+        crate_section, profile, runtime_path, features_str, more_deps, ui_dep
     );
 
     fs::write(build_dir.join("Cargo.toml"), cargo_toml)
@@ -163,24 +208,44 @@ tishlang_runtime = {{ path = {:?}{} }}
         fs::write(build_dir.join("src/generated_native.rs"), gen)
             .map_err(|e| format!("Cannot write generated_native.rs: {}", e))?;
     }
-    fs::write(build_dir.join("src/main.rs"), rust_main)
-        .map_err(|e| format!("Cannot write main.rs: {}", e))?;
+    fs::write(build_dir.join("src").join(src_file), rust_main)
+        .map_err(|e| format!("Cannot write {}: {}", src_file, e))?;
 
     let workspace_target = Path::new(&runtime_path)
         .parent()
         .and_then(|p| p.parent())
         .map(|ws| ws.join("target"));
     let target_dir = workspace_target.filter(|p| p.exists());
+    let cross = build_config.cargo_target.as_deref();
+    let release_sub = if let Some(triple) = cross {
+        format!("{triple}/release")
+    } else {
+        "release".to_string()
+    };
     let binary_dir = target_dir
         .as_ref()
-        .map(|t| t.join("release"))
-        .unwrap_or_else(|| build_dir.join("target").join("release"));
+        .map(|t| t.join(&release_sub))
+        .unwrap_or_else(|| build_dir.join("target").join(&release_sub));
 
-    tishlang_build_utils::run_cargo_build(&build_dir, target_dir.as_deref())?;
+    tishlang_build_utils::run_cargo_build(&build_dir, target_dir.as_deref(), cross)?;
 
-    let binary = tishlang_build_utils::find_release_binary(&binary_dir, out_name)?;
-    let target = tishlang_build_utils::resolve_output_path(output_path, out_name);
-    tishlang_build_utils::copy_binary_to_output(&binary, &target)?;
+    let artifact = if build_config.artifact == NativeArtifact::StaticLib {
+        tishlang_build_utils::find_release_staticlib(&binary_dir, &cargo_name)?
+    } else {
+        tishlang_build_utils::find_release_binary(&binary_dir, &cargo_name)?
+    };
+    let target = if build_config.artifact == NativeArtifact::StaticLib {
+        if output_path.extension().is_some_and(|e| e == "a") {
+            output_path.to_path_buf()
+        } else if output_path.to_string_lossy().ends_with('/') || output_path.is_dir() {
+            output_path.join(format!("lib{out_stem}.a"))
+        } else {
+            output_path.with_extension("a")
+        }
+    } else {
+        tishlang_build_utils::resolve_output_path(output_path, out_stem)
+    };
+    tishlang_build_utils::copy_binary_to_output(&artifact, &target)?;
 
     Ok(())
 }
@@ -321,7 +386,7 @@ tishlang_runtime = {{ path = {:?}{} }}
         .map(|t| t.join("release"))
         .unwrap_or_else(|| build_dir.join("target").join("release"));
 
-    tishlang_build_utils::run_cargo_build(&build_dir, target_dir.as_deref())?;
+    tishlang_build_utils::run_cargo_build(&build_dir, target_dir.as_deref(), None)?;
 
     for i in 0..bins.len() {
         let stem = bins[i].0.as_str();

--- a/crates/tish_native/src/build.rs
+++ b/crates/tish_native/src/build.rs
@@ -71,6 +71,10 @@ fn inject_generated_native_mod(rust_code: &str) -> String {
     }
 }
 
+pub(crate) fn rust_code_needs_tokio(rust_code: &str) -> bool {
+    rust_code.contains("#[tokio::main]") || rust_code.contains("tokio::runtime::Runtime")
+}
+
 pub fn build_via_cargo(
     rust_code: &str,
     native_modules: Vec<ResolvedNativeModule>,
@@ -119,7 +123,7 @@ pub fn build_via_cargo_with_config(
         format!(", features = {:?}", runtime_refs)
     };
 
-    let needs_tokio = rust_code.contains("#[tokio::main]");
+    let needs_tokio = rust_code_needs_tokio(rust_code);
     let tokio_dep = if needs_tokio {
         "\ntokio = { version = \"1\", features = [\"rt-multi-thread\", \"macros\"] }\n"
     } else {

--- a/crates/tish_native/src/config.rs
+++ b/crates/tish_native/src/config.rs
@@ -1,0 +1,48 @@
+//! Native build configuration (desktop binary vs iOS staticlib, cross-target).
+
+use tishlang_compile::NativeEmitMode;
+
+/// Output artifact kind for `tish build --target native`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NativeArtifact {
+    #[default]
+    Bin,
+    StaticLib,
+}
+
+/// Options passed from the CLI into nested `cargo build`.
+#[derive(Debug, Clone, Default)]
+pub struct NativeBuildConfig {
+    pub artifact: NativeArtifact,
+    /// When set, run `cargo build --target <triple>` and skip `-C target-cpu=native`.
+    pub cargo_target: Option<String>,
+    pub emit_mode: NativeEmitMode,
+}
+
+impl NativeBuildConfig {
+    pub fn desktop() -> Self {
+        Self::default()
+    }
+
+    pub fn ios_staticlib(triple: &str) -> Self {
+        Self {
+            artifact: NativeArtifact::StaticLib,
+            cargo_target: Some(triple.to_string()),
+            emit_mode: NativeEmitMode::EmbeddedLib,
+        }
+    }
+
+    pub fn is_cross_compile(&self) -> bool {
+        self.cargo_target.is_some()
+    }
+}
+
+/// Filter runtime features for iOS sandbox builds.
+pub fn ios_runtime_features(features: &[String]) -> Vec<String> {
+    const ALLOW: &[&str] = &["http", "http-hyper", "regex"];
+    features
+        .iter()
+        .filter(|f| ALLOW.contains(&f.as_str()))
+        .cloned()
+        .collect()
+}

--- a/crates/tish_native/src/config.rs
+++ b/crates/tish_native/src/config.rs
@@ -39,7 +39,7 @@ impl NativeBuildConfig {
 
 /// Filter runtime features for iOS sandbox builds.
 pub fn ios_runtime_features(features: &[String]) -> Vec<String> {
-    const ALLOW: &[&str] = &["http", "http-hyper", "regex"];
+    const ALLOW: &[&str] = &["http", "http-hyper", "regex", "timers"];
     features
         .iter()
         .filter(|f| ALLOW.contains(&f.as_str()))

--- a/crates/tish_native/src/lib.rs
+++ b/crates/tish_native/src/lib.rs
@@ -10,6 +10,9 @@
 //! emit Rust using `Vec<f64>` / fixed primitives instead of `Value` on hot paths.
 
 mod build;
+mod config;
+
+pub use config::{ios_runtime_features, NativeArtifact, NativeBuildConfig};
 
 use std::path::Path;
 use tishlang_ast::Program;
@@ -57,6 +60,27 @@ pub fn compile_to_native(
     native_backend: &str,
     optimize: bool,
 ) -> Result<(), NativeError> {
+    compile_to_native_with_config(
+        entry_path,
+        project_root,
+        output_path,
+        features,
+        native_backend,
+        optimize,
+        &NativeBuildConfig::desktop(),
+    )
+}
+
+/// Compile a Tish project to a native binary or static library.
+pub fn compile_to_native_with_config(
+    entry_path: &Path,
+    project_root: Option<&Path>,
+    output_path: &Path,
+    features: &[String],
+    native_backend: &str,
+    optimize: bool,
+    build_config: &NativeBuildConfig,
+) -> Result<(), NativeError> {
     let backend = match native_backend {
         "rust" => Backend::Rust,
         "cranelift" => Backend::Cranelift,
@@ -73,25 +97,44 @@ pub fn compile_to_native(
 
     match backend {
         Backend::Rust => {
+            let ios_cap = build_config.cargo_target.as_ref().map(|_| {
+                ios_runtime_features(features)
+                    .into_iter()
+                    .collect::<std::collections::HashSet<_>>()
+            });
+            let compile_features = if ios_cap.is_some() {
+                ios_runtime_features(features)
+            } else {
+                features.to_vec()
+            };
             let (rust_code, native_modules, effective_features, native_build) =
-                tishlang_compile::compile_project_full(
+                tishlang_compile::compile_project_full_emit(
                     entry_path,
                     project_root,
-                    features,
+                    &compile_features,
                     optimize,
+                    build_config.emit_mode,
+                    ios_cap.as_ref(),
                 )
                 .map_err(|e| NativeError {
                     message: e.to_string(),
                 })?;
 
-            crate::build::build_via_cargo(
+            let features_for_cargo = if build_config.cargo_target.is_some() {
+                ios_runtime_features(&effective_features)
+            } else {
+                effective_features
+            };
+
+            crate::build::build_via_cargo_with_config(
                 &rust_code,
                 native_modules,
                 output_path,
-                &effective_features,
+                &features_for_cargo,
                 &native_build.rust_dependencies_toml,
                 native_build.generated_native_rs.as_deref(),
                 project_root,
+                build_config,
             )
             .map_err(|e| NativeError { message: e })
         }

--- a/crates/tish_native/src/lib.rs
+++ b/crates/tish_native/src/lib.rs
@@ -390,7 +390,7 @@ pub fn compile_many_to_native(
             merged_extra_deps.push_str(extra);
             merged_extra_deps.push('\n');
         }
-        needs_tokio |= rust_code.contains("#[tokio::main]");
+        needs_tokio |= crate::build::rust_code_needs_tokio(&rust_code);
         needs_ui |= rust_code.contains("tishlang_ui");
         bins.push((stem, rust_code, native_build.generated_native_rs));
     }

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -47,7 +47,8 @@ pub use tishlang_builtins::string::{
     pad_start as string_pad_start_impl, repeat as string_repeat_impl,
     replace as string_replace_impl, replace_all as string_replace_all_impl,
     slice as string_slice_impl, split as string_split_impl,
-    starts_with as string_starts_with_impl, substring as string_substring_impl,
+    starts_with as string_starts_with_impl, substr as string_substr_impl,
+    substring as string_substring_impl,
     to_lower_case as string_to_lower_case, to_upper_case as string_to_upper_case,
     trim as string_trim,
 };
@@ -104,6 +105,9 @@ pub fn string_slice(s: &Value, start: &Value, end: &Value) -> Value {
 }
 pub fn string_substring(s: &Value, start: &Value, end: &Value) -> Value {
     string_substring_impl(s, start, end)
+}
+pub fn string_substr(s: &Value, start: &Value, length: &Value) -> Value {
+    string_substr_impl(s, start, length)
 }
 pub fn string_split(s: &Value, sep: &Value) -> Value {
     string_split_impl(s, sep)
@@ -420,6 +424,7 @@ pub use tishlang_builtins::math::{
     exp as tish_math_exp_impl, floor as tish_math_floor_impl, max as tish_math_max_impl,
     min as tish_math_min_impl, pow as tish_math_pow_impl, random as tish_math_random_impl,
     round as tish_math_round_impl, sign as tish_math_sign_impl, sin as tish_math_sin_impl,
+    imul as tish_math_imul_impl,
     sqrt as tish_math_sqrt_impl, tan as tish_math_tan_impl, trunc as tish_math_trunc_impl,
 };
 
@@ -459,6 +464,9 @@ pub fn math_exp(args: &[Value]) -> Value {
 }
 pub fn math_trunc(args: &[Value]) -> Value {
     tish_math_trunc_impl(args)
+}
+pub fn math_imul(args: &[Value]) -> Value {
+    tish_math_imul_impl(args)
 }
 pub fn math_pow(args: &[Value]) -> Value {
     tish_math_pow_impl(args)

--- a/crates/tish_runtime/src/timers.rs
+++ b/crates/tish_runtime/src/timers.rs
@@ -47,15 +47,20 @@ pub fn drain_timers() {
     run_due_timers();
 }
 
-/// Run all due timer callbacks.
+/// Run all due timer callbacks (including timers scheduled by other timers).
 fn run_due_timers() {
-    let due = take_due_timers();
-    for (id, callback, args, interval_ms) in due {
-        if let Value::Function(f) = &callback {
-            let _ = f(&args);
+    for _ in 0..64 {
+        let due = take_due_timers();
+        if due.is_empty() {
+            break;
         }
-        if interval_ms > 0 {
-            re_register_interval(id, callback, args, interval_ms);
+        for (id, callback, args, interval_ms) in due {
+            if let Value::Function(f) = &callback {
+                let _ = f(&args);
+            }
+            if interval_ms > 0 {
+                re_register_interval(id, callback, args, interval_ms);
+            }
         }
     }
 }

--- a/crates/tish_ui/src/lib.rs
+++ b/crates/tish_ui/src/lib.rs
@@ -12,8 +12,9 @@ pub mod runtime;
 #[cfg(feature = "runtime")]
 pub use runtime::{
     alloc_root_id, current_root_id, drop_host_for_root, fragment_value, install_host_for_root,
-    install_thread_local_host, native_create_root, native_use_effect, native_use_memo,
-    native_use_state, run_with_current_root, ui_h, ui_text, unregister_root,
-    unregister_root_hooks_and_effects, with_host_for_root, with_thread_local_host, HeadlessHost,
-    Host, RootId, FRAGMENT_SENTINEL, LEGACY_ROOT_ID,
+    install_thread_local_host, native_create_root,
+    native_use_effect, native_use_layout_effect, native_use_memo, native_use_ref,
+    native_use_state, run_with_current_root, ui_h, ui_text,
+    unregister_root, unregister_root_hooks_and_effects, with_host_for_root,
+    with_thread_local_host, HeadlessHost, Host, RootId, FRAGMENT_SENTINEL, LEGACY_ROOT_ID,
 };

--- a/crates/tish_ui/src/runtime/hooks.rs
+++ b/crates/tish_ui/src/runtime/hooks.rs
@@ -5,6 +5,8 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use std::sync::Arc;
+
 use tishlang_core::{ObjectMap, Value, VmRef};
 
 use super::Host;
@@ -18,7 +20,7 @@ pub const LEGACY_ROOT_ID: RootId = 1;
 thread_local! {
     static HOOKS: RefCell<HashMap<RootId, HookState>> = RefCell::new(HashMap::new());
     static CURRENT_ROOT: Cell<Option<RootId>> = Cell::new(None);
-    static HOSTS: RefCell<HashMap<RootId, Box<dyn Host>>> = RefCell::new(HashMap::new());
+    static HOSTS: RefCell<HashMap<RootId, Rc<RefCell<Box<dyn Host>>>>> = RefCell::new(HashMap::new());
     static NEXT_DYNAMIC_ROOT_ID: Cell<RootId> = Cell::new(2);
     static IN_FLUSH: Cell<bool> = Cell::new(false);
 }
@@ -42,7 +44,8 @@ fn ensure_hook_entry(root_id: RootId) {
 pub fn install_host_for_root(root_id: RootId, host: Box<dyn Host>) {
     ensure_hook_entry(root_id);
     HOSTS.with(|h| {
-        h.borrow_mut().insert(root_id, host);
+        h.borrow_mut()
+            .insert(root_id, Rc::new(RefCell::new(host)));
     });
 }
 
@@ -77,8 +80,10 @@ pub fn unregister_root(root_id: RootId) {
 
 pub fn with_host_for_root<R>(root_id: RootId, f: impl FnOnce(&mut dyn Host) -> R) -> Option<R> {
     HOSTS.with(|c| {
-        let mut m = c.borrow_mut();
-        m.get_mut(&root_id).map(|host| f(host.as_mut()))
+        let m = c.borrow();
+        let host = m.get(&root_id)?;
+        let mut host = host.try_borrow_mut().ok()?;
+        Some(f(host.as_mut()))
     })
 }
 
@@ -128,6 +133,11 @@ pub struct HookState {
     effect_cells: Rc<RefCell<Vec<EffectCell>>>,
     effect_cursor: usize,
     pending_effects: Rc<RefCell<Vec<PendingEffect>>>,
+    layout_effect_cells: Rc<RefCell<Vec<EffectCell>>>,
+    layout_effect_cursor: usize,
+    pending_layout_effects: Rc<RefCell<Vec<PendingEffect>>>,
+    ref_slots: Rc<RefCell<Vec<Value>>>,
+    ref_cursor: usize,
 }
 
 impl Default for HookState {
@@ -143,6 +153,11 @@ impl Default for HookState {
             effect_cells: Rc::new(RefCell::new(Vec::new())),
             effect_cursor: 0,
             pending_effects: Rc::new(RefCell::new(Vec::new())),
+            layout_effect_cells: Rc::new(RefCell::new(Vec::new())),
+            layout_effect_cursor: 0,
+            pending_layout_effects: Rc::new(RefCell::new(Vec::new())),
+            ref_slots: Rc::new(RefCell::new(Vec::new())),
+            ref_cursor: 0,
         }
     }
 }
@@ -160,11 +175,17 @@ fn run_all_effect_cleanups(cells: &RefCell<Vec<EffectCell>>) {
 impl HookState {
     pub fn reset_for_new_root(&mut self) {
         run_all_effect_cleanups(self.effect_cells.as_ref());
+        run_all_effect_cleanups(self.layout_effect_cells.as_ref());
         self.effect_cells.borrow_mut().clear();
+        self.layout_effect_cells.borrow_mut().clear();
         self.effect_cursor = 0;
+        self.layout_effect_cursor = 0;
         self.pending_effects.borrow_mut().clear();
+        self.pending_layout_effects.borrow_mut().clear();
         self.state_slots.borrow_mut().clear();
         self.cursor = 0;
+        self.ref_slots.borrow_mut().clear();
+        self.ref_cursor = 0;
         self.root_vnode = None;
         self.flush_scheduled = false;
         self.memo_cache.borrow_mut().clear();
@@ -284,9 +305,29 @@ pub fn native_use_memo(args: &[Value]) -> Value {
     })
 }
 
-/// `useEffect(effect, deps?)` — runs `effect` after the host commits the tree; compares `deps` like `useMemo`.
-/// If `effect` returns a function, it is called before the next run or on root teardown (`render` replacement / [`unregister_root`]).
-pub fn native_use_effect(args: &[Value]) -> Value {
+/// `useRef(initial)` → `{ current: initial }` (stable object identity per slot).
+pub fn native_use_ref(args: &[Value]) -> Value {
+    let initial = args.first().cloned().unwrap_or(Value::Null);
+    let root_id = root_id_for_hooks();
+    HOOKS.with(|h| {
+        let mut map = h.borrow_mut();
+        let st = map.entry(root_id).or_default();
+        let i = st.ref_cursor;
+        st.ref_cursor += 1;
+        while i >= st.ref_slots.borrow().len() {
+            let mut m = ObjectMap::default();
+            m.insert(Arc::from("current"), initial.clone());
+            st.ref_slots.borrow_mut().push(Value::object(m));
+        }
+        let out = st.ref_slots.borrow()[i].clone();
+        out
+    })
+}
+
+fn queue_effect(
+    args: &[Value],
+    layout: bool,
+) -> Value {
     let Some(Value::Function(effect_fn)) = args.first() else {
         return Value::Null;
     };
@@ -301,9 +342,22 @@ pub fn native_use_effect(args: &[Value]) -> Value {
     HOOKS.with(|h| {
         let mut map = h.borrow_mut();
         let st = map.entry(root_id).or_default();
-        let i = st.effect_cursor;
-        st.effect_cursor += 1;
-        let cells = &st.effect_cells.clone();
+        let (cursor, cells, pending) = if layout {
+            (
+                &mut st.layout_effect_cursor,
+                &st.layout_effect_cells,
+                &st.pending_layout_effects,
+            )
+        } else {
+            (
+                &mut st.effect_cursor,
+                &st.effect_cells,
+                &st.pending_effects,
+            )
+        };
+        let i = *cursor;
+        *cursor += 1;
+        let cells = cells.clone();
         let mut cells_b = cells.borrow_mut();
         while cells_b.len() <= i {
             cells_b.push(EffectCell::default());
@@ -315,7 +369,7 @@ pub fn native_use_effect(args: &[Value]) -> Value {
         drop(cells_b);
 
         if should_run {
-            st.pending_effects.borrow_mut().push(PendingEffect {
+            pending.borrow_mut().push(PendingEffect {
                 slot: i,
                 effect_fn: Value::Function(effect_fn),
                 new_deps: deps,
@@ -325,14 +379,29 @@ pub fn native_use_effect(args: &[Value]) -> Value {
     })
 }
 
-fn flush_pending_effects(root_id: RootId) {
+/// `useLayoutEffect(effect, deps?)` — runs synchronously after commit, before `useEffect`.
+pub fn native_use_layout_effect(args: &[Value]) -> Value {
+    queue_effect(args, true)
+}
+
+/// `useEffect(effect, deps?)` — runs `effect` after the host commits the tree; compares `deps` like `useMemo`.
+/// If `effect` returns a function, it is called before the next run or on root teardown (`render` replacement / [`unregister_root`]).
+pub fn native_use_effect(args: &[Value]) -> Value {
+    queue_effect(args, false)
+}
+
+fn flush_pending_effects_for(
+    root_id: RootId,
+    pending_key: impl FnOnce(&mut HookState) -> &Rc<RefCell<Vec<PendingEffect>>>,
+    cells_key: impl FnOnce(&HookState) -> Rc<RefCell<Vec<EffectCell>>>,
+) {
     let pending: Vec<PendingEffect> = HOOKS.with(|h| {
         h.borrow_mut()
             .get_mut(&root_id)
-            .map(|st| std::mem::take(&mut *st.pending_effects.borrow_mut()))
+            .map(|st| std::mem::take(&mut *pending_key(st).borrow_mut()))
             .unwrap_or_default()
     });
-    let cells_rc = HOOKS.with(|h| h.borrow().get(&root_id).map(|st| st.effect_cells.clone()));
+    let cells_rc = HOOKS.with(|h| h.borrow().get(&root_id).map(cells_key));
     let Some(cells_rc) = cells_rc else {
         return;
     };
@@ -368,6 +437,22 @@ fn flush_pending_effects(root_id: RootId) {
             cell.committed_deps = Some(p.new_deps);
         }
     }
+}
+
+fn flush_pending_layout_effects(root_id: RootId) {
+    flush_pending_effects_for(
+        root_id,
+        |st| &st.pending_layout_effects,
+        |st| st.layout_effect_cells.clone(),
+    );
+}
+
+fn flush_pending_effects(root_id: RootId) {
+    flush_pending_effects_for(
+        root_id,
+        |st| &st.pending_effects,
+        |st| st.effect_cells.clone(),
+    );
 }
 
 fn parse_root_id_arg(args: &[Value]) -> RootId {
@@ -416,6 +501,10 @@ pub fn schedule_flush() {
 }
 
 fn drain_flush_queue() {
+    drain_flush_queue_on_current_thread();
+}
+
+fn drain_flush_queue_on_current_thread() {
     loop {
         let root_id = HOOKS.with(|h| {
             h.borrow()
@@ -440,8 +529,11 @@ fn drain_flush_queue() {
             let st = map.get_mut(&root_id)?;
             st.cursor = 0;
             st.memo_cursor = 0;
+            st.ref_cursor = 0;
             st.effect_cursor = 0;
+            st.layout_effect_cursor = 0;
             st.pending_effects.borrow_mut().clear();
+            st.pending_layout_effects.borrow_mut().clear();
             let app = st.root_app.clone()?;
             let Value::Function(f) = app else {
                 return None;
@@ -452,18 +544,16 @@ fn drain_flush_queue() {
         if let Some(f) = app_fn {
             let tree = f(&[]);
             HOOKS.with(|h| {
-                let mut map = h.borrow_mut();
-                if let Some(st) = map.get_mut(&root_id) {
+                if let Some(st) = h.borrow_mut().get_mut(&root_id) {
                     st.root_vnode = Some(tree.clone());
-                    HOSTS.with(|hosts| {
-                        let mut hm = hosts.borrow_mut();
-                        if let Some(host) = hm.get_mut(&root_id) {
-                            host.commit_root(&tree);
-                        }
-                    });
                 }
             });
+            let host = HOSTS.with(|hosts| hosts.borrow().get(&root_id).cloned());
+            if let Some(host) = host {
+                host.borrow_mut().commit_root(&tree);
+            }
             IN_FLUSH.set(false);
+            flush_pending_layout_effects(root_id);
             flush_pending_effects(root_id);
         }
 

--- a/crates/tish_ui/src/runtime/hooks.rs
+++ b/crates/tish_ui/src/runtime/hooks.rs
@@ -23,6 +23,7 @@ thread_local! {
     static HOSTS: RefCell<HashMap<RootId, Rc<RefCell<Box<dyn Host>>>>> = RefCell::new(HashMap::new());
     static NEXT_DYNAMIC_ROOT_ID: Cell<RootId> = Cell::new(2);
     static IN_FLUSH: Cell<bool> = Cell::new(false);
+    static IN_EFFECT_FLUSH: Cell<bool> = Cell::new(false);
 }
 
 /// Allocate an id for an additional in-process window (starts at 2; 1 is legacy primary).
@@ -212,6 +213,7 @@ fn memo_dep_eq(a: &Value, b: &Value) -> bool {
             }
             ab.iter().zip(bb.iter()).all(|(x, y)| memo_dep_eq(x, y))
         }
+        (Value::Object(a), Value::Object(b)) => tishlang_core::VmRef::ptr_eq(a, b),
         _ => false,
     }
 }
@@ -260,7 +262,7 @@ pub fn native_use_state(args: &[Value]) -> Value {
                     st.flush_scheduled = true;
                 }
             });
-            if !IN_FLUSH.get() {
+            if !IN_FLUSH.get() && !IN_EFFECT_FLUSH.get() {
                 drain_flush_queue();
             }
             Value::Null
@@ -440,19 +442,23 @@ fn flush_pending_effects_for(
 }
 
 fn flush_pending_layout_effects(root_id: RootId) {
+    IN_EFFECT_FLUSH.set(true);
     flush_pending_effects_for(
         root_id,
         |st| &st.pending_layout_effects,
         |st| st.layout_effect_cells.clone(),
     );
+    IN_EFFECT_FLUSH.set(false);
 }
 
 fn flush_pending_effects(root_id: RootId) {
+    IN_EFFECT_FLUSH.set(true);
     flush_pending_effects_for(
         root_id,
         |st| &st.pending_effects,
         |st| st.effect_cells.clone(),
     );
+    IN_EFFECT_FLUSH.set(false);
 }
 
 fn parse_root_id_arg(args: &[Value]) -> RootId {

--- a/crates/tish_ui/src/runtime/mod.rs
+++ b/crates/tish_ui/src/runtime/mod.rs
@@ -2,14 +2,16 @@
 
 mod hooks;
 
-use std::cell::RefCell;
 use std::sync::Arc;
 
 pub use hooks::{
-    alloc_root_id, current_root_id, drop_host_for_root, install_host_for_root, native_create_root,
-    native_use_effect, native_use_memo, native_use_state, run_with_current_root, schedule_flush,
-    unregister_root, unregister_root_hooks_and_effects, with_host_for_root, HookState, RootId,
-    LEGACY_ROOT_ID,
+    alloc_root_id, current_root_id, drop_host_for_root, install_host_for_root,
+    install_thread_local_host, native_create_root,
+    native_use_effect, native_use_layout_effect, native_use_memo, native_use_ref,
+    native_use_state, run_with_current_root,
+    schedule_flush,
+    unregister_root, unregister_root_hooks_and_effects, with_host_for_root,
+    with_thread_local_host, HookState, RootId, LEGACY_ROOT_ID,
 };
 
 use tishlang_core::{ObjectMap, Value, VmRef};
@@ -155,27 +157,6 @@ impl Host for HeadlessHost {
     fn commit_root(&mut self, vnode: &Value) {
         self.last = Some(vnode.clone());
     }
-}
-
-thread_local! {
-    static ACTIVE_HOST: RefCell<Option<Box<dyn Host>>> = RefCell::new(None);
-}
-
-/// Install the thread-local host used by [`schedule_flush`] / `createRoot`.
-pub fn install_thread_local_host(host: Box<dyn Host>) {
-    ACTIVE_HOST.with(|c| {
-        *c.borrow_mut() = Some(host);
-    });
-}
-
-pub fn with_thread_local_host<R>(f: impl FnOnce(&mut dyn Host) -> R) -> Option<R> {
-    ACTIVE_HOST.with(|c| {
-        let mut opt = c.borrow_mut();
-        match opt.as_deref_mut() {
-            Some(host) => Some(f(host)),
-            None => None,
-        }
-    })
 }
 
 /// Tag registry hook for future host-specific intrinsic mapping (HTML tag → component kind).

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -455,6 +455,46 @@ fn init_globals(enabled: &HashSet<String>) -> ObjectMap {
         "trunc".into(),
         Value::native(|args: &[Value]| math_builtins::trunc(args)),
     );
+    // Trig/hypot not covered by `math_builtins`; needed by the 3D engine's
+    // camera + character-controller math (atan2/hypot) on the wasm VM, where
+    // (unlike `--target js`) there is no host `Math` to fall through to.
+    math.insert(
+        "atan2".into(),
+        Value::native(|args: &[Value]| {
+            let y = args.first().and_then(|v| v.as_number()).unwrap_or(f64::NAN);
+            let x = args.get(1).and_then(|v| v.as_number()).unwrap_or(f64::NAN);
+            Value::Number(y.atan2(x))
+        }),
+    );
+    math.insert(
+        "atan".into(),
+        Value::native(|args: &[Value]| {
+            let n = args.first().and_then(|v| v.as_number()).unwrap_or(f64::NAN);
+            Value::Number(n.atan())
+        }),
+    );
+    math.insert(
+        "asin".into(),
+        Value::native(|args: &[Value]| {
+            let n = args.first().and_then(|v| v.as_number()).unwrap_or(f64::NAN);
+            Value::Number(n.asin())
+        }),
+    );
+    math.insert(
+        "acos".into(),
+        Value::native(|args: &[Value]| {
+            let n = args.first().and_then(|v| v.as_number()).unwrap_or(f64::NAN);
+            Value::Number(n.acos())
+        }),
+    );
+    math.insert(
+        "hypot".into(),
+        Value::native(|args: &[Value]| {
+            let nums: Vec<f64> = args.iter().filter_map(|v| v.as_number()).collect();
+            let sum_sq: f64 = nums.iter().map(|n| n * n).sum();
+            Value::Number(sum_sq.sqrt())
+        }),
+    );
     math.insert("PI".into(), Value::Number(std::f64::consts::PI));
     math.insert("E".into(), Value::Number(std::f64::consts::E));
     g.insert("Math".into(), value_object_from_map(math));

--- a/crates/tish_wasm/src/lib.rs
+++ b/crates/tish_wasm/src/lib.rs
@@ -231,6 +231,33 @@ pub fn compile_to_wasm(
     emit_wasm_from_chunk(&chunk, output_path)
 }
 
+/// Compile a Tish project to a raw serialized bytecode chunk.
+///
+/// Writes a single `{output}` file of the exact bytes that the wasm/WASI runtime entry points
+/// (`start` / `run`) deserialize directly — the same chunk `--target wasm` embeds as base64 in
+/// its generated HTML loader, but written raw with no VM binary, JS glue, or HTML wrapper. Lets a
+/// host that already ships the VM runtime (e.g. a bundler) consume the bytecode without the
+/// throwaway standalone build.
+pub fn compile_to_bytecode(
+    entry_path: &Path,
+    project_root: Option<&Path>,
+    output_path: &Path,
+    optimize: bool,
+) -> Result<(), WasmError> {
+    let (chunk, _) = resolve_and_compile_to_chunk(entry_path, project_root, optimize)?;
+    let bytes = serialize(&chunk);
+    if let Some(parent) = output_path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent).map_err(|e| WasmError {
+            message: format!("Cannot create output directory: {}", e),
+        })?;
+    }
+    std::fs::write(output_path, &bytes).map_err(|e| WasmError {
+        message: format!("Cannot write {}: {}", output_path.display(), e),
+    })?;
+    println!("Built: {} ({} bytes)", output_path.display(), bytes.len());
+    Ok(())
+}
+
 /// Compile a Tish project for Wasmtime/WASI.
 ///
 /// Produces a single `{output}.wasm` with embedded bytecode. Run with:

--- a/crates/tish_wasm_runtime/Cargo.toml
+++ b/crates/tish_wasm_runtime/Cargo.toml
@@ -12,6 +12,10 @@ crate-type = ["cdylib", "rlib"]
 [features]
 # For wasm32-unknown-unknown (browser): wasm-bindgen, console output
 browser = ["dep:wasm-bindgen", "tishlang_vm/wasm"]
+# Browser WebGPU / JS-interop FFI + requestAnimationFrame render loop (the
+# `start(chunk, env)` entry). Reflection-based bridge over js-sys; no web-sys
+# WebGPU bindings needed since the WebGPU command API is synchronous.
+gpu = ["browser", "dep:js-sys"]
 # Built-in modules for WASI (wasm32-wasip1): align with `tishlang_cranelift_runtime` / CLI caps
 fs = ["tishlang_vm/fs"]
 process = ["tishlang_vm/process"]
@@ -24,7 +28,9 @@ ws = ["tishlang_vm/ws"]
 [dependencies]
 tishlang_bytecode = { path = "../tish_bytecode", version = ">=0.1" }
 tishlang_vm = { path = "../tish_vm", version = ">=0.1" }
+tishlang_core = { path = "../tish_core", version = ">=0.1" }
 wasm-bindgen = { version = "0.2", optional = true }
+js-sys = { version = "0.3", optional = true }
 
 # rand_core → getrandom 0.4 needs wasm_js on wasm32-unknown-unknown (browser VM build).
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/tish_wasm_runtime/src/gpu.rs
+++ b/crates/tish_wasm_runtime/src/gpu.rs
@@ -1,0 +1,413 @@
+//! Browser WebGPU / JS-interop FFI for the tish bytecode VM.
+//!
+//! Lets a tish program compiled to wasm drive the browser's WebGPU (and any
+//! Web API) without hand-binding each call. The bridge is a tiny set of
+//! reflection-based primitives exposed as VM globals:
+//!
+//! - `js_global(name)` — read a JS global (e.g. `navigator`, `GPUBufferUsage`)
+//! - `js_get(handle, key)` / `js_set(handle, key, val)`
+//! - `js_call(handle, method, argsArray)` — call a method (the whole WebGPU
+//!   command API is synchronous, so this covers it)
+//! - `js_new(ctorNameOrHandle, argsArray)`
+//! - `js_typeof(handle)` — debugging
+//! - `f32a(arr)` / `u16a(arr)` / `u8a(arr)` — tish `number[]` → real typed array
+//! - `request_animation_frame(cb)` — drive a render loop
+//!
+//! GPU/JS objects (device, queue, context, buffers, pipelines, textures,
+//! ImageBitmaps, the host env object …) round-trip through the VM as opaque
+//! [`JsHandle`] values. Async startup (requestAdapter/requestDevice/fetch/
+//! createImageBitmap) is done in JS glue; the ready handles are handed to the
+//! VM via the `host` global by [`start`].
+
+use std::any::Any;
+use std::cell::{Cell, RefCell};
+use std::sync::Arc;
+
+use tishlang_bytecode::deserialize;
+use tishlang_core::{value_call, NativeFn, TishOpaque, Value};
+use tishlang_vm::Vm;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+
+// ---------------------------------------------------------------------------
+// Opaque JS handle
+// ---------------------------------------------------------------------------
+
+/// Opaque tish value wrapping a browser `JsValue`. `JsValue` is `!Send`, which
+/// is why `TishOpaque`'s `Send + Sync` bound is gated off in the browser
+/// (`!send-values`) build — see `tish_core/src/value.rs`.
+struct JsHandle(JsValue);
+
+impl TishOpaque for JsHandle {
+    fn type_name(&self) -> &'static str {
+        "JsHandle"
+    }
+    fn get_method(&self, _name: &str) -> Option<NativeFn> {
+        None
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+fn wrap(v: JsValue) -> Value {
+    Value::Opaque(Arc::new(JsHandle(v)))
+}
+
+fn unwrap_handle(v: &Value) -> Option<JsValue> {
+    match v {
+        Value::Opaque(o) => o.as_any().downcast_ref::<JsHandle>().map(|h| h.0.clone()),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Marshalling  tish Value <-> JsValue
+// ---------------------------------------------------------------------------
+
+/// Convert a tish value to a JS value. Objects/arrays recurse; an opaque
+/// `JsHandle` is spliced in **by reference** (so descriptors can embed live GPU
+/// handles, e.g. `beginRenderPass({ colorAttachments:[{ view:<handle> }] })`).
+/// Functions/promises/symbols are not marshalled (return `null`).
+fn value_to_js(v: &Value) -> JsValue {
+    match v {
+        Value::Number(n) => JsValue::from_f64(*n),
+        Value::String(s) => JsValue::from_str(s.as_ref()),
+        Value::Bool(b) => JsValue::from_bool(*b),
+        Value::Null => JsValue::NULL,
+        Value::Opaque(o) => match o.as_any().downcast_ref::<JsHandle>() {
+            Some(h) => h.0.clone(),
+            None => JsValue::NULL,
+        },
+        Value::Array(arr) => {
+            let out = js_sys::Array::new();
+            for item in arr.borrow().iter() {
+                out.push(&value_to_js(item));
+            }
+            out.into()
+        }
+        Value::Object(obj) => {
+            let out = js_sys::Object::new();
+            let b = obj.borrow();
+            for (k, val) in b.strings.iter() {
+                let _ = js_sys::Reflect::set(
+                    &out,
+                    &JsValue::from_str(k.as_ref()),
+                    &value_to_js(val),
+                );
+            }
+            out.into()
+        }
+        _ => JsValue::NULL,
+    }
+}
+
+/// Convert a JS value back to tish. Primitives map directly; everything else
+/// (objects, functions, typed arrays, GPU objects) becomes an opaque handle —
+/// we deliberately do **not** expand JS containers into tish arrays/objects
+/// (that would re-introduce boxing and lose typed-array identity).
+fn js_to_value(v: JsValue) -> Value {
+    if v.is_null() || v.is_undefined() {
+        Value::Null
+    } else if let Some(n) = v.as_f64() {
+        Value::Number(n)
+    } else if let Some(b) = v.as_bool() {
+        Value::Bool(b)
+    } else if let Some(s) = v.as_string() {
+        Value::String(s.into())
+    } else {
+        wrap(v)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FFI builtins
+// ---------------------------------------------------------------------------
+
+fn ffi_js_global() -> Value {
+    Value::native(|args: &[Value]| {
+        let name = match args.first() {
+            Some(Value::String(s)) => s.clone(),
+            _ => return Value::Null,
+        };
+        match js_sys::Reflect::get(&js_sys::global(), &JsValue::from_str(name.as_ref())) {
+            Ok(v) => js_to_value(v),
+            Err(_) => Value::Null,
+        }
+    })
+}
+
+fn ffi_js_get() -> Value {
+    Value::native(|args: &[Value]| {
+        let obj = match args.first().and_then(unwrap_handle) {
+            Some(o) => o,
+            None => return Value::Null,
+        };
+        let key = args.get(1).map(value_to_js).unwrap_or(JsValue::NULL);
+        match js_sys::Reflect::get(&obj, &key) {
+            Ok(v) => js_to_value(v),
+            Err(_) => Value::Null,
+        }
+    })
+}
+
+fn ffi_js_set() -> Value {
+    Value::native(|args: &[Value]| {
+        let obj = match args.first().and_then(unwrap_handle) {
+            Some(o) => o,
+            None => return Value::Null,
+        };
+        let key = args.get(1).map(value_to_js).unwrap_or(JsValue::NULL);
+        let val = args.get(2).map(value_to_js).unwrap_or(JsValue::NULL);
+        let _ = js_sys::Reflect::set(&obj, &key, &val);
+        Value::Null
+    })
+}
+
+fn ffi_js_call() -> Value {
+    Value::native(|args: &[Value]| {
+        let obj = match args.first().and_then(unwrap_handle) {
+            Some(o) => o,
+            None => return Value::Null,
+        };
+        let method = match args.get(1) {
+            Some(Value::String(s)) => s.clone(),
+            _ => return Value::Null,
+        };
+        let func = match js_sys::Reflect::get(&obj, &JsValue::from_str(method.as_ref())) {
+            Ok(f) => match f.dyn_into::<js_sys::Function>() {
+                Ok(f) => f,
+                Err(_) => return Value::Null,
+            },
+            Err(_) => return Value::Null,
+        };
+        let js_args = js_sys::Array::new();
+        if let Some(Value::Array(a)) = args.get(2) {
+            for item in a.borrow().iter() {
+                js_args.push(&value_to_js(item));
+            }
+        }
+        match js_sys::Reflect::apply(&func, &obj, &js_args) {
+            Ok(v) => js_to_value(v),
+            Err(_) => Value::Null,
+        }
+    })
+}
+
+fn ffi_js_new() -> Value {
+    Value::native(|args: &[Value]| {
+        let ctor: JsValue = match args.first() {
+            Some(Value::String(s)) => {
+                match js_sys::Reflect::get(&js_sys::global(), &JsValue::from_str(s.as_ref())) {
+                    Ok(v) => v,
+                    Err(_) => return Value::Null,
+                }
+            }
+            Some(v @ Value::Opaque(_)) => match unwrap_handle(v) {
+                Some(h) => h,
+                None => return Value::Null,
+            },
+            _ => return Value::Null,
+        };
+        let ctor_fn = match ctor.dyn_into::<js_sys::Function>() {
+            Ok(f) => f,
+            Err(_) => return Value::Null,
+        };
+        let js_args = js_sys::Array::new();
+        if let Some(Value::Array(a)) = args.get(1) {
+            for item in a.borrow().iter() {
+                js_args.push(&value_to_js(item));
+            }
+        }
+        match js_sys::Reflect::construct(&ctor_fn, &js_args) {
+            Ok(v) => js_to_value(v),
+            Err(_) => Value::Null,
+        }
+    })
+}
+
+fn ffi_js_typeof() -> Value {
+    Value::native(|args: &[Value]| {
+        let v = args.first().map(value_to_js).unwrap_or(JsValue::NULL);
+        match v.js_typeof().as_string() {
+            Some(s) => Value::String(s.into()),
+            None => Value::Null,
+        }
+    })
+}
+
+/// `f32a(numberArray)` -> opaque `Float32Array` handle (one-shot copy). Use for
+/// per-frame uniform/transform staging. Large static buffers should instead be
+/// materialised host-side and passed in opaque (never boxed into a tish array).
+fn ffi_f32a() -> Value {
+    Value::native(|args: &[Value]| {
+        let arr = match args.first() {
+            Some(Value::Array(a)) => a.clone(),
+            _ => return Value::Null,
+        };
+        let b = arr.borrow();
+        let ta = js_sys::Float32Array::new_with_length(b.len() as u32);
+        for (i, v) in b.iter().enumerate() {
+            ta.set_index(i as u32, v.as_number().unwrap_or(0.0) as f32);
+        }
+        wrap(ta.into())
+    })
+}
+
+fn ffi_u16a() -> Value {
+    Value::native(|args: &[Value]| {
+        let arr = match args.first() {
+            Some(Value::Array(a)) => a.clone(),
+            _ => return Value::Null,
+        };
+        let b = arr.borrow();
+        let ta = js_sys::Uint16Array::new_with_length(b.len() as u32);
+        for (i, v) in b.iter().enumerate() {
+            ta.set_index(i as u32, v.as_number().unwrap_or(0.0) as u16);
+        }
+        wrap(ta.into())
+    })
+}
+
+fn ffi_u8a() -> Value {
+    Value::native(|args: &[Value]| {
+        let arr = match args.first() {
+            Some(Value::Array(a)) => a.clone(),
+            _ => return Value::Null,
+        };
+        let b = arr.borrow();
+        let ta = js_sys::Uint8Array::new_with_length(b.len() as u32);
+        for (i, v) in b.iter().enumerate() {
+            ta.set_index(i as u32, v.as_number().unwrap_or(0.0) as u8);
+        }
+        wrap(ta.into())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// requestAnimationFrame render loop
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    static RAF_CALLBACK: RefCell<Option<Value>> = const { RefCell::new(None) };
+    static RAF_CLOSURE: RefCell<Option<Closure<dyn FnMut(f64)>>> = const { RefCell::new(None) };
+    // True while a frame is pending, so repeated request_animation_frame calls
+    // within one frame don't compound into runaway scheduling.
+    static RAF_SCHEDULED: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Browser-driven per-frame entry: invoke the stored tish callback, then
+/// re-arm for the next frame. We re-schedule from Rust (rather than requiring
+/// the tish callback to call `request_animation_frame` again each frame) so the
+/// loop runs continuously as long as a callback is registered. `cancel`-ing the
+/// loop = clearing `RAF_CALLBACK`. The `value_call` runs the frame closure to
+/// completion; all WebGPU recording happens synchronously inside.
+fn tick(ts: f64) {
+    let cb = RAF_CALLBACK.with(|c| c.borrow().clone());
+    // This frame's pending schedule is now consumed.
+    RAF_SCHEDULED.with(|f| f.set(false));
+    if let Some(cb) = cb {
+        if matches!(cb, Value::Function(_)) {
+            value_call(&cb, &[Value::Number(ts)]);
+        }
+        // Re-arm only if the callback is still registered (allows a future
+        // cancel by clearing RAF_CALLBACK).
+        if RAF_CALLBACK.with(|c| c.borrow().is_some()) {
+            schedule_raf();
+        }
+    }
+}
+
+fn schedule_raf() {
+    // Coalesce: at most one rAF in flight at a time.
+    if RAF_SCHEDULED.with(|f| f.get()) {
+        return;
+    }
+    RAF_SCHEDULED.with(|f| f.set(true));
+    RAF_CLOSURE.with(|slot| {
+        let mut s = slot.borrow_mut();
+        if s.is_none() {
+            *s = Some(Closure::wrap(Box::new(|ts: f64| tick(ts)) as Box<dyn FnMut(f64)>));
+        }
+        let g = js_sys::global();
+        if let Ok(raf) = js_sys::Reflect::get(&g, &JsValue::from_str("requestAnimationFrame")) {
+            if let Ok(raf_fn) = raf.dyn_into::<js_sys::Function>() {
+                let _ = raf_fn.call1(&g, s.as_ref().unwrap().as_ref().unchecked_ref());
+            }
+        }
+    });
+}
+
+fn ffi_request_animation_frame() -> Value {
+    Value::native(|args: &[Value]| {
+        if let Some(cb) = args.first() {
+            RAF_CALLBACK.with(|c| *c.borrow_mut() = Some(cb.clone()));
+        }
+        schedule_raf();
+        Value::Null
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Install + entry point
+// ---------------------------------------------------------------------------
+
+fn install_ffi(vm: &mut Vm) {
+    vm.set_global("js_global".into(), ffi_js_global());
+    vm.set_global("js_get".into(), ffi_js_get());
+    vm.set_global("js_set".into(), ffi_js_set());
+    vm.set_global("js_call".into(), ffi_js_call());
+    vm.set_global("js_new".into(), ffi_js_new());
+    vm.set_global("js_typeof".into(), ffi_js_typeof());
+    vm.set_global("f32a".into(), ffi_f32a());
+    vm.set_global("u16a".into(), ffi_u16a());
+    vm.set_global("u8a".into(), ffi_u8a());
+    vm.set_global("request_animation_frame".into(), ffi_request_animation_frame());
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console, js_name = error)]
+    fn console_error(s: &str);
+}
+
+fn set_panic_hook() {
+    use std::sync::Once;
+    static HOOK: Once = Once::new();
+    HOOK.call_once(|| {
+        std::panic::set_hook(Box::new(|info| {
+            console_error(&format!("tish wasm panic: {}", info));
+        }));
+    });
+}
+
+/// Browser entry: run a tish bytecode `chunk` with the JS-interop FFI installed
+/// and the host environment object (device/queue/context/format/canvas/assets,
+/// built by the page's async startup glue) exposed as the `host` global.
+///
+/// Returns after top-level tish runs; the `requestAnimationFrame` loop keeps
+/// the captured globals alive via the stored callback, so the VM state persists
+/// across frames even though this call returns.
+/// Invoke the registered frame callback exactly once, without re-scheduling.
+/// For driving frames deterministically from JS when `requestAnimationFrame` is
+/// throttled (e.g. a hidden/offscreen preview tab) — verification & debugging.
+#[wasm_bindgen]
+pub fn tick_once(ts: f64) {
+    let cb = RAF_CALLBACK.with(|c| c.borrow().clone());
+    if let Some(cb) = cb {
+        if matches!(cb, Value::Function(_)) {
+            value_call(&cb, &[Value::Number(ts)]);
+        }
+    }
+}
+
+#[wasm_bindgen]
+pub fn start(chunk: Vec<u8>, env: JsValue) -> Result<(), JsValue> {
+    set_panic_hook();
+    let chunk = deserialize(&chunk).map_err(|e| JsValue::from_str(&e))?;
+    let mut vm = Vm::new();
+    install_ffi(&mut vm);
+    vm.set_global("host".into(), wrap(env));
+    vm.run(&chunk).map_err(|e| JsValue::from_str(&e))?;
+    Ok(())
+}

--- a/crates/tish_wasm_runtime/src/lib.rs
+++ b/crates/tish_wasm_runtime/src/lib.rs
@@ -8,6 +8,11 @@
 use tishlang_bytecode::deserialize;
 use tishlang_vm::Vm;
 
+/// Browser WebGPU / JS-interop FFI + requestAnimationFrame render loop.
+/// Adds the `start(chunk, env)` wasm-bindgen entry used by the engine.
+#[cfg(feature = "gpu")]
+pub mod gpu;
+
 /// Run serialized Tish bytecode (WASI/Wasmtime or native).
 ///
 /// `chunk` is the output of `tishlang_bytecode::serialize(chunk)`.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "tish",
   "version": "1.0.12",
-  "private": true
+  "private": true,
+  "license": "PIF"
 }


### PR DESCRIPTION
Enable other cli app build targets. Can be used with https://github.com/tishlang/tish-apple to create native iOS & MacOS UIs.