### PR TITLE
fix(array): `arr.length = k` truncates / grows the array

### DIFF
--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -2087,6 +2087,19 @@ impl Evaluator {
                             .insert(Arc::clone(prop), val.clone());
                         Ok(val)
                     }
+                    // `arr.length = k` truncates / grows the array (holes read back as Null),
+                    // matching JS and the bytecode VM (issue #62).
+                    Value::Array(arr) if prop.as_ref() == "length" => {
+                        let n = match &val {
+                            Value::Number(n) => *n,
+                            _ => f64::NAN,
+                        };
+                        if n.is_nan() || n < 0.0 || n.fract() != 0.0 || n > 4_294_967_295.0 {
+                            return Err(EvalError::Error("Invalid array length".to_string()));
+                        }
+                        arr.borrow_mut().resize(n as usize, Value::Null);
+                        Ok(val)
+                    }
                     _ => Err(EvalError::Error(format!(
                         "Cannot assign property '{}' on non-object: {:?}",
                         prop, obj_val

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -837,6 +837,16 @@ pub fn set_prop(obj: &Value, key: &str, val: Value) -> Value {
             }
             val
         }
+        // `arr.length = k` truncates / grows the array (holes read back as Null), matching
+        // JS and the VM/interpreter (issue #62).
+        Value::Array(arr) if key == "length" => {
+            let n = extract_num(Some(&val)).unwrap_or(f64::NAN);
+            if n.is_nan() || n < 0.0 || n.fract() != 0.0 || n > 4_294_967_295.0 {
+                panic!("Invalid array length");
+            }
+            arr.borrow_mut().resize(n as usize, Value::Null);
+            val
+        }
         _ => panic!("Cannot assign property on non-object"),
     }
 }

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -3106,6 +3106,13 @@ fn set_member(obj: &Value, key: &Arc<str>, val: Value) -> Result<(), String> {
             Ok(())
         }
         Value::Array(a) => {
+            if key.as_ref() == "length" {
+                // `arr.length = k` truncates or grows (holes read back as Null), JS-style.
+                let new_len = array_length_arg(&val)?;
+                let mut arr = a.borrow_mut();
+                arr.resize(new_len, Value::Null);
+                return Ok(());
+            }
             let idx: usize = key.as_ref().parse().unwrap_or(0);
             let mut arr = a.borrow_mut();
             if idx < arr.len() {
@@ -3116,8 +3123,27 @@ fn set_member(obj: &Value, key: &Arc<str>, val: Value) -> Result<(), String> {
             }
             Ok(())
         }
+        Value::NumberArray(a) => {
+            if key.as_ref() == "length" {
+                let new_len = array_length_arg(&val)?;
+                // NaN is the packed-array hole marker (read back as Null), matching get_index.
+                a.borrow_mut().resize(new_len, f64::NAN);
+                return Ok(());
+            }
+            Err(format!("Cannot set property of {}", obj.type_name()))
+        }
         _ => Err(format!("Cannot set property of {}", obj.type_name())),
     }
+}
+
+/// JS `arr.length = v`: `v` is coerced to a number and must be a valid array length —
+/// a non-negative integer below 2³². Anything else is a RangeError ("Invalid array length").
+fn array_length_arg(val: &Value) -> Result<usize, String> {
+    let n = val.as_number().unwrap_or(f64::NAN);
+    if n.is_nan() || n < 0.0 || n.fract() != 0.0 || n > 4_294_967_295.0 {
+        return Err("Invalid array length".to_string());
+    }
+    Ok(n as usize)
 }
 
 fn get_index(obj: &Value, idx: &Value) -> Result<Value, String> {

--- a/tests/core/array_length_assign.tish
+++ b/tests/core/array_length_assign.tish
@@ -1,0 +1,17 @@
+// arr.length = k truncates / grows the array (issue #62)
+let a = [1, 2, 3, 4, 5]
+a.length = 3
+console.log("trunc len:", a.length)
+console.log("trunc:", a.join(","))
+a.length = 5
+console.log("grow len:", a.length)
+a.length = 0
+console.log("clear len:", a.length)
+console.log("clear:", a.join(","))
+
+let b = []
+b.push(10)
+b.push(20)
+b.push(30)
+b.length = 2
+console.log("b:", b.length, b.join(","))

--- a/tests/core/array_length_assign.tish.expected
+++ b/tests/core/array_length_assign.tish.expected
@@ -1,0 +1,6 @@
+trunc len: 3
+trunc: 1,2,3
+grow len: 5
+clear len: 0
+clear: 
+b: 2 10,20


### PR DESCRIPTION
## Summary
Assigning to `arr.length` was broken on every backend except the JS target:
- **VM** — `"length"` failed to parse as an index and fell through to `unwrap_or(0)`, silently writing `arr[0]` while `.length` stayed unchanged
- **Interpreter** — threw `Cannot assign property 'length' on non-object`
- **native/cranelift runtime** — panicked `Cannot assign property on non-object`

## Fix
`arr.length = k` now resizes on all backends: truncates when shrinking, grows with holes (read back as `Null`) when extending, and raises `Invalid array length` for a non-integer / negative / ≥2³² value — matching JS. Also covers the packed `NumberArray` representation in the VM.

## Test (TDD)
`tests/core/array_length_assign.tish` (+ `.expected` generated from the JS target). Verified identical output on **vm, interp, native, cranelift, js**:
```
trunc len: 3 / trunc: 1,2,3 / grow len: 5 / clear len: 0 / b: 2 10,20
```

Closes #62