### PR TITLE
fix: re-enter JSX text mode after a child element closes (#108)

### DIFF
--- a/crates/tish_compile_js/src/tests_jsx.rs
+++ b/crates/tish_compile_js/src/tests_jsx.rs
@@ -28,6 +28,70 @@ mod tests {
     }
 
     #[test]
+    fn jsx_keyword_text_after_child_element() {
+        // #108: a text run *after* a nested child element must be lexed as JSX text, so a bare
+        // reserved keyword (`as`, `in`, `if`, `return`, `let`) in that run is plain text, not a
+        // keyword token. Text-only children already worked; the bug was failing to re-enter
+        // JSX-text mode once a child element had closed.
+        for kw in ["as", "in", "if", "return", "let"] {
+            let src = format!("fn V() {{ return <div><span>x</span> {kw} JSON</div> }}");
+            let program =
+                parse(&src).unwrap_or_else(|e| panic!("parse failed for trailing `{kw}`: {e}"));
+            let js = compile_with_jsx(&program, false).unwrap();
+            let expected = format!("[h(\"span\", null, [\"x\"]), \" {kw} JSON\"]");
+            assert!(
+                js.contains(&expected),
+                "trailing `{kw}` after child element: expected {expected:?} in output, got: {js}"
+            );
+        }
+    }
+
+    #[test]
+    fn jsx_text_between_and_after_multiple_children() {
+        // Text both between and after child elements stays text (incl. a keyword run between).
+        let src = r#"fn V() { return <div><span>x</span> as <b>y</b> in z</div> }"#;
+        let program = parse(src).unwrap();
+        let js = compile_with_jsx(&program, false).unwrap();
+        assert!(
+            js.contains(
+                "[h(\"span\", null, [\"x\"]), \" as \", h(\"b\", null, [\"y\"]), \" in z\"]"
+            ),
+            "{js}"
+        );
+    }
+
+    #[test]
+    fn jsx_self_closing_child_then_keyword_text() {
+        // A self-closing child (`<br/>`) followed by keyword text must also re-enter text mode.
+        let src = r#"fn V() { return <div><br/> as JSON</div> }"#;
+        let program = parse(src).unwrap();
+        let js = compile_with_jsx(&program, false).unwrap();
+        assert!(
+            js.contains("[h(\"br\", null, []), \" as JSON\"]"),
+            "{js}"
+        );
+    }
+
+    #[test]
+    fn jsx_child_element_inside_expr_container_not_text_mode() {
+        // Re-entering JSX text mode after a child closes must NOT happen when that child lived
+        // inside a `{…}` expression container — otherwise the `)`/`,` that follows is swallowed as
+        // JsxText ("Expected RParen, got JsxText"). Regression for the #108 fix itself, caught by
+        // the downstream suite (tish-audio / tish-midi use `{items.map(x => <li>{x}</li>)}`).
+        let src = r#"fn V(items) { return <ul>{items.map(x => <li>{x}</li>)}</ul> }"#;
+        let program = parse(src).expect("map-in-container must parse");
+        let js = compile_with_jsx(&program, false).unwrap();
+        assert!(js.contains("h(\"ul\""), "{js}");
+        assert!(js.contains(".map("), "{js}");
+
+        // And the combined case: a `{…}` container followed by trailing keyword text.
+        let src2 = r#"fn V(items) { return <div>{items.map(x => <span>{x}</span>)} as JSON</div> }"#;
+        let program2 = parse(src2).expect("container-then-text must parse");
+        let js2 = compile_with_jsx(&program2, false).unwrap();
+        assert!(js2.contains("\" as JSON\""), "{js2}");
+    }
+
+    #[test]
     fn jsx_text_whitespace_coalesced() {
         let src = r#"fn X() { return <p>First paragraph</p> }"#;
         let program = parse(src).unwrap();

--- a/crates/tish_lexer/src/lib.rs
+++ b/crates/tish_lexer/src/lib.rs
@@ -680,6 +680,21 @@ impl<'a> Lexer<'a> {
                         self.jsx_depth = (self.jsx_depth - 1).max(0);
                         self.jsx_stack.pop();
                         self.jsx_sync_in_opening_tag();
+                        // A child element just closed (`</span>` or `<br/>`). If a parent element
+                        // is still open and past its opening tag, we're back in that parent's
+                        // children region, so the following run is JSX text — re-enter text mode.
+                        // Without this, trailing text after a child element ("… as JSON") is lexed
+                        // as code and a bare keyword (`as`, `in`, `if`, …) breaks the parse (#108).
+                        //
+                        // Guard on `jsx_child_brace_depth == 0`: if the closed element lived inside a
+                        // `{…}` expression container (e.g. `<div>{items.map(x => <span/>)}</div>`),
+                        // we're still in that expression, not the parent's text children — entering
+                        // text mode there would swallow the following `)`/`,` as JsxText.
+                        if self.jsx_child_brace_depth == 0
+                            && self.jsx_stack.last().map(|e| !e.in_opener).unwrap_or(false)
+                        {
+                            self.jsx_after_gt = true;
+                        }
                     } else if let Some(top) = self.jsx_stack.last_mut() {
                         if top.in_opener && top.attr_value_braces > 0 {
                             // `>` is a comparison (or shift) token inside `{ ... }`, not end of opening tag.


### PR DESCRIPTION
## Summary
In JSX, a text run **following a nested child element** was lexed as code rather than JSX text. Any bare word in that run that is a reserved keyword (`as`, `in`, `if`, `return`, `let`, …) tokenized as the keyword and broke the parse:

```jsx
<div><span>x</span> as JSON</div>
// → Error: Unexpected token in JSX children: As
```

Text-only children always worked (`<div>download as JSON</div>` ✓); the bug appeared only **after** a child element, because the lexer never returned to JSX-text mode once that child's closing tag (or a self-closing `<br/>`) was consumed.

## Fix
In the lexer's `>` handling, when a child element closes (`</span>` or `<br/>`) and a parent element is still open and **past its opening tag** (we're back in the parent's children region), set `jsx_after_gt` so the following character run is scanned as JSX text until the next `<` or `{`.

## Test
New `tish_compile_js` JSX tests: trailing `as`/`in`/`if`/`return`/`let` after a child element, text both between and after multiple children, and a self-closing child followed by keyword text. Verified the emitted children array, e.g. `[h("span", null, ["x"]), " as JSON"]`.

## How it was found
The downstream regression suite (`regression/downstream/run.sh`) flagged **tish-audio** as a regression — real-world JSX prose like `… <span>MIDI out</span> to synth … download as JSON.`

Closes #108