### PR TITLE
fix(vm): computed member read of a missing key returns null (#113)

### DIFF
--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -3416,12 +3416,9 @@ fn get_index(obj: &Value, idx: &Value) -> Result<Value, String> {
                 None => Err("Index out of bounds".to_string()),
             }
         }
-        Value::Object(_) => object_get(obj, idx).ok_or_else(|| {
-            format!(
-                "Property '{}' not found",
-                idx.to_display_string()
-            )
-        }),
+        // A missing own property returns `null`, not a thrown error — matching dot reads
+        // (#66) and JS object semantics. Keeps `obj[key]` and `obj.key` in lockstep (#113).
+        Value::Object(_) => Ok(object_get(obj, idx).unwrap_or(Value::Null)),
         #[cfg(any(feature = "http", feature = "promise"))]
         Value::Promise(_) => {
             let key_arc: std::sync::Arc<str> = match idx {

--- a/tests/core/missing_property.tish
+++ b/tests/core/missing_property.tish
@@ -9,6 +9,16 @@ console.log(r)
 let o2 = { x: { y: 5 } }
 console.log(o2.x.y)
 console.log(!o2.x.z)
+// Computed (bracket) reads of a missing key must behave identically to dot reads (issue #113):
+// a literal computed key, a variable key, and a nested one all return nullish, never throw.
+let k = "b"
+console.log(!o[k])
+console.log(!o["b"])
+console.log(!o2["x"]["z"])
+let m = {}
+let g = m["nope"] ? "has" : "missing"
+console.log(g)
 // merely reading a missing property must not throw — reaching this line proves it
 let probe = o.nope
+let probe2 = o["nope"]
 console.log("done")

--- a/tests/core/missing_property.tish.expected
+++ b/tests/core/missing_property.tish.expected
@@ -3,4 +3,8 @@ true
 missing
 5
 true
+true
+true
+true
+missing
 done


### PR DESCRIPTION
## Summary

`#66` made a missing **dot** property read return `null` (`get_member`), but the **computed/bracket** path (`get_index`, `crates/tish_vm/src/vm.rs`) still threw on a missing `Object` key. So the two disagreed on the VM/interpreter:

```js
let o = { a: 1 }
!o.b        // -> true   (dot, null per #66)
!o["b"]     // -> Uncaught TypeError: Property 'b' not found   (computed, threw)
let m = {}, k = "x"
m[k] === undefined   // -> threw instead of true
```

This brings the bracket path in line with dot reads and JS object semantics: a missing own property is `null`, not an error.

```rust
// get_index, Value::Object arm
-Value::Object(_) => object_get(obj, idx).ok_or_else(|| format!("Property '{}' not found", idx.to_display_string())),
+Value::Object(_) => Ok(object_get(obj, idx).unwrap_or(Value::Null)),
```

## Why it matters

It restores the everyday map idioms `if (!m[k])`, `m[k] === undefined`, and `let v = m[id]` (variable key) under the VM. The JS target already returned `undefined`, so this was a backend inconsistency: `scii` (run via `tish run`) failed on `users[id]` / `reactions[postId]` / `seen[id]` despite passing when compiled to JS.

## Test plan (TDD)

- Extended `tests/core/missing_property.tish` to cover computed access (literal key `o["b"]`, variable key `o[k]`, nested `o2["x"]["z"]`, ternary on `m["nope"]`). Confirmed **RED** before the fix (threw at the first `o[k]`), **GREEN** after, matching `.expected` exactly on **both** the interpreter and the JS backend.
- All `tests/core/*.tish` pass vs `.expected` (the only diffs are the timing numbers in the `*_stress`/benchmark fixtures — behaviorally identical).
- Downstream: the `scii` app's full suite (14 files / 118 cases) goes from 2 failures to **all green** against the fixed VM.

Closes #113