### PR TITLE
test(regression): run-and-assert suite for example apps

### DIFF
--- a/docs/perf-typed-vs-untyped-baseline.md
+++ b/docs/perf-typed-vs-untyped-baseline.md
@@ -146,6 +146,52 @@ analysis provably can't store a string into a `number[]`.
   `binary_trees` (24× off, hardest). Both extend `TISH_STRUCT_INFER`. `megamorphic` (12× off) is
   polymorphic dispatch → a VM inline-cache concern, not typed codegen.
 
+## Update 2026-06-11 — regression check: perf flat across the 23 commits since `71c874d0` (#79)
+
+Not a new typing lever — a **before/after guard** confirming the feature/fix work that landed on `main`
+since the phase-2 baseline (the six merged PRs #105–#111 plus the rest of the range) did **not** move the
+compute-perf needle. Methodology: the **same** `run_perf_gauntlet.sh` (byte-identical at both commits)
+and the identical 21-fixture `tests/perf/` corpus, built and run on the real checkout at each commit (no
+worktrees) — **baseline `71c874d0`** vs **`main` `c69cf32f`**, min of 5, with the Node/V8 column as a
+machine-noise control (same V8 binary both runs).
+
+**Verdict: no measurable change.** Every per-benchmark delta sits inside run-to-run noise — the Node
+control column drifts by as much or more with zero code change (`fnv_hash` node 104→109 ms,
+`json_roundtrip` 133→125 ms, `queens` 129→124 ms). Status counts are identical (**8 / 21 beat V8**),
+**no benchmark flipped** PASS↔FAIL, and soundness held on both builds (**0 `TYPED≠BOXED`, 0 `≠NODE`**).
+
+`main` (`c69cf32f`) snapshot — full 21-benchmark gauntlet, min of 5 (Δ = `typed (on)` vs `71c874d0`):
+
+| benchmark | boxed (off) | typed (on) | typing-speedup | node (ratio) | Δ typed vs `71c874d0` | status |
+|-----------|------------:|-----------:|---------------:|-------------:|----------------------:|--------|
+| `object_sum` | 82 ms | 1 ms | **81.92×** | 3 ms (0.33×) | 0 | PASS ✓ |
+| `array_hof` | 235 ms | 11 ms | **21.36×** | 29 ms (0.38×) | −1 ms | PASS ✓ |
+| `matmul` | 228 ms | 14 ms | **16.28×** | 17 ms (0.82×) | 0 | PASS ✓ |
+| `recursion_untyped` | 460 ms | 31 ms | **14.84×** | 55 ms (0.56×) | −1 ms | PASS ✓ |
+| `recursion_fib` | 454 ms | 31 ms | **14.64×** | 50 ms (0.62×) | 0 | PASS ✓ |
+| `mandelbrot` | 856 ms | 67 ms | **12.78×** | 56 ms (1.20×) | −1 ms | FAIL (≈V8) |
+| `typed_array_hof` | 266 ms | 99 ms | 2.69× | 33 ms (3.00×) | +6 ms | FAIL (evolve) |
+| `nsieve` | 473 ms | 102 ms | 4.64× | 72 ms (1.42×) | −1 ms | FAIL |
+| `fannkuch` | 3481 ms | 1399 ms | 2.49× | 140 ms (9.99×) | +6 ms | FAIL |
+| `fnv_hash` | 445 ms | 439 ms | 1.01× | 109 ms (4.03×) | +18 ms\* | FAIL |
+| `spectral_norm` | 1826 ms | 1762 ms | 1.04× | 39 ms (45.18×) | +30 ms | FAIL |
+| `queens` | 1079 ms | 1083 ms | 1.00× | 124 ms (8.73×) | +1 ms | FAIL |
+| `nbody` | 889 ms | 860 ms | 1.03× | 11 ms (78.17×) | −21 ms | FAIL |
+| `binary_trees` | 885 ms | 878 ms | 1.01× | 37 ms (23.73×) | −1 ms | FAIL |
+| `megamorphic` | 671 ms | 678 ms | 0.99× | 54 ms (12.56×) | −3 ms | FAIL |
+| `fasta` | 217 ms | 207 ms | 1.05× | 37 ms (5.59×) | +6 ms | FAIL |
+| `json_roundtrip` | 296 ms | 295 ms | 1.00× | 125 ms (2.36×) | −10 ms | FAIL |
+| `k_nucleotide` | 23 ms | 22 ms | 1.05× | 5 ms (4.40×) | 0 | FAIL |
+| `numeric_loop` | 47 ms | 46 ms | 1.02× | 50 ms (0.92×) | −1 ms | PASS ✓ |
+| `math_trig` | 11 ms | 10 ms | 1.10× | 81 ms (0.12×) | 0 | PASS ✓ |
+| `string_concat` | 0 ms | 0 ms | — | 3 ms | 0 | PASS ✓ |
+
+\* `fnv_hash`'s +18 ms (+4.3%) is the largest single mover, but the Node control on that same row drifted
++5 ms (104→109) between runs — i.e. inside the machine's own variance, not a code regression. The "+"
+rows (`fnv_hash`, `spectral_norm` +1.7%, `typed_array_hof` +6.5%, `fasta` +3%) are matched by equal "−"
+rows (`nbody` −2.4%, `json_roundtrip` −3.3%, `recursion_untyped` −3.1%); `boxed (off)` shows the same
+symmetric scatter. No trend, no regression to chase — the recent range was correctness/feature work.
+
 ## Baseline (Apple Silicon, release, min of 3 runs — pre-phase-1 reference, 9-benchmark set)
 
 | benchmark | boxed (off) | typed (on) | typing-speedup | node (ratio) | status | validates |

--- a/regression/examples/README.md
+++ b/regression/examples/README.md
@@ -13,23 +13,26 @@ A transpile smoke only proves "it parses". This suite proves "it **works**":
 ## Why this exists
 
 The downstream suite caught a real **tish JSX-lexer regression** — filed as
-[tishlang/tish#108](https://github.com/tishlang/tish/issues/108). After a nested child element, a
-text run is lexed as code, so a reserved keyword sitting in ordinary markup prose fails to parse:
+[tishlang/tish#108](https://github.com/tishlang/tish/issues/108) and **fixed in #111**. Before that
+fix, after a nested child element a text run was lexed as code, so a reserved keyword sitting in
+ordinary markup prose failed to parse:
 
 ```jsx
-<div><span>x</span> as JSON</div>   // ✗ Parse error: Unexpected token in JSX children: As
+<div><span>x</span> as JSON</div>   // ✗ (pre-#111) Parse error: Unexpected token in JSX children: As
 <div>download as JSON</div>          // ✓ builds fine (no preceding element)
 ```
 
 Affected after a child element: `as` `in` `if` `return` `let` (… any reserved word); fine for
 non-keywords and in text-only children. It bit `tish-audio` (real prose: *"…download as JSON."*
-after inline `<span>`s) and would have shipped silently. **Running the examples is the guard** that
-turns a class of frontend regressions into a red build.
+after inline `<span>`s) and would have shipped silently. #111 closed that specific hole; **running
+the examples is the standing guard** that turns the next such frontend regression into a red build.
 
-## Findings from the first sweep (tish HEAD around `a3d8747`)
+## Findings (re-verified on `main` after #105–#111 landed)
 
-Every example was exercised the right way for its kind. Result: **no frontend regressions** — all
-50 example `.tish` files parse + transpile clean. Concretely:
+Every example was exercised the right way for its kind. Result: **no frontend regressions** — every
+example `.tish` file parses + transpiles clean and the run/serve/lattish assertions hold
+(`PASS 19 · FAIL 0 · SKIP 11`; the three `:3000` rows SKIP on a dev box already running a server on
+that port, and the eight env-gated rows SKIP without `--full`). Concretely:
 
 - **All `run` / `serve` / `lattish` examples behave correctly** when their port is free / deps present.
 - The 9 **lattish** examples render correctly against the **workspace lattish** (wired in like

--- a/regression/examples/README.md
+++ b/regression/examples/README.md
@@ -1,0 +1,97 @@
+# Example-app regression suite
+
+**RUNS** (not just builds) every example app we ship, against the tish checkout you're on (HEAD),
+and asserts observable behavior. Companion to [`regression/downstream`](../downstream/README.md):
+that suite guards external *consumers*; this one guards the examples in this repo.
+
+A transpile smoke only proves "it parses". This suite proves "it **works**":
+
+- **`run`** examples are executed and their **stdout** is asserted.
+- **`serve`** examples (HTTP servers) are started, **probed over HTTP**, asserted, and shut down.
+- **`lattish`** examples are built to JS, **mounted in jsdom**, and their **rendered DOM** is asserted.
+
+## Why this exists
+
+The downstream suite caught a real **tish JSX-lexer regression** — filed as
+[tishlang/tish#108](https://github.com/tishlang/tish/issues/108). After a nested child element, a
+text run is lexed as code, so a reserved keyword sitting in ordinary markup prose fails to parse:
+
+```jsx
+<div><span>x</span> as JSON</div>   // ✗ Parse error: Unexpected token in JSX children: As
+<div>download as JSON</div>          // ✓ builds fine (no preceding element)
+```
+
+Affected after a child element: `as` `in` `if` `return` `let` (… any reserved word); fine for
+non-keywords and in text-only children. It bit `tish-audio` (real prose: *"…download as JSON."*
+after inline `<span>`s) and would have shipped silently. **Running the examples is the guard** that
+turns a class of frontend regressions into a red build.
+
+## Findings from the first sweep (tish HEAD around `a3d8747`)
+
+Every example was exercised the right way for its kind. Result: **no frontend regressions** — all
+50 example `.tish` files parse + transpile clean. Concretely:
+
+- **All `run` / `serve` / `lattish` examples behave correctly** when their port is free / deps present.
+- The 9 **lattish** examples render correctly against the **workspace lattish** (wired in like
+  downstream does — we test the lattish being *developed* beside this checkout, not the published
+  package). This is also the end-to-end proof that the `createRoot(container, host)` pluggable-host
+  change (lattish #4) didn't regress the default DOM path.
+- **Native-only** examples (`tish:http/fs/mlx/metal`, `ffi:`) parse clean; `async-await`,
+  `json-file-edit`, `mdx-docs` build to a native binary. `matmul`'s GPU variants fail only at the
+  **backend** (`mlx`/`metal` toolchain), not the frontend — tracked as `xfail`/env-gated, not a regression.
+
+### Calibration gotchas baked into the manifest (so they don't read as failures)
+
+- `new-expression` prints `sampleRate = 48000` on this machine (audio-device dependent) — assert the
+  stable `sampleRate =`, not a specific rate.
+- The `http-*` servers honor `$PORT`; `json-api`/`echo-server`/`counter-api` **hardcode 3000**. The
+  runner relocates the former to a free port (`auto`) and **skips** the latter if 3000 is held by a
+  foreign process (e.g. a local Next.js dev server) — a port conflict is a SKIP, never a regression.
+- `lat-app` renders a "Sign up" form; `lat-06-effects`' `useEffect` does async work that rejects in
+  jsdom — the render harness asserts the **synchronous** initial render and swallows async rejections.
+
+## Run it
+
+```bash
+regression/examples/run.sh                 # deterministic core (run/serve/lattish); env-gated rows SKIP
+regression/examples/run.sh --full          # also run net/db/gpu/wasm/npm/prebuild/slow rows
+regression/examples/run.sh hello-world json-api lat-01-counter   # a subset by name
+regression/examples/run.sh --list          # print the manifest
+regression/examples/run.sh --tish /path/to/other/tish            # test a different checkout
+```
+
+The suite **fails (exit 1)** only on a real regression — a row marked `pass` that misbehaves. An
+`xfail` row that unexpectedly passes is a warning (time to flip it to `pass`). Env/port conflicts
+are reported as **SKIP**, not failures.
+
+## How it wires a consumer to tish HEAD
+
+1. Builds the HEAD `tish` binary (`cargo build --release -p tishlang`) and puts it on `PATH`.
+2. Copies each example into a scratch dir (so a mutating example like `json-file-edit` never touches
+   the repo).
+3. For `lattish` examples, rsyncs the **workspace lattish** (`$TISH/../lattish`) into
+   `node_modules/lattish` — the npm analog of downstream's Cargo path-rewrite — then builds + mounts
+   it in jsdom (jsdom is resolved from the workspace lattish's `node_modules`).
+4. Runs the example and asserts per its kind.
+
+## Manifest — `examples.tsv`
+
+Tab-separated: `name  dir  entry  kind  features  check  expect  tags  expected`
+
+| field | values |
+|---|---|
+| `dir` | `examples/foo` (this repo) · `@lattish:PATH` (a path under `../lattish`) |
+| `entry` | the `.tish` to run/build, relative to `dir` |
+| `kind` | `run` (executes + exits) · `serve` (HTTP server) · `lattish` (build→jsdom render) |
+| `features` | comma list for `--feature` (or `-`) |
+| `check` | for `serve`: `METHOD:PORT:PATH` (PORT may be `auto` if the example honors `$PORT`). `-` otherwise |
+| `expect` | substring that must appear (stdout · HTTP body · rendered DOM text) |
+| `tags` | env needs; any of `net db gpu wasm npm prebuild native slow vite` makes the row SKIP unless `--full` (`mutates` is informational) |
+| `expected` | `pass` (must stay green — a failure is a regression) · `xfail` (known-broken pending env/migration) |
+
+## Adding an example
+
+Append a line to `examples.tsv`. Pick the `kind`, give a concrete `expect` (quote a literal the app
+prints / serves / renders), and tag any environment it needs so CI skips it cleanly. If it needs
+network, a database, a GPU, a prebuild step, or an `npm install`, tag it so the default run stays
+deterministic; document anything subtle here (see the calibration gotchas above).

--- a/regression/examples/examples.tsv
+++ b/regression/examples/examples.tsv
@@ -58,3 +58,9 @@ matmul-gpu	examples/matmul	src/matmul_gpu.tish	run	-	-	gpu	gpu	xfail
 wasmtime	examples/wasmtime-modules	src/main.tish	run	-	-	Hello	wasm	pass
 pg	examples/pg	query_example.tish	run	-	-	rows	db	pass
 mdx-docs	examples/mdx-docs	src/build.tish	run	fs	-	Built	prebuild	pass
+#
+# ── intentionally NOT a row (documented exclusion, so it is not "silently uncovered") ─────────────
+# examples/tty (the `tish:tty` raw-mode key demo shipped with #101/#105) reads live keypresses in
+# raw mode and has no deterministic stdout to assert without a PTY — there is no run/serve/lattish
+# kind that fits it here. Excluded on purpose. If a PTY-driven harness is added later, add the row
+# with a `native` tag so the default run stays deterministic.

--- a/regression/examples/examples.tsv
+++ b/regression/examples/examples.tsv
@@ -1,0 +1,60 @@
+# Example-app regression manifest — RUN (not just build) the in-repo examples against tish HEAD.
+# Companion to regression/downstream (which tests external CONSUMERS). This suite catches breakage
+# in the examples we ship, and — unlike a transpile smoke — actually EXECUTES each app and asserts
+# observable behavior (stdout / HTTP response / rendered DOM).
+#
+# Columns (TAB-separated): name  dir  entry  kind  features  check  expect  tags  expected
+#   dir       path under the tish repo (examples/foo), or `@lattish:PATH` for a path under ../lattish
+#   entry     the .tish to run/build, relative to dir
+#   kind      run     = executes and EXITS; assert `expect` appears in stdout
+#             serve   = long-running HTTP server; runner starts it, probes `check`, asserts `expect`, kills it
+#             lattish = builds to JS with the LOCAL workspace lattish wired in, mounts it in jsdom,
+#                       asserts `expect` appears in #root's rendered text  (real runtime test, not a build)
+#   features  comma list for `--feature` (or `-`)
+#   check     for serve: METHOD:PORT:PATH (e.g. GET:3000:/users). `-` otherwise.
+#   expect    substring that MUST appear (stdout | HTTP body | rendered DOM text)
+#   tags      env requirements; any tag in the skip-set makes the row SKIP unless --full is passed.
+#             skip-set: net db gpu wasm npm prebuild native slow vite   (mutates is informational only)
+#   expected  pass = must be green (a failure is a regression) · xfail = known-broken pending env/migration
+#
+# Run:  regression/examples/run.sh            # deterministic core (run/serve/lattish); env-gated rows SKIP
+#       regression/examples/run.sh --full     # also run net/db/gpu/wasm/npm/prebuild/slow rows
+#       regression/examples/run.sh hello-world json-api lat-01-counter   # a subset
+#
+# ── run: executes and exits, assert stdout ──────────────────────────────────────────────────────
+hello-world	examples/hello-world	src/main.tish	run	-	-	Hello from Tish!	-	pass
+data-processing	examples/data-processing	src/main.tish	run	-	-	Grand Total	-	pass
+modules-example	examples/modules-example	src/main.tish	run	-	-	Hello, Universe	-	pass
+new-expression	examples/new-expression	src/main.tish	run	-	-	sampleRate =	-	pass
+js-to-tish	examples/js-to-tish-example	src/main.tish	run	-	-	Average:	-	pass
+json-file-edit	examples/json-file-edit	src/main.tish	run	fs	-	version = 2	mutates	pass
+#
+# ── serve: HTTP server — start, probe, assert response, shut down ────────────────────────────────
+json-api	examples/json-api	src/main.tish	serve	http	GET:3000:/users	Alice	-	pass
+echo-server	examples/echo-server	src/main.tish	serve	http	GET:3000:/health	OK	-	pass
+counter-api	examples/counter-api	src/main.tish	serve	http	GET:3000:/health	healthy	-	pass
+http-hello	examples/http-hello	src/main.tish	serve	http,process	GET:auto:/	Hello from Tish	-	pass
+http-modules	examples/http-modules-example	src/main.tish	serve	http,process	GET:auto:/	sup, World	-	pass
+http-env-var	examples/http-env-var-example	src/main.tish	serve	http,process	GET:auto:/	tishreg	-	pass
+container	examples/container-example	src/main.tish	serve	http,process	GET:auto:/health	OK	-	pass
+#
+# ── lattish: build to JS (workspace lattish wired) + mount in jsdom + assert rendered DOM ─────────
+lat-01-counter	@lattish:examples/features	01-counter.tish	lattish	-	-	Increment	-	pass
+lat-02-list	@lattish:examples/features	02-list.tish	lattish	-	-	Build app	-	pass
+lat-03-greeting	@lattish:examples/features	03-greeting.tish	lattish	-	-	Hello,	-	pass
+lat-04-ref	@lattish:examples/features	04-ref.tish	lattish	-	-	Name:	-	pass
+lat-05-memo	@lattish:examples/features	05-memo.tish	lattish	-	-	Doubled:	-	pass
+lat-06-effects	@lattish:examples/features	06-effects.tish	lattish	-	-	Loading	-	pass
+lat-07-batched	@lattish:examples/features	07-batched.tish	lattish	-	-	Batch update	-	pass
+lat-08-fragment	@lattish:examples/features	08-fragment.tish	lattish	-	-	Second paragraph	-	pass
+lat-app	examples/lattish	src/App.tish	lattish	-	-	Sign up	-	pass
+#
+# ── env-gated: real apps, but need network / db / gpu / a prebuild step — SKIP unless --full ──────
+async-await	examples/async-await	src/main.tish	run	http,process	-	All fetches ok: true	net	pass
+npm-usage	examples/npm-usage	src/main.tish	run	-	-	Hello from @tishlang/tish	npm	pass
+ffi	examples/ffi	demo.tish	run	-	-	hypot(3, 4) = 5	native,prebuild	pass
+matmul-cpu	examples/matmul	src/main.tish	run	-	-	cpu 128x128	slow	pass
+matmul-gpu	examples/matmul	src/matmul_gpu.tish	run	-	-	gpu	gpu	xfail
+wasmtime	examples/wasmtime-modules	src/main.tish	run	-	-	Hello	wasm	pass
+pg	examples/pg	query_example.tish	run	-	-	rows	db	pass
+mdx-docs	examples/mdx-docs	src/build.tish	run	fs	-	Built	prebuild	pass

--- a/regression/examples/lattish-render.mjs
+++ b/regression/examples/lattish-render.mjs
@@ -1,0 +1,76 @@
+// Mount a built lattish example in jsdom and assert it rendered.
+// Usage: node lattish-render.mjs <built-app.js> <expected-substring>
+// Exits 0 if #root's rendered text contains the expected substring, else 1.
+// This is a real RUNTIME test: the app's createRoot(...).render(App) actually executes,
+// the reconciler builds DOM, and we read it back. A build alone would not catch a
+// mount-time throw or an empty render.
+import { readFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import { join } from "node:path"
+
+const [, , jsPath, expected] = process.argv
+if (!jsPath || expected === undefined) {
+  console.error("usage: lattish-render.mjs <app.js> <expected>")
+  process.exit(2)
+}
+
+// jsdom is CJS and lives in the workspace lattish's node_modules. ESM `import "jsdom"`
+// resolves from THIS file's dir (ignores NODE_PATH), so resolve it explicitly relative
+// to the lattish package the runner points us at.
+const pkg = process.env.LATTISH_PKG
+if (!pkg) {
+  console.error("LATTISH_PKG not set (path to workspace lattish)")
+  process.exit(2)
+}
+const require = createRequire(join(pkg, "package.json"))
+const { JSDOM } = require("jsdom")
+
+// An app's useEffect may kick off async work (e.g. fetch) that has no business in this
+// synchronous render check and would reject in jsdom. Swallow it rather than crash.
+process.on("unhandledRejection", () => {})
+process.on("uncaughtException", () => {})
+
+const dom = new JSDOM(`<!doctype html><html><body><div id="root"></div></body></html>`, {
+  pretendToBeVisual: true,
+})
+// The built bundle is self-contained (lattish inlined) and references the DOM as globals.
+globalThis.window = dom.window
+globalThis.document = dom.window.document
+globalThis.requestAnimationFrame = (cb) => dom.window.setTimeout(() => cb(Date.now()), 0)
+globalThis.cancelAnimationFrame = (id) => dom.window.clearTimeout(id)
+
+const root = () => dom.window.document.getElementById("root")
+const seen = () => {
+  const r = root()
+  if (!r) return ""
+  return (r.textContent || "") + " " + (r.innerHTML || "")
+}
+const has = (s) => s.includes(expected)
+
+const code = readFileSync(jsPath, "utf8")
+try {
+  // top-level createRoot(getElementById("root")).render(App) runs here (synchronous mount)
+  ;(0, eval)(code) // eslint-disable-line no-eval
+} catch (e) {
+  console.error("RENDER THREW:", e && e.stack ? e.stack.split("\n").slice(0, 3).join("\n") : e)
+  process.exit(1)
+}
+
+// 1) assert on the SYNCHRONOUS initial render (what the user sees before effects fire)
+if (has(seen())) {
+  console.error(`rendered OK (#root contains "${expected}")`)
+  process.exit(0)
+}
+// 2) not there yet: let microtask/timeout effects settle, then re-check
+await new Promise((r) => dom.window.setTimeout(r, 40))
+const after = seen()
+if (after.replace(/ /g, "").trim() === "") {
+  console.error("EMPTY RENDER: #root has no content after mount")
+  process.exit(1)
+}
+if (!has(after)) {
+  console.error(`MISSING: expected "${expected}" in rendered #root, got: ${JSON.stringify(root().textContent.slice(0, 180))}`)
+  process.exit(1)
+}
+console.error(`rendered OK (#root contains "${expected}")`)
+process.exit(0)

--- a/regression/examples/run.sh
+++ b/regression/examples/run.sh
@@ -10,9 +10,10 @@
 # their rendered DOM asserted.
 #
 # Why this exists: the downstream suite caught a JSX-lexer regression
-# (tishlang/tish#108) where a reserved keyword as bare text after a nested
-# child element fails to parse. A keyword like that hiding in example markup
-# would have shipped silently. Running the examples is the guard.
+# (tishlang/tish#108, fixed in #111) where a reserved keyword as bare text after
+# a nested child element failed to parse. A keyword like that hiding in example
+# markup would have shipped silently. Running the examples is the standing guard
+# against the next one.
 #
 # Usage:
 #   regression/examples/run.sh [all | NAME ...] [options]

--- a/regression/examples/run.sh
+++ b/regression/examples/run.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Example-app regression suite — RUN (not just build) every in-repo example
+# against THIS tish checkout (HEAD), and assert observable behavior.
+#
+# Companion to regression/downstream (external consumers). Where a transpile
+# smoke only proves "it parses", this suite proves "it WORKS": run-and-exit
+# programs are executed and their stdout asserted; HTTP servers are started,
+# probed, and shut down; lattish apps are built to JS, mounted in jsdom, and
+# their rendered DOM asserted.
+#
+# Why this exists: the downstream suite caught a JSX-lexer regression
+# (tishlang/tish#108) where a reserved keyword as bare text after a nested
+# child element fails to parse. A keyword like that hiding in example markup
+# would have shipped silently. Running the examples is the guard.
+#
+# Usage:
+#   regression/examples/run.sh [all | NAME ...] [options]
+#     --tish DIR   tish checkout to test against (default: this repo root)
+#     --full       also run env-gated rows (net/db/gpu/wasm/npm/prebuild/slow)
+#     --keep       keep the scratch workdir
+#     --list       print the manifest and exit
+# Env: TISH_DIR overrides --tish.
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+MANIFEST="$SCRIPT_DIR/examples.tsv"
+RENDER_HARNESS="$SCRIPT_DIR/lattish-render.mjs"
+
+TISH="${TISH_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+LATTISH_WS=""        # resolved after TISH is known
+FULL=0
+KEEP=0
+SELECT=()
+# tags that require an environment we don't assume in a default/CI run
+SKIP_TAGS="net db gpu wasm npm prebuild native slow vite"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tish) TISH=$(cd "$2" && pwd); shift 2 ;;
+    --full) FULL=1; shift ;;
+    --keep) KEEP=1; shift ;;
+    --list) grep -vE '^\s*#|^\s*$' "$MANIFEST"; exit 0 ;;
+    all) shift ;;
+    -*) echo "unknown option: $1" >&2; exit 2 ;;
+    *) SELECT+=("$1"); shift ;;
+  esac
+done
+
+[[ -f "$TISH/crates/tish_core/Cargo.toml" ]] || { echo "ERROR: --tish '$TISH' is not a tish checkout"; exit 2; }
+[[ -f "$MANIFEST" ]] || { echo "ERROR: manifest not found: $MANIFEST"; exit 2; }
+LATTISH_WS="$(cd "$TISH/.." && pwd)/lattish"
+
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/tish-examples.XXXXXX")
+mkdir -p "$WORKDIR"
+[[ $KEEP -eq 1 ]] || trap 'rm -rf "$WORKDIR"' EXIT
+
+echo "tish HEAD under test: $TISH ($(git -C "$TISH" rev-parse --short HEAD 2>/dev/null || echo '?'))"
+echo "workdir:              $WORKDIR"
+
+# 1. build the HEAD tish binary once, put it on PATH
+echo "building HEAD tish binary…"
+( cd "$TISH" && cargo build --release -p tishlang >/dev/null 2>&1 ) \
+  || { echo "ERROR: failed to build tish (cargo build --release -p tishlang)"; exit 2; }
+export PATH="$TISH/target/release:$PATH"
+# the lattish render harness resolves jsdom (CJS) from this package's node_modules
+export LATTISH_PKG="$LATTISH_WS"
+# deterministic env for the server examples that read env vars
+export TEST="tishreg" DEPLOYMENT_ID="reg1" TISH_HTTP_WORKERS=1
+
+HAVE_JSDOM=0; [[ -d "$LATTISH_WS/node_modules/jsdom" ]] && HAVE_JSDOM=1
+
+# a TCP port with a LISTEN socket?
+port_busy() { lsof -nP -iTCP:"$1" -sTCP:LISTEN >/dev/null 2>&1; }
+# first free port in a high range (for PORT-respecting servers)
+free_port() { local p; for p in $(seq 8123 8999); do port_busy "$p" || { echo "$p"; return; }; done; echo 0; }
+# kill only OUR tish listeners still holding a port (workers the parent didn't reap) —
+# never touches a foreign process on that port.
+free_tish_port() {
+  local lp; for lp in $(lsof -nP -iTCP:"$1" -sTCP:LISTEN -t 2>/dev/null); do
+    [[ "$(ps -p "$lp" -o comm= 2>/dev/null)" == *tish* ]] && kill "$lp" 2>/dev/null
+  done
+}
+
+echo ""
+
+PASS=(); FAIL=(); XFAIL=(); UNXPASS=(); SKIP=()
+
+# resolve a manifest `dir` to an absolute source path (handles the @lattish: prefix)
+resolve_dir() {
+  case "$1" in
+    @lattish:*) echo "$LATTISH_WS/${1#@lattish:}" ;;
+    *) echo "$TISH/$1" ;;
+  esac
+}
+
+# is any of the row's tags in the skip-set?
+row_is_env_gated() {
+  local tags="$1" t s
+  [[ "$tags" == "-" || -z "$tags" ]] && return 1
+  IFS=',' read -ra _ts <<< "$tags"
+  for t in "${_ts[@]}"; do
+    for s in $SKIP_TAGS; do [[ "$t" == "$s" ]] && return 0; done
+  done
+  return 1
+}
+
+classify() { # rc expected name
+  local rc="$1" expected="$2" name="$3"
+  if [[ $rc -eq 0 ]]; then
+    if [[ "$expected" == "xfail" ]]; then echo "   ⚠ UNEXPECTED PASS (flip to pass)"; UNXPASS+=("$name")
+    else echo "   ✓ PASS"; PASS+=("$name"); fi
+  else
+    if [[ "$expected" == "xfail" ]]; then echo "   ✓ xfail (as expected)"; XFAIL+=("$name")
+    else echo "   ✗ FAIL (regression!)"; FAIL+=("$name"); fi
+  fi
+}
+
+run_program() { # dir entry features expect logfile  -> sets RC
+  local dir="$1" entry="$2" features="$3" expect="$4" log="$5"
+  local featflag=""
+  [[ "$features" != "-" && -n "$features" ]] && featflag="--feature $features"
+  ( cd "$dir" && tish run "$entry" $featflag ) >"$log" 2>&1
+  local rc=$?
+  if [[ $rc -ne 0 ]]; then RC=1; return; fi
+  grep -qF "$expect" "$log" && RC=0 || RC=1
+}
+
+run_serve() { # dir entry features check expect logfile -> sets RC (0 pass, 1 fail, 2 skip)
+  local dir="$1" entry="$2" features="$3" check="$4" expect="$5" log="$6"
+  # NOTE: split the parses across statements — `local a=.. b=${a}` reads the OUTER a, not the
+  # one being declared, so port/path would come out empty (same footgun as downstream/run.sh).
+  local method="${check%%:*}"
+  local rest="${check#*:}"
+  local port="${rest%%:*}"
+  local path="${rest#*:}"
+  local featflag=""
+  [[ "$features" != "-" && -n "$features" ]] && featflag="--feature $features"
+  # `auto` = the example honors $PORT, so relocate it to a free port. A FIXED port that is
+  # already busy belongs to a foreign process we won't disturb → skip (can't test through it).
+  local port_pass=""
+  if [[ "$port" == "auto" ]]; then
+    port=$(free_port); [[ "$port" == "0" ]] && { echo "   no free port available"; RC=2; return; }
+    port_pass="$port"
+  elif port_busy "$port"; then
+    echo "   port $port busy (foreign process) — skip"; RC=2; return
+  fi
+  if [[ -n "$port_pass" ]]; then
+    ( cd "$dir" && PORT="$port_pass" tish run "$entry" $featflag ) >"$log" 2>&1 &
+  else
+    ( cd "$dir" && tish run "$entry" $featflag ) >"$log" 2>&1 &
+  fi
+  local pid=$!
+  local body="" i
+  for ((i=0; i<80; i++)); do
+    if ! kill -0 "$pid" 2>/dev/null; then break; fi   # server died early
+    body=$(curl -s -m 1 -X "$method" "http://127.0.0.1:$port$path" 2>/dev/null)
+    [[ -n "$body" ]] && break
+    sleep 0.25
+  done
+  # tear down the server + any workers, and make sure the port is released for the next row
+  pkill -P "$pid" 2>/dev/null; kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+  free_tish_port "$port"
+  # a port we thought was free but lost a race to → skip rather than cry regression
+  if [[ -z "$body" ]] && grep -qiE "address already in use|failed to bind" "$log"; then
+    echo "   port $port lost a bind race (foreign process) — skip"; RC=2; return
+  fi
+  echo "--- response body ---" >>"$log"; echo "$body" >>"$log"
+  [[ -n "$body" ]] && grep -qF "$expect" <<< "$body" && RC=0 || RC=1
+}
+
+run_lattish() { # dir entry expect logfile -> sets RC  (build to JS + jsdom render)
+  local dir="$1" entry="$2" expect="$3" log="$4"
+  local out="$WORKDIR/$(basename "$dir")-$(basename "$entry" .tish).js"
+  if ! ( cd "$dir" && tish build "$entry" -o "$out" --target js ) >"$log" 2>&1; then RC=1; return; fi
+  node "$RENDER_HARNESS" "$out" "$expect" >>"$log" 2>&1 && RC=0 || RC=1
+}
+
+while IFS=$'\t' read -r name dir entry kind features check expect tags expected; do
+  [[ -z "${name:-}" || "$name" =~ ^[[:space:]]*# ]] && continue
+  if [[ ${#SELECT[@]} -gt 0 ]]; then
+    m=0; for s in "${SELECT[@]}"; do [[ "$s" == "$name" ]] && m=1; done
+    [[ $m -eq 1 ]] || continue
+  elif [[ $FULL -eq 0 ]] && row_is_env_gated "$tags"; then
+    echo "── $name ── SKIP (env-gated: $tags; use --full)"; SKIP+=("$name"); continue
+  fi
+
+  src=$(resolve_dir "$dir")
+  if [[ ! -d "$src" ]]; then echo "── $name ── SKIP (missing: $src)"; SKIP+=("$name"); continue; fi
+
+  # copy into scratch so run-time mutation (e.g. json-file-edit) never touches the repo
+  scratch="$WORKDIR/$name"
+  rsync -a --exclude node_modules --exclude dist --exclude target --exclude .git "$src/" "$scratch/" >/dev/null 2>&1
+
+  # lattish apps: wire the LOCAL workspace lattish under node_modules/lattish (bare `import "lattish"`)
+  if [[ "$kind" == "lattish" ]]; then
+    if [[ ! -d "$LATTISH_WS" ]]; then echo "── $name ── SKIP (no workspace lattish at $LATTISH_WS)"; SKIP+=("$name"); continue; fi
+    if [[ $HAVE_JSDOM -eq 0 ]]; then echo "── $name ── SKIP (jsdom not installed in $LATTISH_WS; run npm install there)"; SKIP+=("$name"); continue; fi
+    mkdir -p "$scratch/node_modules"
+    rsync -a --exclude node_modules --exclude .git "$LATTISH_WS/" "$scratch/node_modules/lattish/" >/dev/null 2>&1
+  fi
+
+  echo "── $name ── $kind  ($entry, expect \"$expect\", expected=$expected)"
+  log="$WORKDIR/$name.log"; RC=1
+  case "$kind" in
+    run)     run_program "$scratch" "$entry" "$features" "$expect" "$log" ;;
+    serve)   run_serve   "$scratch" "$entry" "$features" "$check" "$expect" "$log" ;;
+    lattish) run_lattish "$scratch" "$entry" "$expect" "$log" ;;
+    *) echo "   ✗ unknown kind: $kind"; FAIL+=("$name"); continue ;;
+  esac
+  if [[ $RC -eq 2 ]]; then SKIP+=("$name"); continue; fi
+  [[ $RC -ne 0 ]] && { echo "   — last log lines —"; tail -3 "$log" | sed 's/^/      /'; }
+  classify "$RC" "$expected" "$name"
+done < <(grep -vE '^\s*#|^\s*$' "$MANIFEST")
+
+echo ""
+echo "═════════════════════ EXAMPLE REGRESSION SUMMARY ═════════════════════"
+printf "  PASS (%d):   %s\n" "${#PASS[@]}" "${PASS[*]:-(none)}"
+printf "  xfail (%d):  %s\n" "${#XFAIL[@]}" "${XFAIL[*]:-(none)}"
+printf "  SKIP (%d):   %s\n" "${#SKIP[@]}" "${SKIP[*]:-(none)}"
+[[ ${#UNXPASS[@]} -gt 0 ]] && printf "  ⚠ UNEXPECTED PASS (flip to pass): %s\n" "${UNXPASS[*]}"
+[[ ${#FAIL[@]} -gt 0 ]]    && printf "  ✗ REGRESSIONS: %s\n" "${FAIL[*]}"
+echo "══════════════════════════════════════════════════════════════════════"
+
+[[ ${#FAIL[@]} -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Adds **`regression/examples/`** — a companion to [`regression/downstream`](../tree/main/regression/downstream) that **RUNS** (not just builds) every in-repo example against tish HEAD and **asserts observable behavior**. A transpile smoke only proves "it parses"; this proves "it works", so a frontend break in a shipped example becomes a red build instead of shipping silently.

## Why

The downstream suite surfaced a real **JSX-lexer regression** ([#108](https://github.com/tishlang/tish/issues/108)) — **now fixed in #111**. Before that fix, after a nested child element a text run was lexed as code, so a reserved keyword in ordinary markup prose failed to parse:

```jsx
<div><span>x</span> as JSON</div>   // ✗ (pre-#111) Parse error: Unexpected token in JSX children: As
<div>download as JSON</div>          // ✓ ok (no preceding element)
```

It hit a real app (`tish-audio`: *"…download as JSON."* after inline `<span>`s) and would have shipped unnoticed. #111 closed that specific hole; **running the examples is the standing guard** that turns the next such regression into a red build.

## What it does

Per example `kind`:

| kind | how it's tested |
|------|-----------------|
| `run` | execute the program, assert a **stdout** substring |
| `serve` | start the HTTP server, **probe it over HTTP**, assert the response, tear it down (relocates `$PORT`-honoring servers to a free port; skips a hardcoded port held by a foreign process) |
| `lattish` | build to JS with the **workspace lattish** wired in, **mount in jsdom**, assert the **rendered DOM** — a real runtime test that catches mount-time throws and empty renders a build never would |

Env-gated rows (`net/db/gpu/wasm/npm/prebuild/slow`) **SKIP** by default and run under `--full`. The interactive `examples/tty` raw-mode demo (shipped with #101/#105) is a documented exclusion — it reads live keypresses with no deterministic headless stdout to assert.

## Files

- `regression/examples/run.sh` — runner (builds HEAD tish, copies each example to scratch, wires workspace lattish for lattish apps)
- `regression/examples/examples.tsv` — manifest of the runnable examples (+ the documented `tty` exclusion)
- `regression/examples/lattish-render.mjs` — jsdom mount-and-assert harness
- `regression/examples/README.md` — docs + findings (the #108 motivation, native-vs-frontend split, per-example calibration notes)

## Result — re-verified on `main` after #105–#111 landed

```
PASS (19)   6 run · 4 serve · 9 lattish
FAIL (0)
SKIP (11)   3 port-conflict (a local :3000 server) · 8 env-gated
```

No frontend regressions — every example parses, transpiles, and behaves; none of the recently-merged fixes (#105–#111) moved an assertion. The 9 lattish examples rendering green also exercises the `createRoot(container, host)` pluggable-host path (lattish #4) end-to-end.

## Run it

```bash
regression/examples/run.sh            # deterministic core; env-gated rows SKIP
regression/examples/run.sh --full     # also net/db/gpu/wasm/npm/prebuild/slow
regression/examples/run.sh --list     # print the manifest
```
