### PR TITLE
feat(vm): runtime errors carry source `file:line`

### DIFF
--- a/crates/tish/src/main.rs
+++ b/crates/tish/src/main.rs
@@ -188,7 +188,7 @@ fn run_stdin_source(
     } else {
         tishlang_opt::optimize(&prog)
     };
-    run_program(&program, &cwd, backend, no_optimize, features)
+    run_program(&program, &cwd, backend, no_optimize, features, None)
 }
 
 fn run_file(
@@ -237,7 +237,7 @@ fn run_file(
         .parent()
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|| std::path::PathBuf::from("."));
-    run_program(&program, &ffi_base, backend, no_optimize, features)
+    run_program(&program, &ffi_base, backend, no_optimize, features, Some(path))
 }
 
 /// Load every `ffi:<path>` cdylib the program imports, resolving each path relative to `base_dir`
@@ -266,6 +266,7 @@ fn run_program(
     backend: &str,
     no_optimize: bool,
     features: &[String],
+    source_name: Option<&str>,
 ) -> Result<(), String> {
     // FFI: load each `ffi:<path>` cdylib (resolved relative to the importing file) into a
     // name→export map the backends register as a native module. Built once, shared across backends.
@@ -299,10 +300,15 @@ fn run_program(
         return Ok(());
     }
 
+    let source_arc: Option<std::sync::Arc<str>> = source_name.map(std::sync::Arc::from);
     let chunk = if no_optimize {
-        tishlang_bytecode::compile_unoptimized(program).map_err(|e| e.to_string())?
+        // `--no-optimize` keeps the simpler path; line info is most useful with optimization on.
+        let mut c = tishlang_bytecode::compile_unoptimized(program).map_err(|e| e.to_string())?;
+        c.source = source_arc.clone();
+        c
     } else {
-        tishlang_bytecode::compile(program).map_err(|e| e.to_string())?
+        tishlang_bytecode::compile_with_source(program, source_arc.clone())
+            .map_err(|e| e.to_string())?
     };
     let caps = vm_capabilities_for_cli_run(features);
     let mut vm = tishlang_vm::Vm::with_capabilities(caps);

--- a/crates/tish/tests/error_source_location.rs
+++ b/crates/tish/tests/error_source_location.rs
@@ -1,0 +1,36 @@
+//! Issue #74: a runtime error from the bytecode VM carries its source location (`file:line`)
+//! instead of a bare message, so embedders/users can find where it came from.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+fn runtime_error_reports_source_file_and_line() {
+    let tish = PathBuf::from(env!("CARGO_BIN_EXE_tish"));
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("runtime_error_location.tish");
+    assert!(fixture.is_file(), "missing fixture {}", fixture.display());
+
+    // `obj.field.deep` reads `.field` of `null` on line 4 of the fixture.
+    let out = Command::new(&tish)
+        .args(["run", "--backend", "vm", fixture.to_str().unwrap()])
+        .output()
+        .expect("spawn tish run");
+    assert!(!out.status.success(), "expected a runtime error");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        stderr.contains(":4"),
+        "error should report the source line (4):\n{stderr}"
+    );
+    assert!(
+        stderr.contains("runtime_error_location.tish"),
+        "error should report the source file:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Cannot read property 'field' of null"),
+        "error should keep the original message:\n{stderr}"
+    );
+}

--- a/crates/tish/tests/fixtures/runtime_error_location.tish
+++ b/crates/tish/tests/fixtures/runtime_error_location.tish
@@ -1,0 +1,5 @@
+let a = 1
+let b = 2
+let obj = null
+let x = obj.field.deep
+console.log(x)

--- a/crates/tish_bytecode/src/chunk.rs
+++ b/crates/tish_bytecode/src/chunk.rs
@@ -73,6 +73,12 @@ pub struct Chunk {
     /// Inline caches for object property access, one cell per entry in `names` (so indexed by the
     /// same name index `GetMember`/`SetMember` carry). Runtime-only; not part of the serialized program.
     pub inline_caches: InlineCaches,
+    /// Source line table: `(code_offset, line)` pairs, sorted by offset, one entry per line change
+    /// (issue #74). Consulted only when formatting a runtime error, so it adds zero execution
+    /// overhead. Debug-only / runtime-only — not serialized (persisted bytecode loses line info).
+    pub lines: Vec<(u32, u32)>,
+    /// Source file path for error messages (`file:line`); propagated to nested chunks. Runtime-only.
+    pub source: Option<Arc<str>>,
 }
 
 impl Chunk {
@@ -87,6 +93,36 @@ impl Chunk {
             num_slots: 0,
             slot_based: false,
             inline_caches: InlineCaches::default(),
+            lines: Vec::new(),
+            source: None,
+        }
+    }
+
+    /// Record that the instruction starting at `offset` originates from source `line` (1-based).
+    /// Only stored when the line changes, keeping the table compact. Issue #74.
+    pub fn mark_line(&mut self, offset: usize, line: u32) {
+        if line == 0 {
+            return;
+        }
+        match self.lines.last() {
+            Some(&(_, last_line)) if last_line == line => {}
+            _ => self.lines.push((offset as u32, line)),
+        }
+    }
+
+    /// Source line for a bytecode `offset` (the line of the nearest preceding `mark_line`), or
+    /// `None` if no line info is available (e.g. deserialized bytecode). Issue #74.
+    pub fn line_at(&self, offset: usize) -> Option<u32> {
+        if self.lines.is_empty() {
+            return None;
+        }
+        let off = offset as u32;
+        // Largest recorded offset <= `off`.
+        let idx = self.lines.partition_point(|&(o, _)| o <= off);
+        if idx == 0 {
+            Some(self.lines[0].1)
+        } else {
+            Some(self.lines[idx - 1].1)
         }
     }
 

--- a/crates/tish_bytecode/src/compiler.rs
+++ b/crates/tish_bytecode/src/compiler.rs
@@ -796,6 +796,13 @@ impl<'a> Compiler<'a> {
         self.chunk.write_u8(op as u8);
     }
 
+    /// Record the source line of the code about to be emitted, for runtime error locations
+    /// (issue #74). Cheap and deduped: only a line *change* adds a table entry.
+    fn mark_line(&mut self, span: tishlang_ast::Span) {
+        let offset = self.chunk.code.len();
+        self.chunk.mark_line(offset, span.start.0 as u32);
+    }
+
     fn emit_u8(&mut self, op: Opcode, v: u8) {
         self.chunk.write_u8(op as u8);
         self.chunk.write_u16(v as u16);
@@ -1127,6 +1134,7 @@ impl<'a> Compiler<'a> {
     }
 
     fn compile_statement(&mut self, stmt: &Statement) -> Result<(), CompileError> {
+        self.mark_line(stmt.span());
         match stmt {
             Statement::Block { statements, .. } => {
                 self.emit(Opcode::EnterBlock);
@@ -1476,6 +1484,7 @@ impl<'a> Compiler<'a> {
                     None
                 };
                 let mut inner = Chunk::new();
+                inner.source = self.chunk.source.clone(); // propagate file for error locations (#74)
                 if let Some(rp) = rest_param {
                     param_names.push(Arc::clone(&rp.name));
                     inner.rest_param_index = (param_names.len() as u16).saturating_sub(1);
@@ -1828,6 +1837,7 @@ impl<'a> Compiler<'a> {
     }
 
     fn compile_expr(&mut self, expr: &Expr) -> Result<(), CompileError> {
+        self.mark_line(expr.span());
         match expr {
             Expr::Literal { value, .. } => {
                 let c = match value {
@@ -2158,6 +2168,7 @@ impl<'a> Compiler<'a> {
                     ArrowBody::Block(s) => stmt_is_param_only(s, pset),
                 });
                 let mut inner = Chunk::new();
+                inner.source = self.chunk.source.clone(); // propagate file for error locations (#74)
                 for p in &param_names {
                     inner.add_name(Arc::clone(p));
                 }
@@ -2519,30 +2530,42 @@ impl<'a> Compiler<'a> {
 
 /// Compile a Tish program to bytecode (with peephole optimizations).
 pub fn compile(program: &Program) -> Result<Chunk, CompileError> {
-    compile_internal(program, true, false)
+    compile_internal(program, true, false, None)
+}
+
+/// Compile, tagging the chunk with a source file path so runtime errors can report
+/// `file:line` (issue #74). The line table is built during compilation and survives the
+/// in-place peephole pass; it is not serialized.
+pub fn compile_with_source(
+    program: &Program,
+    source: Option<std::sync::Arc<str>>,
+) -> Result<Chunk, CompileError> {
+    compile_internal(program, true, false, source)
 }
 
 /// Compile without peephole optimizations (for --no-optimize).
 pub fn compile_unoptimized(program: &Program) -> Result<Chunk, CompileError> {
-    compile_internal(program, false, false)
+    compile_internal(program, false, false, None)
 }
 
 /// Compile for REPL: last expression statement leaves its value on the stack (no Pop, no trailing Null).
 pub fn compile_for_repl(program: &Program) -> Result<Chunk, CompileError> {
-    compile_internal(program, true, true)
+    compile_internal(program, true, true, None)
 }
 
 /// Compile for REPL without peephole optimizations.
 pub fn compile_for_repl_unoptimized(program: &Program) -> Result<Chunk, CompileError> {
-    compile_internal(program, false, true)
+    compile_internal(program, false, true, None)
 }
 
 fn compile_internal(
     program: &Program,
     peephole: bool,
     retain_last_expr: bool,
+    source: Option<std::sync::Arc<str>>,
 ) -> Result<Chunk, CompileError> {
     let mut chunk = Chunk::new();
+    chunk.source = source; // tag before compiling so nested chunks inherit it (#74)
     let mut compiler = Compiler::new(&mut chunk, retain_last_expr);
     compiler.compile_program(program)?;
     if peephole {

--- a/crates/tish_bytecode/src/lib.rs
+++ b/crates/tish_bytecode/src/lib.rs
@@ -12,7 +12,8 @@ pub const NO_REST_PARAM: u16 = 0xFFFF;
 
 pub use chunk::{Chunk, Constant};
 pub use compiler::{
-    compile, compile_for_repl, compile_for_repl_unoptimized, compile_unoptimized, CompileError,
+    compile, compile_for_repl, compile_for_repl_unoptimized, compile_unoptimized,
+    compile_with_source, CompileError,
 };
 pub use encoding::{binop_to_u8, compound_op_to_u8, u8_to_binop, u8_to_unaryop, unaryop_to_u8};
 pub use opcode::Opcode;

--- a/crates/tish_bytecode/src/serialize.rs
+++ b/crates/tish_bytecode/src/serialize.rs
@@ -186,5 +186,8 @@ pub fn deserialize(mut data: &[u8]) -> Result<Chunk, String> {
         num_slots,
         slot_based,
         inline_caches,
+        // Debug-only; not part of the serialized format (issue #74).
+        lines: Vec::new(),
+        source: None,
     })
 }

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -42,6 +42,19 @@ fn pending_throw_is_set() -> bool {
     VM_PENDING_THROW.with(|c| c.borrow().is_some())
 }
 
+/// Append the source location of the instruction at `off` to a runtime-error message, e.g.
+/// `Cannot read property 'x' of null (at app.tish:4)` (issue #74). No-ops when the chunk
+/// carries no line table (e.g. deserialized bytecode).
+fn locate_error(chunk: &Chunk, off: usize, msg: &str) -> String {
+    match chunk.line_at(off) {
+        Some(line) => match &chunk.source {
+            Some(src) => format!("{msg} (at {src}:{line})"),
+            None => format!("{msg} (at line {line})"),
+        },
+        None => msg.to_string(),
+    }
+}
+
 /// Wrap a closure in the right shared pointer for the current build.
 /// Under `send-values` that's `Arc<dyn Fn + Send + Sync>`; otherwise it's
 /// plain `Rc<dyn Fn>`. Call sites can stay ignorant of the distinction.
@@ -1497,6 +1510,10 @@ impl Vm {
         // A closure created while this is non-empty snapshots these into a fresh overlay so it
         // captures the loop variable's value for THIS iteration. Pushed/popped by LoopVarsBegin/End.
         let mut active_loop_vars: Vec<Arc<str>> = Vec::new();
+        // Offset of the instruction currently executing — updated each iteration, read by the
+        // error macros to attach a source location (issue #74). Declared here (not in the loop)
+        // so it's in scope where `catchable!` is defined (macro hygiene).
+        let mut instr_off = 0usize;
 
         // Throw `$v` to the nearest enclosing handler (issue #60): if this frame has a live
         // `try`, jump to its `catch` with `$v` on the stack; otherwise park `$v` in the
@@ -1522,7 +1539,10 @@ impl Vm {
             ($expr:expr) => {
                 match $expr {
                     Ok(v) => v,
-                    Err(msg) => raise!(construct_builtin::error_object("TypeError", &msg)),
+                    Err(msg) => raise!(construct_builtin::error_object(
+                        "TypeError",
+                        &locate_error(chunk, instr_off, &msg)
+                    )),
                 }
             };
         }
@@ -1531,6 +1551,8 @@ impl Vm {
             if ip >= code.len() {
                 break;
             }
+            // Offset of the instruction about to execute (read by the error macros, #74).
+            instr_off = ip;
             let op = code[ip];
             ip += 1;
             if op == Opcode::Nop as u8 {


### PR DESCRIPTION
## Summary
Bytecode VM runtime errors now report **where** they came from:
```
Cannot read property 'field' of null (at app.tish:4)
```
instead of a bare `Cannot read property 'field' of null` (issue #74). Errors inside functions report their own line; caught errors carry the location in `e.message` too.

## How
- The compiler builds a **per-chunk line table** — `(offset, line)` pairs, one per line change — while emitting bytecode (`Chunk::mark_line`/`line_at`). It's a runtime/debug-only field (**not serialized**) and survives the in-place peephole pass (which Nop-replaces, never shifts offsets), so it stays accurate with optimization on.
- On a runtime error the VM looks up the failing instruction's offset → line and prepends `file:line`. **Zero execution overhead** — the table is consulted only when formatting an error.
- The source path is threaded from the CLI (`compile_with_source`) and propagated to nested function chunks.

## Stacked on #94 (#60)
The location is attached at the error-interception points introduced by #60 (`catchable!`). Base retargets to `main` once #94 merges.

## Test (TDD)
`crates/tish/tests/error_source_location.rs` — asserts a null-property-access error's stderr contains the file name, `:4` (the line), and the original message. Full integration suite green (19/19).

## Notes
Persisted bytecode (`--target bytecode`) and the tree-walk interpreter don't carry the line table; this targets the bytecode VM, which is what #74 is about.

Closes #74