### PR TITLE
fix(vm): missing own-property read returns `null` instead of throwing

### DIFF
--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -2650,10 +2650,9 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                 }
             }
             let map = m.borrow();
-            map.strings
-                .get(key.as_ref())
-                .cloned()
-                .ok_or_else(|| format!("Property '{}' not found", key))
+            // Reading a missing own property returns `null` (tish's nullish value), matching
+            // JS object semantics and the tree-walk interpreter — not a thrown error (#66).
+            Ok(map.strings.get(key.as_ref()).cloned().unwrap_or(Value::Null))
         }
         Value::NumberArray(a) => {
             let key_s = key.as_ref();

--- a/tests/core/missing_property.tish
+++ b/tests/core/missing_property.tish
@@ -1,0 +1,14 @@
+// Reading a missing own property returns a nullish value instead of throwing (issue #66).
+// (Asserted via falsy context so it's identical on every backend — tish has no `undefined`,
+// and the JS target prints `undefined` for a raw missing read, so we don't print it raw.)
+let o = { a: 1 }
+console.log(o.a)
+console.log(!o.b)
+let r = o.b ? "has" : "missing"
+console.log(r)
+let o2 = { x: { y: 5 } }
+console.log(o2.x.y)
+console.log(!o2.x.z)
+// merely reading a missing property must not throw — reaching this line proves it
+let probe = o.nope
+console.log("done")

--- a/tests/core/missing_property.tish.expected
+++ b/tests/core/missing_property.tish.expected
@@ -1,0 +1,6 @@
+1
+true
+missing
+5
+true
+done


### PR DESCRIPTION
## Summary
Reading a missing **own property** of an object threw `Property 'X' not found` on the bytecode VM, breaking the ubiquitous `obj.maybeMissing` / `obj.maybeMissing ? … : …` pattern. The tree-walk interpreter already returns tish's nullish value here, so the VM was the only diverging backend (a #67-class gap).

## Fix
`get_member`'s `Value::Object` arm now returns `Value::Null` for a missing key instead of `Err`, matching the interpreter and JS object semantics. (tish has no `undefined`; `null` is its single nullish value — so the issue's "return undefined" means "return null, don't throw".)

## Test (TDD)
`tests/core/missing_property.tish`. Because tish has no `undefined` and the JS target prints `undefined` for a raw missing read, the assertions use falsy context (`!o.b`, `o.b ? … : …`) so they're byte-identical on every backend, and a bare `let probe = o.nope` proves it no longer throws. Verified on **vm, interp, native, cranelift, wasi, js**; full integration suite green (19/19).

Closes #66