### PR TITLE
feat: `tish:tty` — interactive terminal I/O (raw mode, key/resize events, size, stdin)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,6 +759,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,7 +984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
 
@@ -1634,6 +1659,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1726,6 +1757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -2651,6 +2683,19 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2658,7 +2703,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2932,6 +2977,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3093,7 +3169,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3490,6 +3566,7 @@ dependencies = [
  "arc-swap",
  "bytes",
  "core_affinity",
+ "crossterm",
  "futures",
  "futures-util",
  "http",

--- a/crates/tish/Cargo.toml
+++ b/crates/tish/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 default = ["full", "fast-alloc"]
 # Alias: same dependency edges as `default` (kept for `--features full` in CI and docs).
 # Includes `pg` so `tish run` can resolve `import … from '@tishlang/pg'` (`cargo:tish_pg`) on the bytecode VM.
-full = ["http", "fs", "process", "regex", "ws", "timers", "pg"]
+full = ["http", "fs", "process", "regex", "ws", "timers", "tty", "pg"]
 # Fast allocator (mimalloc) as the process `#[global_allocator]`. tish's object/array/string workloads
 # are allocation-bound (a sampling profile of object-heavy code spends ~14%+ in system malloc/free);
 # mimalloc is markedly faster for the many-small-allocations pattern — the same reason JSC ships bmalloc.
@@ -34,6 +34,7 @@ fs      = ["tishlang_eval/fs",      "tishlang_runtime/fs",      "tishlang_compil
 process = ["tishlang_eval/process", "tishlang_runtime/process", "tishlang_compile/process", "tishlang_vm/process"]
 regex   = ["tishlang_eval/regex",   "tishlang_runtime/regex",   "tishlang_compile/regex",   "tishlang_vm/regex"]
 ws      = ["tishlang_eval/ws",      "tishlang_runtime/ws",      "tishlang_compile/ws",      "tishlang_vm/ws"]
+tty     = ["tishlang_eval/tty",     "tishlang_runtime/tty",     "tishlang_compile/tty",     "tishlang_vm/tty"]
 # GPU compute — Apple Silicon only
 [dependencies]
 rustyline = { version = "17", features = ["with-file-history"] }

--- a/crates/tish/src/cli_help.rs
+++ b/crates/tish/src/cli_help.rs
@@ -349,8 +349,10 @@ fn capabilities_section(oh: &str, t: &str, r: &str) -> String {
           RegExp
   {t}ws{r}
           WebSocket client / server
+  {t}tty{r}
+          Interactive terminal: raw mode, key/resize events, size, alt screen (`import from \"tish:tty\"`)
   {t}full{r}
-          All of the above (http, timers, fs, process, regex, ws)
+          All of the above (http, timers, fs, process, regex, ws, tty)
 
 Omit --feature to allow every capability compiled into this `tish` binary; pass flags to restrict what scripts may use. The CLI is normally built with all of them (Cargo default on `tishlang`)."
     )
@@ -430,8 +432,10 @@ pub fn build_after_help() -> String {
           RegExp
   {t}ws{r}
           WebSocket client / server
+  {t}tty{r}
+          Interactive terminal: raw mode, key/resize events, size, alt screen (`import from \"tish:tty\"`)
   {t}full{r}
-          All of the above (http, timers, fs, process, regex, ws)
+          All of the above (http, timers, fs, process, regex, ws, tty)
 
 For `--target native`, these choose what is linked into the **output** executable (omit = same set as this `tish` binary was built with). Minimal native outputs still use a full `tish` CLI unless you built it with `cargo build -p tishlang --no-default-features`."
     )

--- a/crates/tish/src/main.rs
+++ b/crates/tish/src/main.rs
@@ -30,7 +30,7 @@ fn normalize_capability_flags(features: &[String]) -> HashSet<String> {
     for s in features {
         for part in s.split(',').map(str::trim).filter(|p| !p.is_empty()) {
             if part == "full" {
-                for name in ["http", "timers", "fs", "process", "regex", "ws"] {
+                for name in ["http", "timers", "fs", "process", "regex", "ws", "tty"] {
                     out.insert(name.to_string());
                 }
             } else {

--- a/crates/tish/tests/fixtures/tty_capability.tish
+++ b/crates/tish/tests/fixtures/tty_capability.tish
@@ -1,0 +1,9 @@
+// tish:tty capability (issue #101). Asserts the module loads and degrades gracefully when
+// stdout/stdin is not a terminal (CI), so the output is deterministic without a real TTY.
+import { isTTY, size, setRawMode, enterAltScreen, leaveAltScreen, read, readLine } from 'tish:tty'
+console.log("isTTY:", typeof isTTY())
+console.log("size:", size() ? "object" : "null")
+console.log("setRawMode:", typeof setRawMode)
+console.log("read:", typeof read)
+console.log("readLine:", typeof readLine)
+console.log("alt:", typeof enterAltScreen, typeof leaveAltScreen)

--- a/crates/tish/tests/tty_capability.rs
+++ b/crates/tish/tests/tty_capability.rs
@@ -1,0 +1,43 @@
+//! Issue #101: the `tish:tty` capability (raw mode, terminal size, key/resize events) is
+//! available on every backend behind the `tty` feature. CI has no real terminal, so this
+//! asserts the module loads and degrades gracefully (size → null, isTTY → a boolean, the
+//! event/raw-mode primitives are functions). Interactive behavior is covered manually.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+const EXPECTED: &str = "\
+isTTY: boolean
+size: null
+setRawMode: function
+read: function
+readLine: function
+alt: function function
+";
+
+fn run(backend: &str, fixture: &str) -> String {
+    let tish = PathBuf::from(env!("CARGO_BIN_EXE_tish"));
+    let out = Command::new(&tish)
+        .args(["run", "--backend", backend, "--feature", "tty", fixture])
+        .output()
+        .expect("spawn tish run");
+    assert!(
+        out.status.success(),
+        "tish run --backend {backend} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn tty_module_loads_and_degrades_without_a_terminal() {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("tty_capability.tish");
+    assert!(fixture.is_file(), "missing fixture {}", fixture.display());
+    let fixture = fixture.to_str().unwrap();
+
+    assert_eq!(run("vm", fixture), EXPECTED, "vm output mismatch");
+    assert_eq!(run("interp", fixture), EXPECTED, "interp output mismatch");
+}

--- a/crates/tish_compile/Cargo.toml
+++ b/crates/tish_compile/Cargo.toml
@@ -14,6 +14,7 @@ fs = []
 process = []
 regex = []
 ws = []
+tty = []
 
 [dependencies]
 tishlang_ast = { path = "../tish_ast", version = ">=0.1" }

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1133,6 +1133,16 @@ impl Codegen {
                     "wsBroadcast" => Some("Value::native(|args: &[Value]| tishlang_runtime::ws_broadcast_native(args))"),
                     _ => None,
                 },
+            "tish:tty" if self.has_feature("tty") => match export_name {
+                    "size" => Some("Value::native(|args: &[Value]| tishlang_runtime::tty_size(args))"),
+                    "isTTY" => Some("Value::native(|args: &[Value]| tishlang_runtime::tty_is_tty(args))"),
+                    "setRawMode" => Some("Value::native(|args: &[Value]| tishlang_runtime::tty_set_raw_mode(args))"),
+                    "enterAltScreen" => Some("Value::native(|args: &[Value]| tishlang_runtime::tty_enter_alt_screen(args))"),
+                    "leaveAltScreen" => Some("Value::native(|args: &[Value]| tishlang_runtime::tty_leave_alt_screen(args))"),
+                    "read" => Some("Value::native(|args: &[Value]| tishlang_runtime::tty_read(args))"),
+                    "readLine" => Some("Value::native(|args: &[Value]| tishlang_runtime::tty_read_line(args))"),
+                    _ => None,
+                },
             _ => return None,
         };
         init.map(String::from)
@@ -1140,7 +1150,10 @@ impl Codegen {
 
     fn has_feature(&self, name: &str) -> bool {
         if self.features.contains("full") {
-            matches!(name, "http" | "timers" | "fs" | "process" | "regex" | "ws")
+            matches!(
+                name,
+                "http" | "timers" | "fs" | "process" | "regex" | "ws" | "tty"
+            )
         } else {
             self.features.contains(name)
         }

--- a/crates/tish_compile/src/resolve.rs
+++ b/crates/tish_compile/src/resolve.rs
@@ -69,8 +69,8 @@ pub fn normalize_builtin_spec(spec: &str) -> Option<String> {
 pub fn is_builtin_native_spec(spec: &str) -> bool {
     matches!(
         spec,
-        "tish:fs" | "tish:http" | "tish:timers" | "tish:process" | "tish:ws"
-    ) || matches!(spec, "fs" | "http" | "timers" | "process" | "ws")
+        "tish:fs" | "tish:http" | "tish:timers" | "tish:process" | "tish:ws" | "tish:tty"
+    ) || matches!(spec, "fs" | "http" | "timers" | "process" | "ws" | "tty")
 }
 
 /// Resolve all native imports in a merged program via package.json lookup.

--- a/crates/tish_cranelift_runtime/Cargo.toml
+++ b/crates/tish_cranelift_runtime/Cargo.toml
@@ -14,6 +14,7 @@ http = ["tishlang_vm/http"]
 promise = ["tishlang_vm/promise"]
 timers = ["tishlang_vm/timers"]
 ws = ["tishlang_vm/ws"]
+tty = ["tishlang_vm/tty"]
 regex = ["tishlang_vm/regex"]
 
 [lib]

--- a/crates/tish_eval/Cargo.toml
+++ b/crates/tish_eval/Cargo.toml
@@ -26,6 +26,7 @@ http = [
 ]
 fs = []
 process = []
+tty = ["dep:tishlang_runtime", "tishlang_runtime/tty"]
 regex = ["dep:fancy-regex", "tishlang_core/regex"]
 tokio = ["dep:tokio"]
 ws = ["dep:tishlang_runtime", "tishlang_runtime/ws"]

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -995,6 +995,32 @@ impl Evaluator {
                     ));
                 }
             }
+            "tish:tty" => {
+                #[cfg(feature = "tty")]
+                {
+                    let mut exports: PropMap = PropMap::default();
+                    exports.insert("size".into(), Value::Native(natives::tty_size));
+                    exports.insert("isTTY".into(), Value::Native(natives::tty_is_tty));
+                    exports.insert("setRawMode".into(), Value::Native(natives::tty_set_raw_mode));
+                    exports.insert(
+                        "enterAltScreen".into(),
+                        Value::Native(natives::tty_enter_alt_screen),
+                    );
+                    exports.insert(
+                        "leaveAltScreen".into(),
+                        Value::Native(natives::tty_leave_alt_screen),
+                    );
+                    exports.insert("read".into(), Value::Native(natives::tty_read));
+                    exports.insert("readLine".into(), Value::Native(natives::tty_read_line));
+                    Ok(Value::object(exports))
+                }
+                #[cfg(not(feature = "tty"))]
+                {
+                    return Err(EvalError::Error(
+                        "tish:tty requires the tty feature. Rebuild with: cargo build -p tishlang --features tty".into(),
+                    ));
+                }
+            }
             "tish:process" => {
                 #[cfg(feature = "process")]
                 {

--- a/crates/tish_eval/src/natives.rs
+++ b/crates/tish_eval/src/natives.rs
@@ -471,3 +471,81 @@ pub fn mkdir(args: &[Value]) -> Result<Value, String> {
     };
     Ok(Value::Bool(result.is_ok()))
 }
+
+// ── Interactive terminal I/O (issue #101), behind the `tty` feature ──────────────────────
+// Build the interpreter's `Value` from the shared, Value-agnostic core in
+// `tishlang_runtime::tty`, so the interpreter, VM, and native backends behave identically.
+
+#[cfg(feature = "tty")]
+fn tty_obj(pairs: Vec<(&str, Value)>) -> Value {
+    let mut m = crate::value::PropMap::with_capacity(pairs.len());
+    for (k, v) in pairs {
+        m.insert(k.into(), v);
+    }
+    Value::object(m)
+}
+
+#[cfg(feature = "tty")]
+pub fn tty_size(_args: &[Value]) -> Result<Value, String> {
+    Ok(match tishlang_runtime::tty::size() {
+        Some((cols, rows)) => tty_obj(vec![
+            ("cols", Value::Number(cols as f64)),
+            ("rows", Value::Number(rows as f64)),
+        ]),
+        None => Value::Null,
+    })
+}
+
+#[cfg(feature = "tty")]
+pub fn tty_is_tty(_args: &[Value]) -> Result<Value, String> {
+    Ok(Value::Bool(tishlang_runtime::tty::is_tty()))
+}
+
+#[cfg(feature = "tty")]
+pub fn tty_set_raw_mode(args: &[Value]) -> Result<Value, String> {
+    let on = args.first().map(|v| v.is_truthy()).unwrap_or(false);
+    Ok(Value::Bool(tishlang_runtime::tty::set_raw_mode(on)))
+}
+
+#[cfg(feature = "tty")]
+pub fn tty_enter_alt_screen(_args: &[Value]) -> Result<Value, String> {
+    Ok(Value::Bool(tishlang_runtime::tty::enter_alt_screen()))
+}
+
+#[cfg(feature = "tty")]
+pub fn tty_leave_alt_screen(_args: &[Value]) -> Result<Value, String> {
+    Ok(Value::Bool(tishlang_runtime::tty::leave_alt_screen()))
+}
+
+#[cfg(feature = "tty")]
+pub fn tty_read_line(_args: &[Value]) -> Result<Value, String> {
+    Ok(match tishlang_runtime::tty::read_line() {
+        Some(s) => Value::String(s.into()),
+        None => Value::Null,
+    })
+}
+
+#[cfg(feature = "tty")]
+pub fn tty_read(args: &[Value]) -> Result<Value, String> {
+    use tishlang_runtime::tty::TtyEvent;
+    let timeout = match args.first() {
+        Some(Value::Number(ms)) => Some(ms.max(0.0) as u64),
+        _ => None,
+    };
+    Ok(match tishlang_runtime::tty::read_event(timeout) {
+        Some(TtyEvent::Key { key, ctrl, alt, shift }) => tty_obj(vec![
+            ("type", Value::String("key".into())),
+            ("key", Value::String(key.into())),
+            ("ctrl", Value::Bool(ctrl)),
+            ("alt", Value::Bool(alt)),
+            ("shift", Value::Bool(shift)),
+        ]),
+        Some(TtyEvent::Resize { cols, rows }) => tty_obj(vec![
+            ("type", Value::String("resize".into())),
+            ("cols", Value::Number(cols as f64)),
+            ("rows", Value::Number(rows as f64)),
+        ]),
+        Some(TtyEvent::Other) => tty_obj(vec![("type", Value::String("other".into()))]),
+        None => Value::Null,
+    })
+}

--- a/crates/tish_native/src/build.rs
+++ b/crates/tish_native/src/build.rs
@@ -16,6 +16,7 @@ const RUNTIME_CARGO_FEATURES: &[&str] = &[
     "process",
     "regex",
     "ws",
+    "tty",
 ];
 
 /// Map CLI/compile features to flags passed to `tishlang_runtime` in the temp crate's Cargo.toml.

--- a/crates/tish_runtime/Cargo.toml
+++ b/crates/tish_runtime/Cargo.toml
@@ -56,6 +56,8 @@ http-hyper = [
 ]
 fs = []
 process = []
+# Interactive terminal I/O (issue #101): raw mode, key/resize events, size, alt screen.
+tty = ["dep:crossterm"]
 regex = ["tishlang_core/regex"]
 # WebSocket (JS-like API). Modular: import { WebSocket, Server } from 'tish:ws'.
 # Requires `send-values` because the WS server keeps an `Arc<dyn Fn + Send +
@@ -84,6 +86,8 @@ tiny_http = { version = "0.12.0", optional = true }
 socket2 = { version = "0.5", features = ["all"], optional = true }
 libc = { version = "0.2", optional = true }
 arc-swap = { version = "1", optional = true }
+# Interactive terminal I/O (feature = tty): cross-platform raw mode, key/resize events, size.
+crossterm = { version = "0.28", optional = true }
 # hyper backend (feature = http-hyper)
 hyper = { version = "1", default-features = false, features = ["server", "http1", "http2"], optional = true }
 hyper-util = { version = "0.1", features = ["server", "tokio"], optional = true }

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -1054,6 +1054,13 @@ mod native_promise;
 #[cfg(feature = "ws")]
 mod ws;
 
+#[cfg(feature = "tty")]
+pub mod tty;
+#[cfg(feature = "tty")]
+pub use tty::{
+    tty_enter_alt_screen, tty_is_tty, tty_leave_alt_screen, tty_read, tty_read_line, tty_set_raw_mode, tty_size,
+};
+
 #[cfg(feature = "ws")]
 pub use ws::{
     web_socket_client, web_socket_server_accept, web_socket_server_construct,

--- a/crates/tish_runtime/src/tty.rs
+++ b/crates/tish_runtime/src/tty.rs
@@ -1,0 +1,217 @@
+//! Interactive terminal I/O for Tish (issue #101), behind the `tty` feature.
+//!
+//! Exposes raw mode, the alternate screen, terminal size, and key/resize **events** via
+//! `crossterm`, so Tish programs can build interactive TUIs (menus, forms, live keyboard
+//! navigation). Imported as `import { … } from 'tish:tty'`.
+//!
+//! The Value-agnostic core (`size`, `is_tty`, `set_raw_mode`, `read_event`, …) returns plain
+//! Rust data so every backend — the bytecode VM (via the `tty_*` wrappers here) and the
+//! tree-walk interpreter (whose `Value` is a distinct type) — can build its own `Value` from
+//! the same logic. Errors surface as `null`/`false` rather than panicking.
+
+use std::io::{IsTerminal, Write};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tishlang_core::{ObjectMap, Value};
+
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::terminal;
+
+/// A terminal event delivered by [`read_event`]. Plain data so each backend maps it to its
+/// own `Value` object.
+pub enum TtyEvent {
+    Key {
+        key: String,
+        ctrl: bool,
+        alt: bool,
+        shift: bool,
+    },
+    Resize {
+        cols: u16,
+        rows: u16,
+    },
+    /// Mouse / focus / paste — reported generically so an input loop can ignore it.
+    Other,
+}
+
+// ── Value-agnostic core (shared by every backend) ───────────────────────────────────────
+
+/// Terminal `(cols, rows)`, or `None` if not connected to a terminal.
+pub fn size() -> Option<(u16, u16)> {
+    terminal::size().ok()
+}
+
+/// Whether stdin **and** stdout are connected to a terminal.
+pub fn is_tty() -> bool {
+    std::io::stdin().is_terminal() && std::io::stdout().is_terminal()
+}
+
+/// Enter (cbreak) or leave raw mode. Returns `true` on success.
+pub fn set_raw_mode(enabled: bool) -> bool {
+    if enabled {
+        terminal::enable_raw_mode().is_ok()
+    } else {
+        terminal::disable_raw_mode().is_ok()
+    }
+}
+
+/// Switch to / from the alternate screen buffer (full-screen apps).
+pub fn enter_alt_screen() -> bool {
+    let mut out = std::io::stdout();
+    let ok = crossterm::execute!(out, terminal::EnterAlternateScreen).is_ok();
+    let _ = out.flush();
+    ok
+}
+pub fn leave_alt_screen() -> bool {
+    let mut out = std::io::stdout();
+    let ok = crossterm::execute!(out, terminal::LeaveAlternateScreen).is_ok();
+    let _ = out.flush();
+    ok
+}
+
+/// Read the next terminal event. `timeout_ms = None` blocks; `Some(ms)` polls for `ms`
+/// milliseconds (0 = non-blocking) and returns `None` on timeout. Key-release events
+/// (Windows) are skipped, yielding `None`.
+pub fn read_event(timeout_ms: Option<u64>) -> Option<TtyEvent> {
+    if let Some(ms) = timeout_ms {
+        match event::poll(Duration::from_millis(ms)) {
+            Ok(true) => {}
+            _ => return None,
+        }
+    }
+    match event::read().ok()? {
+        Event::Key(k) => {
+            if k.kind == KeyEventKind::Release {
+                return None;
+            }
+            Some(TtyEvent::Key {
+                key: key_code_name(k.code),
+                ctrl: k.modifiers.contains(KeyModifiers::CONTROL),
+                alt: k.modifiers.contains(KeyModifiers::ALT),
+                shift: k.modifiers.contains(KeyModifiers::SHIFT),
+            })
+        }
+        Event::Resize(cols, rows) => Some(TtyEvent::Resize { cols, rows }),
+        _ => Some(TtyEvent::Other),
+    }
+}
+
+/// Read one line of **cooked** input from stdin (line mode), with the trailing newline
+/// stripped. Returns `None` at EOF. For raw key-by-key input use [`read_event`].
+pub fn read_line() -> Option<String> {
+    use std::io::BufRead;
+    let mut s = String::new();
+    match std::io::stdin().lock().read_line(&mut s) {
+        Ok(0) => None,
+        Ok(_) => {
+            while s.ends_with('\n') || s.ends_with('\r') {
+                s.pop();
+            }
+            Some(s)
+        }
+        Err(_) => None,
+    }
+}
+
+/// Normalize a crossterm key code to a stable JS-friendly name (`"a"`, `"Enter"`, `"Up"`,
+/// `"Esc"`, `"F1"`, …).
+fn key_code_name(code: KeyCode) -> String {
+    match code {
+        KeyCode::Char(c) => c.to_string(),
+        KeyCode::Enter => "Enter".into(),
+        KeyCode::Esc => "Esc".into(),
+        KeyCode::Backspace => "Backspace".into(),
+        KeyCode::Tab => "Tab".into(),
+        KeyCode::BackTab => "BackTab".into(),
+        KeyCode::Delete => "Delete".into(),
+        KeyCode::Insert => "Insert".into(),
+        KeyCode::Home => "Home".into(),
+        KeyCode::End => "End".into(),
+        KeyCode::PageUp => "PageUp".into(),
+        KeyCode::PageDown => "PageDown".into(),
+        KeyCode::Up => "Up".into(),
+        KeyCode::Down => "Down".into(),
+        KeyCode::Left => "Left".into(),
+        KeyCode::Right => "Right".into(),
+        KeyCode::F(n) => format!("F{n}"),
+        KeyCode::Null => "Null".into(),
+        other => format!("{other:?}"),
+    }
+}
+
+// ── core::Value wrappers for the bytecode VM / native runtime ────────────────────────────
+
+fn obj(pairs: Vec<(&str, Value)>) -> Value {
+    let mut m = ObjectMap::default();
+    for (k, v) in pairs {
+        m.insert(Arc::from(k), v);
+    }
+    Value::object(m)
+}
+
+/// `size()` → `{ cols, rows }` or `null`.
+pub fn tty_size(_args: &[Value]) -> Value {
+    match size() {
+        Some((cols, rows)) => obj(vec![
+            ("cols", Value::Number(cols as f64)),
+            ("rows", Value::Number(rows as f64)),
+        ]),
+        None => Value::Null,
+    }
+}
+
+/// `isTTY()` → bool.
+pub fn tty_is_tty(_args: &[Value]) -> Value {
+    Value::Bool(is_tty())
+}
+
+/// `setRawMode(enabled)` → bool (success).
+pub fn tty_set_raw_mode(args: &[Value]) -> Value {
+    Value::Bool(set_raw_mode(args.first().map(|v| v.is_truthy()).unwrap_or(false)))
+}
+
+/// `enterAltScreen()` / `leaveAltScreen()` → bool.
+pub fn tty_enter_alt_screen(_args: &[Value]) -> Value {
+    Value::Bool(enter_alt_screen())
+}
+pub fn tty_leave_alt_screen(_args: &[Value]) -> Value {
+    Value::Bool(leave_alt_screen())
+}
+
+/// `readLine()` → one line of cooked stdin (no trailing newline), or `null` at EOF.
+pub fn tty_read_line(_args: &[Value]) -> Value {
+    match read_line() {
+        Some(s) => Value::String(s.into()),
+        None => Value::Null,
+    }
+}
+
+/// `read(timeoutMs?)` → an event object (`{ type, … }`) or `null`.
+pub fn tty_read(args: &[Value]) -> Value {
+    let timeout = match args.first() {
+        Some(Value::Number(ms)) => Some(ms.max(0.0) as u64),
+        _ => None,
+    };
+    match read_event(timeout) {
+        Some(TtyEvent::Key {
+            key,
+            ctrl,
+            alt,
+            shift,
+        }) => obj(vec![
+            ("type", Value::String("key".into())),
+            ("key", Value::String(key.into())),
+            ("ctrl", Value::Bool(ctrl)),
+            ("alt", Value::Bool(alt)),
+            ("shift", Value::Bool(shift)),
+        ]),
+        Some(TtyEvent::Resize { cols, rows }) => obj(vec![
+            ("type", Value::String("resize".into())),
+            ("cols", Value::Number(cols as f64)),
+            ("rows", Value::Number(rows as f64)),
+        ]),
+        Some(TtyEvent::Other) => obj(vec![("type", Value::String("other".into()))]),
+        None => Value::Null,
+    }
+}

--- a/crates/tish_runtime/src/tty.rs
+++ b/crates/tish_runtime/src/tty.rs
@@ -37,9 +37,18 @@ pub enum TtyEvent {
 
 // ── Value-agnostic core (shared by every backend) ───────────────────────────────────────
 
-/// Terminal `(cols, rows)`, or `None` if not connected to a terminal.
+/// Terminal `(cols, rows)`, or `None` if stdout is not connected to a terminal.
+///
+/// Gated on `stdout().is_terminal()` to match Node (`process.stdout.columns` is
+/// `undefined` when stdout is not a TTY). Without the gate, `crossterm::terminal::size()`
+/// can still succeed via the controlling terminal even when stdout is redirected — so a
+/// piped run (e.g. CI, `tish run x.tish | cat`) would report a bogus size instead of null.
 pub fn size() -> Option<(u16, u16)> {
-    terminal::size().ok()
+    if std::io::stdout().is_terminal() {
+        terminal::size().ok()
+    } else {
+        None
+    }
 }
 
 /// Whether stdin **and** stdout are connected to a terminal.

--- a/crates/tish_vm/Cargo.toml
+++ b/crates/tish_vm/Cargo.toml
@@ -23,6 +23,7 @@ wasm = ["dep:wasm-bindgen"]
 # (some Cargo/cache combinations only saw `tishlang_runtime/http` and built VM stubs without http).
 fs = ["dep:tishlang_runtime", "tishlang_runtime/fs"]
 process = ["dep:tishlang_runtime", "tishlang_runtime/process"]
+tty = ["dep:tishlang_runtime", "tishlang_runtime/tty"]
 # Timer globals + `tish:timers` LoadNativeExport (uses tishlang_runtime TLS timer registry).
 timers = ["dep:tishlang_runtime"]
 # Any HTTP build needs Send-safe values so handlers can be dispatched

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -129,6 +129,8 @@ pub fn all_compiled_capabilities() -> HashSet<String> {
     s.insert("regex".to_string());
     #[cfg(feature = "ws")]
     s.insert("ws".to_string());
+    #[cfg(feature = "tty")]
+    s.insert("tty".to_string());
     s
 }
 
@@ -140,7 +142,8 @@ pub fn all_compiled_capabilities() -> HashSet<String> {
         feature = "promise",
         feature = "timers",
         feature = "process",
-        feature = "ws"
+        feature = "ws",
+        feature = "tty"
     )),
     allow(unused_variables)
 )]
@@ -318,6 +321,27 @@ fn get_builtin_export(enabled: &HashSet<String>, spec: &str, export_name: &str) 
             })),
             "wsBroadcast" => Some(Value::native(|args: &[Value]| {
                 tishlang_runtime::ws_broadcast_native(args)
+            })),
+            _ => None,
+        };
+    }
+    #[cfg(feature = "tty")]
+    if spec == "tish:tty" && cap_allows(enabled, "tty") {
+        return match export_name {
+            "size" => Some(Value::native(|args: &[Value]| tishlang_runtime::tty_size(args))),
+            "isTTY" => Some(Value::native(|args: &[Value]| tishlang_runtime::tty_is_tty(args))),
+            "setRawMode" => Some(Value::native(|args: &[Value]| {
+                tishlang_runtime::tty_set_raw_mode(args)
+            })),
+            "enterAltScreen" => Some(Value::native(|args: &[Value]| {
+                tishlang_runtime::tty_enter_alt_screen(args)
+            })),
+            "leaveAltScreen" => Some(Value::native(|args: &[Value]| {
+                tishlang_runtime::tty_leave_alt_screen(args)
+            })),
+            "read" => Some(Value::native(|args: &[Value]| tishlang_runtime::tty_read(args))),
+            "readLine" => Some(Value::native(|args: &[Value]| {
+                tishlang_runtime::tty_read_line(args)
             })),
             _ => None,
         };

--- a/examples/tty/keys.tish
+++ b/examples/tty/keys.tish
@@ -1,0 +1,27 @@
+// Interactive key viewer (issue #101). Run in a real terminal:
+//   tish run --feature tty examples/tty/keys.tish
+// Press keys to see them; resize the window to see resize events; press 'q' or Ctrl+C to quit.
+import { isTTY, size, setRawMode, read } from 'tish:tty'
+
+if (!isTTY()) {
+  console.log("Not a terminal — run this directly in a terminal.")
+} else {
+  let dims = size()
+  console.log("Terminal:", dims.cols, "x", dims.rows, "— press keys ('q' to quit)")
+  setRawMode(true)
+  let running = true
+  while (running) {
+    let ev = read(200)          // poll with a 200ms timeout (non-blocking-ish)
+    if (ev == null) { continue } // nothing this tick
+    if (ev.type == "key") {
+      console.log("key:", ev.key, "ctrl:", ev.ctrl, "alt:", ev.alt, "shift:", ev.shift)
+      if (ev.key == "q") { running = false }
+      if (ev.ctrl && ev.key == "c") { running = false }
+    }
+    if (ev.type == "resize") {
+      console.log("resize:", ev.cols, "x", ev.rows)
+    }
+  }
+  setRawMode(false)
+  console.log("bye")
+}


### PR DESCRIPTION
## Summary
Adds a `tty` capability (issue #101) so Tish can host interactive terminal UIs (menus, forms, live keyboard navigation) — the missing input piece for the single-binary CLIs `tish build` already produces.

`import { … } from 'tish:tty'` (behind the `tty` feature, included in `--feature full`):

| export | description |
|---|---|
| `size()` | `{ cols, rows }` (or `null` if not a terminal) |
| `isTTY()` | stdin+stdout are a terminal |
| `setRawMode(enabled)` | enter/leave raw (cbreak) mode |
| `enterAltScreen()` / `leaveAltScreen()` | alternate screen buffer |
| `read(timeoutMs?)` | next event — `{type:'key',key,ctrl,alt,shift}` or `{type:'resize',cols,rows}`; blocks with no arg, **polls (non-blocking)** with a timeout |
| `readLine()` | cooked line input |

## Implementation
Cross-platform via **crossterm**. A Value-agnostic core in `tishlang_runtime::tty` (plain Rust data) is shared by **all backends** — the bytecode VM, the tree-walk interpreter (whose `Value` is a distinct type), and the native + **cranelift** compiled targets — so behavior is identical. The capability is feature-gated across `tish_runtime`/`tish_vm`/`tish_eval`/`tish_compile` + the native-build runtime-feature list, and degrades gracefully off-terminal (`size`→null, raw mode no-op).

## Test
- `crates/tish/tests/tty_capability.rs` — module loads + graceful non-TTY behavior on vm + interp (CI has no terminal).
- `readLine` verified with piped stdin on vm/interp/native.
- Full integration suite green (19/19) across all backends.
- `examples/tty/keys.tish` — interactive key/resize viewer.

Closes #101