### PR TITLE
ci: skip release/publish steps when no version bump (#86 follow-up)

### DIFF
--- a/.github/workflows/build-npm-binaries.yml
+++ b/.github/workflows/build-npm-binaries.yml
@@ -460,13 +460,16 @@ jobs:
         run: |
           VERSION="${{ steps.next_version_semantic.outputs.new_release_version }}"
           if [ -z "$VERSION" ]; then
-            echo "Could not determine next version from semantic-release"
-            exit 1
+            echo "::notice::No version bump in these commits — skipping the release/publish steps (#86)."
+            echo "published=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "published=true" >> $GITHUB_OUTPUT
           echo "Next version: $VERSION"
 
       - name: Set package version for npm pack
+        if: steps.next_version.outputs.published == 'true'
         run: |
           node -e "
           const fs = require('fs');
@@ -478,6 +481,7 @@ jobs:
           VERSION: ${{ steps.next_version.outputs.version }}
 
       - name: Set @tishlang/cargo-bindgen package version for npm pack
+        if: steps.next_version.outputs.published == 'true'
         run: |
           node -e "
           const fs = require('fs');
@@ -489,6 +493,7 @@ jobs:
           VERSION: ${{ steps.next_version.outputs.version }}
 
       - name: Copy workspace source for native compile (rust backend)
+        if: steps.next_version.outputs.published == 'true'
         run: |
           cp Cargo.toml npm/tish/
           cp LICENSE npm/tish/
@@ -498,6 +503,7 @@ jobs:
           rm -f npm/tish/crates/tish/Cargo.toml.bak
 
       - name: Create npm package tarball
+        if: steps.next_version.outputs.published == 'true'
         env:
           TISH_NPM_PACK_REQUIRE: "1"
         run: |
@@ -506,6 +512,7 @@ jobs:
           mv npm/tish/tishlang-tish-*.tgz tish-npm-package.tgz
 
       - name: Create @tishlang/cargo-bindgen npm package tarball
+        if: steps.next_version.outputs.published == 'true'
         env:
           TISHLANG_CARGO_BINDGEN_NPM_PACK_REQUIRE: "1"
         run: |
@@ -514,6 +521,7 @@ jobs:
           mv npm/cargo-bindgen/tishlang-cargo-bindgen-*.tgz cargo-bindgen-npm-package.tgz
 
       - name: Create or update release branch and push
+        if: steps.next_version.outputs.published == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -524,6 +532,7 @@ jobs:
           git push origin "$BRANCH" --force
 
       - name: Generate release notes from commits
+        if: steps.next_version.outputs.published == 'true'
         id: changelog
         run: |
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
@@ -541,6 +550,7 @@ jobs:
           } > release-body.md
 
       - name: Create or update GitHub prerelease via API
+        if: steps.next_version.outputs.published == 'true'
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -585,6 +595,7 @@ jobs:
           echo "release_id=$RELEASE_ID" >> $GITHUB_OUTPUT
 
       - name: Upload platform binaries to prerelease (individual + zip)
+        if: steps.next_version.outputs.published == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Follow-up to #86. The `Release (prerelease branch + GitHub API)` job's `Export next version` step still did `exit 1` when there was no version bump, failing the pipeline on no-release merges (see the #86 merge run). It now sets `published=false` + `exit 0`, and all publish steps are gated on `published == 'true'`, so a no-bump push skips them instead of failing.

Refs #86