### PR TITLE
fix: braceless `if (cond) return` no longer swallows the next statement (#96)

### DIFF
--- a/crates/tish_parser/src/parser.rs
+++ b/crates/tish_parser/src/parser.rs
@@ -1345,9 +1345,22 @@ impl<'a> Parser<'a> {
 
     fn parse_return(&mut self) -> Result<Statement, String> {
         let span_start = self.expect(TokenKind::Return)?.span.start;
-        let value = if matches!(self.peek_kind(), Some(TokenKind::Semicolon))
-            || matches!(self.peek_kind(), Some(TokenKind::Dedent))
-            || matches!(self.peek_kind(), Some(TokenKind::RBrace))
+        // JS restricted production: `return [no LineTerminator here] Expression`.
+        // A line break between `return` and its argument inserts a semicolon, so
+        // `return` alone is `return null`. The lexer emits no token for a same-indent
+        // line break (only Indent/Dedent on level *changes*), so a braceless
+        // `if (c) return` followed by a statement on the next line would otherwise
+        // swallow that statement as the return value (#96). Detect the line break by
+        // comparing the next token's line to the `return` keyword's line.
+        let next_on_new_line = self
+            .peek()
+            .map(|t| t.span.start.0 > span_start.0)
+            .unwrap_or(true);
+        let value = if next_on_new_line
+            || matches!(
+                self.peek_kind(),
+                Some(TokenKind::Semicolon | TokenKind::Dedent | TokenKind::RBrace)
+            )
             || self.peek_kind().is_none()
         {
             None

--- a/tests/core/braceless_return.js
+++ b/tests/core/braceless_return.js
@@ -1,0 +1,34 @@
+// A braceless `if (cond) return` must NOT swallow the statement on the next line.
+// Regression test for #96. (Translation of braceless_return.tish; the js-target
+// oracle runs the tish-compiled output, this file gates that comparison.)
+
+let log = [];
+function rec(m) { log.push(m); }
+
+function f(skip) {
+  if (skip) return;
+  rec("ran");
+}
+f(false);
+console.log(JSON.stringify(log));          // ["ran"]
+
+let log2 = [];
+function rec2(m) { log2.push(m); }
+function g(skip) {
+  if (skip) return;
+  rec2("ran2");
+}
+g(true);
+console.log(JSON.stringify(log2));         // []
+
+function h(x) {
+  if (x > 0) return "pos";
+  return "nonpos";
+}
+console.log(h(5), h(-1));                   // pos nonpos
+
+function sum(a, b) {
+  return a +
+    b;
+}
+console.log(sum(3, 4));                     // 7

--- a/tests/core/braceless_return.tish
+++ b/tests/core/braceless_return.tish
@@ -1,0 +1,38 @@
+// A braceless `if (cond) return` must NOT swallow the statement on the next line
+// as the return's argument (JS restricted production: a line break after `return`
+// ends the statement). Regression test for #96.
+
+let log = []
+fn rec(m) { log.push(m) }
+
+// braceless return; `rec("ran")` is an independent statement
+fn f(skip) {
+  if (skip) return
+  rec("ran")
+}
+f(false)
+console.log(JSON.stringify(log))          // ["ran"]
+
+// taking the branch returns early, skipping rec
+let log2 = []
+fn rec2(m) { log2.push(m) }
+fn g(skip) {
+  if (skip) return
+  rec2("ran2")
+}
+g(true)
+console.log(JSON.stringify(log2))         // []
+
+// braceless return WITH a value on the same line still works
+fn h(x) {
+  if (x > 0) return "pos"
+  return "nonpos"
+}
+console.log(h(5), h(-1))                   // pos nonpos
+
+// a multi-line expression whose first token is on the `return` line is one value
+fn sum(a, b) {
+  return a +
+    b
+}
+console.log(sum(3, 4))                      // 7

--- a/tests/core/braceless_return.tish.expected
+++ b/tests/core/braceless_return.tish.expected
@@ -1,0 +1,4 @@
+["ran"]
+[]
+pos nonpos
+7

--- a/tests/main.js
+++ b/tests/main.js
@@ -1048,6 +1048,43 @@ console.log("16 >> 2 =", 16 >> 2);
 }
 
 {
+// A braceless `if (cond) return` must NOT swallow the statement on the next line.
+// Regression test for #96. (Translation of braceless_return.tish; the js-target
+// oracle runs the tish-compiled output, this file gates that comparison.)
+
+let log = [];
+function rec(m) { log.push(m); }
+
+function f(skip) {
+  if (skip) return;
+  rec("ran");
+}
+f(false);
+console.log(JSON.stringify(log));          // ["ran"]
+
+let log2 = [];
+function rec2(m) { log2.push(m); }
+function g(skip) {
+  if (skip) return;
+  rec2("ran2");
+}
+g(true);
+console.log(JSON.stringify(log2));         // []
+
+function h(x) {
+  if (x > 0) return "pos";
+  return "nonpos";
+}
+console.log(h(5), h(-1));                   // pos nonpos
+
+function sum(a, b) {
+  return a +
+    b;
+}
+console.log(sum(3, 4));                     // 7
+}
+
+{
 // MVP test: break and continue in nested loops (JS equivalent of break_continue.tish)
 let found = 0;
 for (let i = 0; i < 3; i = i + 1) {

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -1055,6 +1055,48 @@ console.log("16 >> 2 =", 16 >> 2)
 }
 __perf_run_core_bitwise()
 
+fn __perf_run_core_braceless_return() {
+// A braceless `if (cond) return` must NOT swallow the statement on the next line
+// as the return's argument (JS restricted production: a line break after `return`
+// ends the statement). Regression test for #96.
+
+let log = []
+fn rec(m) { log.push(m) }
+
+// braceless return; `rec("ran")` is an independent statement
+fn f(skip) {
+  if (skip) return
+  rec("ran")
+}
+f(false)
+console.log(JSON.stringify(log))          // ["ran"]
+
+// taking the branch returns early, skipping rec
+let log2 = []
+fn rec2(m) { log2.push(m) }
+fn g(skip) {
+  if (skip) return
+  rec2("ran2")
+}
+g(true)
+console.log(JSON.stringify(log2))         // []
+
+// braceless return WITH a value on the same line still works
+fn h(x) {
+  if (x > 0) return "pos"
+  return "nonpos"
+}
+console.log(h(5), h(-1))                   // pos nonpos
+
+// a multi-line expression whose first token is on the `return` line is one value
+fn sum(a, b) {
+  return a +
+    b
+}
+console.log(sum(3, 4))                      // 7
+}
+__perf_run_core_braceless_return()
+
 fn __perf_run_core_break_continue() {
 // MVP test: break and continue in nested loops
 let found = 0


### PR DESCRIPTION
## Summary
A braceless `if (skip) return` followed by a statement on the next line parsed as `return <that-statement>`. The statement then only ran when the branch was **taken** (inverted logic) and was otherwise dropped — silently, with no error.

```tish
fn f(skip) {
  if (skip) return      // braceless
  rec("ran")            // <-- was parsed as `return rec("ran")`
}
f(false)                // expected rec("ran") to run; it didn't
```

## Cause
The lexer emits no token for a **same-indentation** line break (only `Indent`/`Dedent` on level changes), so `parse_return` had no statement boundary and greedily parsed the next line as the return value. JS avoids this with the restricted production `return [no LineTerminator here] Expression`.

## Fix
In `parse_return`, a line break between `return` and the next token now terminates the statement (yields `return null`), detected by comparing the next token's line to the `return` keyword's line. Unchanged:
- `return x` — value on the same line.
- `return a +\n  b` — argument **starts** on the `return` line, so the multi-line expression is still one value.

Only `return` is affected; `break`/`continue` take no argument and `throw` requires one.

## Test
`tests/core/braceless_return.tish` covers braceless early-return (not taken), branch-taken early-return, same-line return value, and a multi-line return expression. Passes on all 6 backends (interpreter, VM, native, cranelift, wasi, js). Bundled perf sources regenerated.

Closes #96