### PR TITLE
fix: string relational operators (`<` `<=` `>` `>=`) compare lexicographically (#99)

### DIFF
--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -2344,10 +2344,12 @@ impl Evaluator {
             BinOp::Pow => self.binop_number(l, r, |a, b| Value::Number(a.powf(b))),
             BinOp::StrictEq => Ok(Value::Bool(l.strict_eq(r))),
             BinOp::StrictNe => Ok(Value::Bool(!l.strict_eq(r))),
-            BinOp::Lt => self.binop_number(l, r, |a, b| Value::Bool(a < b)),
-            BinOp::Le => self.binop_number(l, r, |a, b| Value::Bool(a <= b)),
-            BinOp::Gt => self.binop_number(l, r, |a, b| Value::Bool(a > b)),
-            BinOp::Ge => self.binop_number(l, r, |a, b| Value::Bool(a >= b)),
+            // Relational ops compare strings lexicographically when BOTH operands
+            // are strings (JS semantics); otherwise coerce to numbers via binop_number.
+            BinOp::Lt => self.binop_relational(l, r, |o| o.is_lt()),
+            BinOp::Le => self.binop_relational(l, r, |o| o.is_le()),
+            BinOp::Gt => self.binop_relational(l, r, |o| o.is_gt()),
+            BinOp::Ge => self.binop_relational(l, r, |o| o.is_ge()),
             BinOp::And => Ok(Value::Bool(l.is_truthy() && r.is_truthy())),
             BinOp::Or => Ok(Value::Bool(l.is_truthy() || r.is_truthy())),
             BinOp::BitAnd => self.binop_int32(l, r, |a, b| Value::Number((a & b) as f64)),
@@ -2495,6 +2497,25 @@ impl Evaluator {
         let a = l.as_number().unwrap_or(f64::NAN);
         let b = r.as_number().unwrap_or(f64::NAN);
         Ok(f(a, b))
+    }
+
+    /// Relational comparison (`<` `<=` `>` `>=`). When both operands are strings,
+    /// compare lexicographically; otherwise coerce to numbers. `pred` maps the
+    /// resulting `Ordering` to a bool. A NaN-involved numeric comparison yields no
+    /// ordering and is always `false`, matching JS (`NaN < 5` → false).
+    fn binop_relational<F>(&self, l: &Value, r: &Value, pred: F) -> Result<Value, String>
+    where
+        F: FnOnce(std::cmp::Ordering) -> bool,
+    {
+        let ord = match (l, r) {
+            (Value::String(a), Value::String(b)) => Some(a.as_ref().cmp(b.as_ref())),
+            _ => {
+                let a = l.as_number().unwrap_or(f64::NAN);
+                let b = r.as_number().unwrap_or(f64::NAN);
+                a.partial_cmp(&b)
+            }
+        };
+        Ok(Value::Bool(ord.map(pred).unwrap_or(false)))
     }
 
     fn eval_unary(&self, op: UnaryOp, v: &Value) -> Result<Value, String> {

--- a/crates/tish_opt/src/lib.rs
+++ b/crates/tish_opt/src/lib.rs
@@ -787,6 +787,21 @@ fn fold_to_uint32(x: f64) -> u32 {
     }
 }
 
+/// Constant-fold a relational comparison (`<` `<=` `>` `>=`). Two string literals
+/// compare lexicographically; otherwise the numeric coercions `ln`/`rn` are used.
+/// `pred` maps the `Ordering` to a bool; a NaN-involved numeric comparison has no
+/// ordering and is `false` — matching the VM/interp/native runtime exactly.
+fn fold_relational<F>(left: &Literal, right: &Literal, ln: f64, rn: f64, pred: F) -> bool
+where
+    F: FnOnce(std::cmp::Ordering) -> bool,
+{
+    let ord = match (left, right) {
+        (Literal::String(a), Literal::String(b)) => Some(a.as_ref().cmp(b.as_ref())),
+        _ => ln.partial_cmp(&rn),
+    };
+    ord.map(pred).unwrap_or(false)
+}
+
 fn try_fold_binop(left: &Literal, op: BinOp, right: &Literal) -> Option<Literal> {
     use BinOp::*;
     let ln = literal_as_number(left);
@@ -819,10 +834,13 @@ fn try_fold_binop(left: &Literal, op: BinOp, right: &Literal) -> Option<Literal>
         Ne => Literal::Bool(!literal_strict_eq(left, right)),
         StrictEq => Literal::Bool(literal_strict_eq(left, right)),
         StrictNe => Literal::Bool(!literal_strict_eq(left, right)),
-        Lt => Literal::Bool(ln < rn),
-        Le => Literal::Bool(ln <= rn),
-        Gt => Literal::Bool(ln > rn),
-        Ge => Literal::Bool(ln >= rn),
+        // Relational ops fold lexicographically when BOTH operands are string
+        // literals (JS semantics — must match the VM/interp/native runtime), else
+        // numerically. A NaN-involved numeric comparison is always false.
+        Lt => Literal::Bool(fold_relational(left, right, ln, rn, |o| o.is_lt())),
+        Le => Literal::Bool(fold_relational(left, right, ln, rn, |o| o.is_le())),
+        Gt => Literal::Bool(fold_relational(left, right, ln, rn, |o| o.is_gt())),
+        Ge => Literal::Bool(fold_relational(left, right, ln, rn, |o| o.is_ge())),
         And => Literal::Bool(literal_is_truthy(left) && literal_is_truthy(right)),
         Or => Literal::Bool(literal_is_truthy(left) || literal_is_truthy(right)),
         // ToInt32/ToUint32 (modulo 2³², NaN/±Infinity → 0), matching the VM/interp exactly.

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -2668,10 +2668,25 @@ fn eval_binop(op: BinOp, l: &Value, r: &Value) -> Result<Value, String> {
         Ne => Ok(Bool(!l.strict_eq(r))),
         StrictEq => Ok(Bool(l.strict_eq(r))),
         StrictNe => Ok(Bool(!l.strict_eq(r))),
-        Lt => Ok(Bool(ln < rn)),
-        Le => Ok(Bool(ln <= rn)),
-        Gt => Ok(Bool(ln > rn)),
-        Ge => Ok(Bool(ln >= rn)),
+        // Relational operators: when BOTH operands are strings, compare them
+        // lexicographically (JS semantics). Otherwise coerce to numbers — a string
+        // mixed with a number still falls through to numeric coercion (NaN → false).
+        Lt => Ok(Bool(match (l, r) {
+            (String(a), String(b)) => a.as_str() < b.as_str(),
+            _ => ln < rn,
+        })),
+        Le => Ok(Bool(match (l, r) {
+            (String(a), String(b)) => a.as_str() <= b.as_str(),
+            _ => ln <= rn,
+        })),
+        Gt => Ok(Bool(match (l, r) {
+            (String(a), String(b)) => a.as_str() > b.as_str(),
+            _ => ln > rn,
+        })),
+        Ge => Ok(Bool(match (l, r) {
+            (String(a), String(b)) => a.as_str() >= b.as_str(),
+            _ => ln >= rn,
+        })),
         And => Ok(Bool(l.is_truthy() && r.is_truthy())),
         Or => Ok(Bool(l.is_truthy() || r.is_truthy())),
         // `to_int32`/`to_uint32` = JS ToInt32/ToUint32 (modulo 2³², NaN/±Infinity → 0); not a

--- a/tests/core/string_relational.js
+++ b/tests/core/string_relational.js
@@ -1,0 +1,21 @@
+// String relational operators (`<` `<=` `>` `>=`) compare lexicographically
+// when both operands are strings (JS semantics). Regression test for #99.
+
+// ── literal forms (constant-folded) ────────────────────────────────────
+console.log("a" < "b", "b" < "a", "a" <= "a", "b" > "a");
+console.log("apple" < "banana", "apple" < "apply", "app" < "apple");
+console.log("Z" < "a", "10" < "9", "" < "a");
+console.log("a" >= "a", "b" >= "a", "a" > "a", "a" <= "b");
+
+// ── variable forms (runtime path) ──────────────────────────────────────
+let x = "a";
+let y = "b";
+console.log(x < y, y < x, x <= x, y > x);
+
+let lo = "a";
+let hi = "z";
+let c = "m";
+console.log(c >= lo, c <= hi, c >= lo ? c <= hi : false);
+
+// ── numeric comparison is unaffected ───────────────────────────────────
+console.log(1 < 2, 2 < 1, 3 <= 3, 5 > 4);

--- a/tests/core/string_relational.tish
+++ b/tests/core/string_relational.tish
@@ -1,0 +1,26 @@
+// String relational operators (`<` `<=` `>` `>=`) compare lexicographically
+// when both operands are strings (JS semantics). Regression test for #99, where
+// strings coerced to NaN and every comparison returned `false`.
+//
+// Each line is exercised twice: once with string literals (constant-folded by
+// the optimizer) and once via variables (the runtime path in every backend), so
+// the fold and the runtime must agree.
+
+// ── literal forms (constant-folded) ────────────────────────────────────
+console.log("a" < "b", "b" < "a", "a" <= "a", "b" > "a")
+console.log("apple" < "banana", "apple" < "apply", "app" < "apple")
+console.log("Z" < "a", "10" < "9", "" < "a")
+console.log("a" >= "a", "b" >= "a", "a" > "a", "a" <= "b")
+
+// ── variable forms (runtime path) ──────────────────────────────────────
+let x = "a"
+let y = "b"
+console.log(x < y, y < x, x <= x, y > x)
+
+let lo = "a"
+let hi = "z"
+let c = "m"
+console.log(c >= lo, c <= hi, c >= lo ? c <= hi : false)
+
+// ── numeric comparison is unaffected ───────────────────────────────────
+console.log(1 < 2, 2 < 1, 3 <= 3, 5 > 4)

--- a/tests/core/string_relational.tish.expected
+++ b/tests/core/string_relational.tish.expected
@@ -1,0 +1,7 @@
+true false true true
+true true true
+true true true
+true true false true
+true false true true
+true true true
+true false true true

--- a/tests/main.js
+++ b/tests/main.js
@@ -3217,6 +3217,30 @@ console.log(sum)
 }
 
 {
+// String relational operators (`<` `<=` `>` `>=`) compare lexicographically
+// when both operands are strings (JS semantics). Regression test for #99.
+
+// ── literal forms (constant-folded) ────────────────────────────────────
+console.log("a" < "b", "b" < "a", "a" <= "a", "b" > "a");
+console.log("apple" < "banana", "apple" < "apply", "app" < "apple");
+console.log("Z" < "a", "10" < "9", "" < "a");
+console.log("a" >= "a", "b" >= "a", "a" > "a", "a" <= "b");
+
+// ── variable forms (runtime path) ──────────────────────────────────────
+let x = "a";
+let y = "b";
+console.log(x < y, y < x, x <= x, y > x);
+
+let lo = "a";
+let hi = "z";
+let c = "m";
+console.log(c >= lo, c <= hi, c >= lo ? c <= hi : false);
+
+// ── numeric comparison is unaffected ───────────────────────────────────
+console.log(1 < 2, 2 < 1, 3 <= 3, 5 > 4);
+}
+
+{
 // MVP test: switch statement (JS equivalent of switch.tish)
 let x = 2;
 switch (x) {

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3264,6 +3264,36 @@ console.log(sum)
 }
 __perf_run_core_string_methods_perf()
 
+fn __perf_run_core_string_relational() {
+// String relational operators (`<` `<=` `>` `>=`) compare lexicographically
+// when both operands are strings (JS semantics). Regression test for #99, where
+// strings coerced to NaN and every comparison returned `false`.
+//
+// Each line is exercised twice: once with string literals (constant-folded by
+// the optimizer) and once via variables (the runtime path in every backend), so
+// the fold and the runtime must agree.
+
+// ── literal forms (constant-folded) ────────────────────────────────────
+console.log("a" < "b", "b" < "a", "a" <= "a", "b" > "a")
+console.log("apple" < "banana", "apple" < "apply", "app" < "apple")
+console.log("Z" < "a", "10" < "9", "" < "a")
+console.log("a" >= "a", "b" >= "a", "a" > "a", "a" <= "b")
+
+// ── variable forms (runtime path) ──────────────────────────────────────
+let x = "a"
+let y = "b"
+console.log(x < y, y < x, x <= x, y > x)
+
+let lo = "a"
+let hi = "z"
+let c = "m"
+console.log(c >= lo, c <= hi, c >= lo ? c <= hi : false)
+
+// ── numeric comparison is unaffected ───────────────────────────────────
+console.log(1 < 2, 2 < 1, 3 <= 3, 5 > 4)
+}
+__perf_run_core_string_relational()
+
 fn __perf_run_core_switch() {
 // MVP test: switch statement
 let x = 2


### PR DESCRIPTION
## Summary
`<` `<=` `>` `>=` coerced **both** operands to numbers, so any string operand became `NaN` and every string comparison returned `false` — including equal operands with `<=`/`>=` (`"a" <= "a"` → `false`). Only `===`/`!==` worked on strings.

```tish
console.log("a" < "b", "b" < "a", "a" <= "a", "b" > "a")
// before: false false false false
// after:  true false true true
```

## Fix
Two strings now compare **lexicographically** (JS semantics); a string mixed with a number still coerces numerically (NaN → `false`). Fixed in all three sites that evaluate relational ops so every backend agrees:

- **VM** `eval_binop` (`tish_vm`) — `(String, String)` → `as_str()` ordering, else numeric.
- **Interpreter** — new `binop_relational` helper (`tish_eval`) mirroring the VM.
- **Optimizer** `try_fold_binop` (`tish_opt`) — new `fold_relational` so constant-folding string literals matches the runtime. This also drove the **JS target**, which previously folded `"a" < "b"` to `false` at compile time.

The native runtime `ops::lt/le/gt/ge` already handled strings, and its numeric fast-path is guarded to numeric operands, so strings route through the correct path. A NaN-involved numeric comparison stays `false`, matching JS.

## Test
`tests/core/string_relational.tish` covers literal (constant-folded) **and** variable (runtime) forms, lexicographic multi-char/prefix ordering, char-range checks, and unaffected numeric comparison. Passes on all 6 backends (interpreter, VM, native, cranelift, wasi, js).

Closes #99