### PR TITLE
ci: skip semver dry-run when no version bump (#86)

### DIFF
--- a/.github/workflows/build-npm-binaries.yml
+++ b/.github/workflows/build-npm-binaries.yml
@@ -113,11 +113,12 @@ jobs:
           TISH_SEMANTIC_RELEASE_CI: "1"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Require incremental release
+      - name: Report release status
         run: |
           if [ "${{ steps.semantic.outputs.new_release_published }}" != "true" ]; then
-            echo "No incremental release would be triggered. Push commits that trigger a release (feat/fix/perf/BREAKING CHANGE per conventional commits)."
-            exit 1
+            echo "::notice::No version bump in these commits — skipping the release check (no feat/fix/perf/BREAKING CHANGE per conventional commits)."
+            echo "No incremental release would be triggered; skipping rather than failing (#86)."
+            exit 0
           fi
           echo "Release would be triggered - check passed."
 


### PR DESCRIPTION
## Summary
The `Release check (semantic-release dry-run)` job in `build-npm-binaries.yml` did `exit 1` when a push to `main` had no release-triggering commits, turning the pipeline red for `ci`/`docs`/`chore` changes and for merges without a `feat`/`fix`/`perf`/`BREAKING CHANGE`.

## Fix
The step now logs a `::notice::` and `exit 0` (skips) instead of failing when `new_release_published != true`. A real release still passes the check as before.

Closes #86