### PR TITLE
fix: support `\xNN`, `\uNNNN`, and `\u{…}` string escapes (#98)

### DIFF
--- a/crates/tish_lexer/src/lib.rs
+++ b/crates/tish_lexer/src/lib.rs
@@ -363,10 +363,69 @@ impl<'a> Lexer<'a> {
             'n' => Ok('\n'),
             'r' => Ok('\r'),
             't' => Ok('\t'),
+            'b' => Ok('\u{0008}'),
+            'f' => Ok('\u{000C}'),
+            'v' => Ok('\u{000B}'),
+            '0' => Ok('\0'),
             '\\' => Ok('\\'),
+            // `\xNN` — exactly two hex digits → code point 0x00..=0xFF (JS/TS).
+            'x' => {
+                let cp = self.read_hex_digits(2)?;
+                char::from_u32(cp).ok_or_else(|| format!("Invalid \\x escape: \\x{:02X}", cp))
+            }
+            // `\uNNNN` (exactly four hex digits) or `\u{N..}` (1-6 hex digits, ES6).
+            'u' => {
+                let cp = if self.peek() == Some('{') {
+                    self.advance(); // consume '{'
+                    let cp = self.read_hex_until_brace()?;
+                    match self.advance() {
+                        Some('}') => cp,
+                        _ => return Err("Unterminated \\u{...} escape (expected '}')".to_string()),
+                    }
+                } else {
+                    self.read_hex_digits(4)?
+                };
+                // Lone surrogates (0xD800..=0xDFFF) are valid UTF-16 code units in JS but
+                // not Unicode scalar values; tish strings are UTF-8, so reject them.
+                char::from_u32(cp)
+                    .ok_or_else(|| format!("Invalid \\u escape: code point U+{:04X}", cp))
+            }
             c if extra_allowed.contains(&c) => Ok(c),
             _ => Err(format!("Unknown escape: \\{}", escaped)),
         }
+    }
+
+    /// Read exactly `n` hex digits and return the parsed code point.
+    fn read_hex_digits(&mut self, n: usize) -> Result<u32, String> {
+        let mut value: u32 = 0;
+        for _ in 0..n {
+            let c = self.advance().ok_or("Unterminated hex escape")?;
+            let digit = c
+                .to_digit(16)
+                .ok_or_else(|| format!("Invalid hex digit in escape: '{}'", c))?;
+            value = value * 16 + digit;
+        }
+        Ok(value)
+    }
+
+    /// Read 1-6 hex digits for a `\u{...}` escape (stops at `}`); validates the count
+    /// and that the value is within the Unicode range.
+    fn read_hex_until_brace(&mut self) -> Result<u32, String> {
+        let mut value: u32 = 0;
+        let mut count = 0;
+        while let Some(c) = self.peek() {
+            let Some(digit) = c.to_digit(16) else { break };
+            self.advance();
+            value = value * 16 + digit;
+            count += 1;
+            if count > 6 || value > 0x10_FFFF {
+                return Err("Invalid \\u{...} escape: code point out of range".to_string());
+            }
+        }
+        if count == 0 {
+            return Err("Empty \\u{} escape (expected hex digits)".to_string());
+        }
+        Ok(value)
     }
 
     fn read_string(&mut self, quote: char) -> Result<String, String> {

--- a/tests/core/string_escapes.js
+++ b/tests/core/string_escapes.js
@@ -1,0 +1,26 @@
+// Hex (`\xNN`), unicode (`\uNNNN`), and braced unicode (`\u{N..}`) string
+// escapes, plus the standard `\0 \b \f \v`. Regression test for #98, where
+// the lexer rejected `\x`/`\u` with "Unknown escape".
+//
+// Astral code points are checked by equality against the literal character
+// (not `.length`) so the test does not depend on UTF-16-vs-scalar semantics.
+
+// -- \xNN (two hex digits) --
+let esc = "\x1b";
+console.log(esc.charCodeAt(0), esc.length); // 27 1
+console.log("\x41\x42\x43"); // ABC
+
+// -- \uNNNN (four hex digits, BMP) --
+console.log("\u0041\u0042"); // AB
+console.log("\u00e9" === "é"); // true (e-acute)
+
+// -- \u{N..} braced (ES6) --
+console.log("\u{48}\u{49}"); // HI
+console.log("\u{1F600}" === "😀"); // true (astral)
+
+// -- standard control escapes --
+console.log("\0".charCodeAt(0), "\b".charCodeAt(0)); // 0 8
+console.log("\f".charCodeAt(0), "\v".charCodeAt(0)); // 12 11
+
+// -- escapes inside template literals --
+console.log(`x=\x58 u=\u0059`); // x=X u=Y

--- a/tests/core/string_escapes.tish
+++ b/tests/core/string_escapes.tish
@@ -1,0 +1,26 @@
+// Hex (`\xNN`), unicode (`\uNNNN`), and braced unicode (`\u{N..}`) string
+// escapes, plus the standard `\0 \b \f \v`. Regression test for #98, where
+// the lexer rejected `\x`/`\u` with "Unknown escape".
+//
+// Astral code points are checked by equality against the literal character
+// (not `.length`) so the test does not depend on UTF-16-vs-scalar semantics.
+
+// -- \xNN (two hex digits) --
+let esc = "\x1b"
+console.log(esc.charCodeAt(0), esc.length)              // 27 1
+console.log("\x41\x42\x43")                          // ABC
+
+// -- \uNNNN (four hex digits, BMP) --
+console.log("\u0041\u0042")                        // AB
+console.log("\u00e9" === "é")                   // true (e-acute)
+
+// -- \u{N..} braced (ES6) --
+console.log("\u{48}\u{49}")                        // HI
+console.log("\u{1F600}" === "😀")                 // true (astral)
+
+// -- standard control escapes --
+console.log("\0".charCodeAt(0), "\b".charCodeAt(0))      // 0 8
+console.log("\f".charCodeAt(0), "\v".charCodeAt(0))      // 12 11
+
+// -- escapes inside template literals --
+console.log(`x=\x58 u=\u0059`)                      // x=X u=Y

--- a/tests/core/string_escapes.tish.expected
+++ b/tests/core/string_escapes.tish.expected
@@ -1,0 +1,9 @@
+27 1
+ABC
+AB
+true
+HI
+true
+0 8
+12 11
+x=X u=Y

--- a/tests/main.js
+++ b/tests/main.js
@@ -3009,6 +3009,35 @@ console.log(s);
 }
 
 {
+// Hex (`\xNN`), unicode (`\uNNNN`), and braced unicode (`\u{N..}`) string
+// escapes, plus the standard `\0 \b \f \v`. Regression test for #98, where
+// the lexer rejected `\x`/`\u` with "Unknown escape".
+//
+// Astral code points are checked by equality against the literal character
+// (not `.length`) so the test does not depend on UTF-16-vs-scalar semantics.
+
+// -- \xNN (two hex digits) --
+let esc = "\x1b";
+console.log(esc.charCodeAt(0), esc.length); // 27 1
+console.log("\x41\x42\x43"); // ABC
+
+// -- \uNNNN (four hex digits, BMP) --
+console.log("\u0041\u0042"); // AB
+console.log("\u00e9" === "é"); // true (e-acute)
+
+// -- \u{N..} braced (ES6) --
+console.log("\u{48}\u{49}"); // HI
+console.log("\u{1F600}" === "😀"); // true (astral)
+
+// -- standard control escapes --
+console.log("\0".charCodeAt(0), "\b".charCodeAt(0)); // 0 8
+console.log("\f".charCodeAt(0), "\v".charCodeAt(0)); // 12 11
+
+// -- escapes inside template literals --
+console.log(`x=\x58 u=\u0059`); // x=X u=Y
+}
+
+{
 // String methods tests
 
 let str = "Hello, World!"

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3054,6 +3054,36 @@ console.log(s)
 }
 __perf_run_core_string_coercion()
 
+fn __perf_run_core_string_escapes() {
+// Hex (`\xNN`), unicode (`\uNNNN`), and braced unicode (`\u{N..}`) string
+// escapes, plus the standard `\0 \b \f \v`. Regression test for #98, where
+// the lexer rejected `\x`/`\u` with "Unknown escape".
+//
+// Astral code points are checked by equality against the literal character
+// (not `.length`) so the test does not depend on UTF-16-vs-scalar semantics.
+
+// -- \xNN (two hex digits) --
+let esc = "\x1b"
+console.log(esc.charCodeAt(0), esc.length)              // 27 1
+console.log("\x41\x42\x43")                          // ABC
+
+// -- \uNNNN (four hex digits, BMP) --
+console.log("\u0041\u0042")                        // AB
+console.log("\u00e9" === "é")                   // true (e-acute)
+
+// -- \u{N..} braced (ES6) --
+console.log("\u{48}\u{49}")                        // HI
+console.log("\u{1F600}" === "😀")                 // true (astral)
+
+// -- standard control escapes --
+console.log("\0".charCodeAt(0), "\b".charCodeAt(0))      // 0 8
+console.log("\f".charCodeAt(0), "\v".charCodeAt(0))      // 12 11
+
+// -- escapes inside template literals --
+console.log(`x=\x58 u=\u0059`)                      // x=X u=Y
+}
+__perf_run_core_string_escapes()
+
 fn __perf_run_core_string_methods() {
 // String methods tests
 


### PR DESCRIPTION
## Summary
String (and template) literals rejected `\x` and `\u` escapes with `Parse error: Unknown escape`, so ANSI sequences and unicode code points had to be built via `String.fromCharCode(...)`.

```tish
let esc = "\x1b"      // before: Parse error: Unknown escape: \x
let u   = "A"    // before: Parse error: Unknown escape: \u
```

## Fix
Extends `handle_escape` (shared by both string and template-literal lexing) with the JS/TS escape forms:

| Escape | Meaning |
|--------|---------|
| `\xNN` | exactly two hex digits → code point `0x00..=0xFF` |
| `\uNNNN` | exactly four hex digits (BMP) |
| `\u{N..}` | 1–6 hex digits, ES6 braced form, validated `<= 0x10FFFF` |
| `\0 \b \f \v` | the remaining standard JS control escapes (also previously missing) |

Lone surrogates (`U+D800..U+DFFF`) are rejected with a clear error — tish strings are UTF-8 and have no scalar representation for them. Malformed escapes (non-hex digit, empty `\u{}`, out-of-range) produce descriptive lexer errors instead of silently mis-decoding.

## Test
`tests/core/string_escapes.tish` covers `\x`, `\u` (BMP), `\u{…}` (including an **astral** code point verified by equality against the literal char, so the test doesn't depend on UTF-16-vs-scalar `.length` semantics), the new control escapes, and escapes **inside template literals**. Passes on all 6 backends (interpreter, VM, native, cranelift, wasi, js).

Closes #98