### PR TITLE
ci(release): build, pack & upload tish-format and tish-lint npm tarballs

### DIFF
--- a/.github/workflows/build-npm-binaries.yml
+++ b/.github/workflows/build-npm-binaries.yml
@@ -340,6 +340,8 @@ jobs:
         run: |
           cargo build --release -p tishlang --target ${{ matrix.target }} --features full
           cargo build --release -p tishlang_cargo_bindgen --target ${{ matrix.target }}
+          cargo build --release -p tishlang_fmt --target ${{ matrix.target }}
+          cargo build --release -p tishlang_lint --target ${{ matrix.target }}
 
       - name: Install cross and build (Linux ARM64)
         if: ${{ matrix.use_cross }}
@@ -347,6 +349,8 @@ jobs:
           cargo install cross
           cross build --target ${{ matrix.target }} -p tishlang --release --features full
           cross build --target ${{ matrix.target }} -p tishlang_cargo_bindgen --release
+          cross build --target ${{ matrix.target }} -p tishlang_fmt --release
+          cross build --target ${{ matrix.target }} -p tishlang_lint --release
 
       - name: Stage binary for upload
         shell: bash
@@ -364,6 +368,18 @@ jobs:
             cp "target/${{ matrix.target }}/release/tishlang-cargo-bindgen" "staging/tish-bindgen"
           fi
 
+      - name: Stage tish-fmt / tish-lint binaries for upload
+        shell: bash
+        run: |
+          mkdir -p staging
+          if [ "${{ matrix.platform }}" = "win32-x64" ]; then
+            cp "target/${{ matrix.target }}/release/tish-fmt.exe"  "staging/tish-fmt.exe"
+            cp "target/${{ matrix.target }}/release/tish-lint.exe" "staging/tish-lint.exe"
+          else
+            cp "target/${{ matrix.target }}/release/tish-fmt"  "staging/tish-fmt"
+            cp "target/${{ matrix.target }}/release/tish-lint" "staging/tish-lint"
+          fi
+
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
@@ -375,6 +391,18 @@ jobs:
         with:
           name: bindgen-${{ matrix.platform }}
           path: staging/tish-bindgen*
+
+      - name: Upload tish-fmt binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: fmt-${{ matrix.platform }}
+          path: staging/tish-fmt*
+
+      - name: Upload tish-lint binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-${{ matrix.platform }}
+          path: staging/tish-lint*
 
   release:
     name: Release (prerelease branch + GitHub API)
@@ -431,6 +459,21 @@ jobs:
           chmod +x npm/cargo-bindgen/platform/linux-arm64/tish-bindgen
           chmod +x npm/cargo-bindgen/platform/darwin-arm64/tish-bindgen
           chmod +x npm/cargo-bindgen/platform/darwin-x64/tish-bindgen
+
+          # dir:artifactPrefix:binary — mirror the tish/cargo-bindgen layout for the two wrapper packages
+          for entry in tish-format:fmt:tish-fmt tish-lint:lint:tish-lint; do
+            dir="${entry%%:*}"; rest="${entry#*:}"; pref="${rest%%:*}"; bin="${rest##*:}"
+            for plat in darwin-arm64 darwin-x64 linux-x64 linux-arm64 win32-x64; do
+              mkdir -p "npm/$dir/platform/$plat"
+            done
+            cp "artifacts/$pref-linux-x64/$bin"      "npm/$dir/platform/linux-x64/$bin"
+            cp "artifacts/$pref-linux-arm64/$bin"    "npm/$dir/platform/linux-arm64/$bin"
+            cp "artifacts/$pref-darwin-arm64/$bin"   "npm/$dir/platform/darwin-arm64/$bin"
+            cp "artifacts/$pref-darwin-x64/$bin"     "npm/$dir/platform/darwin-x64/$bin"
+            cp "artifacts/$pref-win32-x64/$bin.exe"  "npm/$dir/platform/win32-x64/$bin.exe"
+            chmod +x "npm/$dir/platform/linux-x64/$bin" "npm/$dir/platform/linux-arm64/$bin" \
+                     "npm/$dir/platform/darwin-arm64/$bin" "npm/$dir/platform/darwin-x64/$bin"
+          done
 
       - name: Create platform binaries zip
         run: |
@@ -492,6 +535,21 @@ jobs:
         env:
           VERSION: ${{ steps.next_version.outputs.version }}
 
+      - name: Set @tishlang/tish-format + @tishlang/tish-lint package versions for npm pack
+        if: steps.next_version.outputs.published == 'true'
+        run: |
+          for dir in tish-format tish-lint; do
+            node -e "
+            const fs = require('fs');
+            const f = './npm/$dir/package.json';
+            const p = require(f);
+            p.version = process.env.VERSION;
+            fs.writeFileSync(f, JSON.stringify(p, null, 2));
+            "
+          done
+        env:
+          VERSION: ${{ steps.next_version.outputs.version }}
+
       - name: Copy workspace source for native compile (rust backend)
         if: steps.next_version.outputs.published == 'true'
         run: |
@@ -501,6 +559,20 @@ jobs:
           cp -r crates npm/tish/
           sed -i.bak "s/^version = .*/version = \"${{ steps.next_version.outputs.version }}\"/" npm/tish/crates/tish/Cargo.toml
           rm -f npm/tish/crates/tish/Cargo.toml.bak
+
+      - name: Copy workspace source into tish-format / tish-lint (source-build fallback)
+        if: steps.next_version.outputs.published == 'true'
+        run: |
+          # dir:crate — each wrapper bundles the workspace so `postinstall` can cargo-build its bin if no prebuilt platform binary fits
+          for entry in tish-format:tish_fmt tish-lint:tish_lint; do
+            dir="${entry%%:*}"; crate="${entry##*:}"
+            cp Cargo.toml "npm/$dir/"
+            cp LICENSE "npm/$dir/"
+            cp justfile "npm/$dir/"
+            cp -r crates "npm/$dir/"
+            sed -i.bak "s/^version = .*/version = \"${{ steps.next_version.outputs.version }}\"/" "npm/$dir/crates/$crate/Cargo.toml"
+            rm -f "npm/$dir/crates/$crate/Cargo.toml.bak"
+          done
 
       - name: Create npm package tarball
         if: steps.next_version.outputs.published == 'true'
@@ -519,6 +591,18 @@ jobs:
           node npm/cargo-bindgen/scripts/install-bin.js
           cd npm/cargo-bindgen && npm pack && cd ../..
           mv npm/cargo-bindgen/tishlang-cargo-bindgen-*.tgz cargo-bindgen-npm-package.tgz
+
+      - name: Create @tishlang/tish-format + @tishlang/tish-lint npm package tarballs
+        if: steps.next_version.outputs.published == 'true'
+        env:
+          TISH_NPM_PACK_REQUIRE: "1"
+        run: |
+          node npm/tish-format/scripts/install-bin.js
+          cd npm/tish-format && npm pack && cd ../..
+          mv npm/tish-format/tishlang-tish-format-*.tgz tish-format-npm-package.tgz
+          node npm/tish-lint/scripts/install-bin.js
+          cd npm/tish-lint && npm pack && cd ../..
+          mv npm/tish-lint/tishlang-tish-lint-*.tgz tish-lint-npm-package.tgz
 
       - name: Create or update release branch and push
         if: steps.next_version.outputs.published == 'true'
@@ -631,3 +715,5 @@ jobs:
           upload_asset npm/tish/tish-platform-binaries.zip "tish-platform-binaries.zip" "Platform binaries (all OS)" "application/zip"
           upload_asset tish-npm-package.tgz "tish-npm-package.tgz" "npm package (publish with: npm publish)" "application/octet-stream"
           upload_asset cargo-bindgen-npm-package.tgz "cargo-bindgen-npm-package.tgz" "npm @tishlang/cargo-bindgen (publish with: npm publish)" "application/octet-stream"
+          upload_asset tish-format-npm-package.tgz "tish-format-npm-package.tgz" "npm @tishlang/tish-format (publish with: npm publish)" "application/octet-stream"
+          upload_asset tish-lint-npm-package.tgz "tish-lint-npm-package.tgz" "npm @tishlang/tish-lint (publish with: npm publish)" "application/octet-stream"

--- a/crates/tish_fmt/src/lib.rs
+++ b/crates/tish_fmt/src/lib.rs
@@ -1239,6 +1239,10 @@ impl Printer {
                 self.buf.push_str("typeof ");
                 self.child(operand, PREC_POSTFIX);
             }
+            Expr::Delete { target, .. } => {
+                self.buf.push_str("delete ");
+                self.child(target, PREC_POSTFIX);
+            }
             Expr::PostfixInc { name, .. } => {
                 self.buf.push_str(name.as_ref());
                 self.buf.push_str("++");
@@ -1519,6 +1523,7 @@ fn expr_prec(e: &Expr) -> u8 {
         Expr::Binary { op, .. } => binop_prec(*op),
         Expr::Unary { .. }
         | Expr::TypeOf { .. }
+        | Expr::Delete { .. }
         | Expr::Await { .. }
         | Expr::PrefixInc { .. }
         | Expr::PrefixDec { .. } => 14,
@@ -2135,5 +2140,18 @@ let x = add(1, 2)
 ";
         let out = format_source(src).unwrap();
         assert_eq!(out, src, "{out:?}");
+    }
+
+    #[test]
+    fn formats_delete_expression() {
+        // Regression: Expr::Delete (the `delete` operator) must be handled by the formatter —
+        // a non-exhaustive `match` here broke the `tish-format` build once the delete feature landed.
+        let src = "fn f(o, k) {\ndelete o.a\ndelete o[\"b\"]\nlet x = delete o[k]\nreturn x\n}\n";
+        let out = format_source(src).unwrap();
+        assert!(out.contains("delete o.a"), "{out}");
+        assert!(out.contains("delete o[\"b\"]"), "{out}");
+        assert!(out.contains("delete o[k]"), "{out}");
+        tishlang_parser::parse(&out).unwrap();
+        assert_eq!(format_source(&out).unwrap(), out, "not idempotent:\n{out}");
     }
 }


### PR DESCRIPTION
## Problem

The `npm-release.yml` publisher has a **4-package tarball matrix** — `tish`, `cargo-bindgen`, **`tish-format`**, **`tish-lint`** — and each tarball job downloads a pre-built `<pkg>-npm-package.tgz` **release asset** and `npm publish`es it. But `build-npm-binaries.yml` only built/packed/uploaded **two** of them (`tish`, `cargo-bindgen`).

So `@tishlang/tish-format` and `@tishlang/tish-lint` never had a release asset, and their publish jobs have failed on **every** release:

```
Release has no asset tish-format-npm-package.tgz
##[error]Process completed with exit code 1.
```

(seen on the v1.13.1, v1.13.2, and v2.0.0 release runs). The other 5 jobs are green because `tish`/`cargo-bindgen` have assets and `pg`/`create-tish-app` publish from source / skip-if-already-published.

## Fix

Mirror the `tish` pipeline for both wrapper packages (they're binary-backed: crate `tishlang_fmt` → `tish-fmt`, crate `tishlang_lint` → `tish-lint`, with a `postinstall` that installs the platform binary or cargo-builds from the bundled workspace):

1. **build** `tishlang_fmt` + `tishlang_lint` for every target (native + cross steps)
2. **stage** the binaries into each package's `platform/<os-arch>/`
3. **set** the package version and **bundle** the workspace source (`Cargo.toml`/`crates`/`justfile`/`LICENSE`) for the postinstall source-build fallback
4. **`npm pack`** each and **`upload_asset`** the two `*-npm-package.tgz` files the publisher expects

## Scope / caveat

- This fixes **future** releases. It does **not** retroactively add assets to the already-built **v2.0.0** — the `tish-format`/`tish-lint` publish jobs there stay red until a re-cut produces the assets. (Per the chosen "wire build only" approach; nothing here publishes to npm.)
- The `build` job runs on this PR and validates that both crates compile + stage on all 5 targets; the packaging/upload steps run only on the `main`-push `release` job (mirrors the proven `tish` steps).