### PR TITLE
ci(crates): publish tishlang_ffi + guard against missing publishable crates

### DIFF
--- a/.github/workflows/crates-release.yml
+++ b/.github/workflows/crates-release.yml
@@ -41,6 +41,7 @@ jobs:
           CRATES=(
             tishlang_build_utils
             tishlang_core
+            tishlang_ffi
             tishlang_ast
             tishlang_resolve
             tishlang_ui
@@ -70,6 +71,17 @@ jobs:
             tishlang_lsp
             tishlang
           )
+          # Drift guard: every publishable workspace crate MUST be listed above. A crate that's added
+          # to the workspace but forgotten here (as tishlang_ffi was) otherwise only surfaces as a
+          # mid-publish "no matching package named '<crate>' found" failure on a dependent. Fail early
+          # and loudly instead. (publish=false crates — e.g. the mathext FFI example — are excluded.)
+          missing=0
+          while IFS= read -r c; do
+            printf '%s\n' "${CRATES[@]}" | grep -qx "$c" \
+              || { echo "::error::publishable crate '$c' is missing from the CRATES list in crates-release.yml"; missing=1; }
+          done < <(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.publish == null or (.publish | length > 0)) | .name')
+          [ "$missing" -eq 0 ] || { echo "Add the crate(s) above to CRATES in dependency order, then re-run."; exit 1; }
+
           for crate in "${CRATES[@]}"; do
             if curl -sSf -o /dev/null -A "tishlang-release/1.0 (https://github.com/tishlang/tish)" "https://crates.io/api/v1/crates/${crate}/${VERSION}"; then
               echo "Skipping $crate v${VERSION} (already published)"


### PR DESCRIPTION
## Problem

The crates.io publish for **v2.0.1** failed:

```
Publishing tishlang v2.0.1...
error: failed to prepare local package for uploading
Caused by:
  no matching package named `tishlang_ffi` found
  required by package `tishlang v2.0.1 (.../crates/tish)`
```

`tishlang_ffi` is a workspace member and a (registry) dependency of `tishlang`, but it was **never in the `CRATES` publish list** in `crates-release.yml` — so it never got pushed to crates.io, and publishing the dependent `tishlang` crate can't resolve it.

## Audit

`cargo metadata` over the workspace: **32 members → 31 publishable** (only `mathext`, the FFI example, is `publish = false`). The publish list had **30** — exactly `tishlang_ffi` was missing. No stale entries; no published crate depends on an unpublishable one.

## Fix

1. **Add `tishlang_ffi`** to `CRATES`, right after `tishlang_core` (its only registry dep). Full ordering re-validated topologically — every crate's registry deps precede it.
2. **Drift guard**: before the publish loop, fail fast if any publishable workspace crate (from `cargo metadata`, excluding `publish=false`) is missing from `CRATES`. Verified locally: passes now, and would have flagged exactly `tishlang_ffi` before this change.

## To complete v2.0.1

`crates-release.yml` runs on `release` events, so after merge: re-trigger it for v2.0.1 (edit the v2.0.1 release, or re-run the failed workflow). Crates already published at 2.0.1 are skipped by the existing `curl` check; it will then publish `tishlang_ffi` and `tishlang`.