### PR TITLE
fix(resolve): handle delete in tish_resolve + build/upload tish-lsp release binaries

### DIFF
--- a/.github/workflows/build-npm-binaries.yml
+++ b/.github/workflows/build-npm-binaries.yml
@@ -342,6 +342,7 @@ jobs:
           cargo build --release -p tishlang_cargo_bindgen --target ${{ matrix.target }}
           cargo build --release -p tishlang_fmt --target ${{ matrix.target }}
           cargo build --release -p tishlang_lint --target ${{ matrix.target }}
+          cargo build --release -p tishlang_lsp --target ${{ matrix.target }}
 
       - name: Install cross and build (Linux ARM64)
         if: ${{ matrix.use_cross }}
@@ -351,6 +352,7 @@ jobs:
           cross build --target ${{ matrix.target }} -p tishlang_cargo_bindgen --release
           cross build --target ${{ matrix.target }} -p tishlang_fmt --release
           cross build --target ${{ matrix.target }} -p tishlang_lint --release
+          cross build --target ${{ matrix.target }} -p tishlang_lsp --release
 
       - name: Stage binary for upload
         shell: bash
@@ -368,16 +370,18 @@ jobs:
             cp "target/${{ matrix.target }}/release/tishlang-cargo-bindgen" "staging/tish-bindgen"
           fi
 
-      - name: Stage tish-fmt / tish-lint binaries for upload
+      - name: Stage tish-fmt / tish-lint / tish-lsp binaries for upload
         shell: bash
         run: |
           mkdir -p staging
           if [ "${{ matrix.platform }}" = "win32-x64" ]; then
             cp "target/${{ matrix.target }}/release/tish-fmt.exe"  "staging/tish-fmt.exe"
             cp "target/${{ matrix.target }}/release/tish-lint.exe" "staging/tish-lint.exe"
+            cp "target/${{ matrix.target }}/release/tish-lsp.exe"  "staging/tish-lsp.exe"
           else
             cp "target/${{ matrix.target }}/release/tish-fmt"  "staging/tish-fmt"
             cp "target/${{ matrix.target }}/release/tish-lint" "staging/tish-lint"
+            cp "target/${{ matrix.target }}/release/tish-lsp"  "staging/tish-lsp"
           fi
 
       - name: Upload binary
@@ -403,6 +407,12 @@ jobs:
         with:
           name: lint-${{ matrix.platform }}
           path: staging/tish-lint*
+
+      - name: Upload tish-lsp binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: lsp-${{ matrix.platform }}
+          path: staging/tish-lsp*
 
   release:
     name: Release (prerelease branch + GitHub API)
@@ -713,6 +723,12 @@ jobs:
           upload_asset npm/cargo-bindgen/platform/darwin-x64/tish-bindgen "tish-bindgen-darwin-x64" "tish-bindgen macOS (Intel)" "application/octet-stream"
           upload_asset npm/cargo-bindgen/platform/win32-x64/tish-bindgen.exe "tish-bindgen-win32-x64.exe" "tish-bindgen Windows (x64)" "application/octet-stream"
           upload_asset npm/tish/tish-platform-binaries.zip "tish-platform-binaries.zip" "Platform binaries (all OS)" "application/zip"
+          # tish-lsp raw binaries — the tish-vscode extension downloads tish-lsp-<platform> from the release.
+          upload_asset artifacts/lsp-linux-x64/tish-lsp        "tish-lsp-linux-x64"      "tish-lsp Linux (x64)"           "application/octet-stream"
+          upload_asset artifacts/lsp-linux-arm64/tish-lsp      "tish-lsp-linux-arm64"    "tish-lsp Linux (ARM64)"         "application/octet-stream"
+          upload_asset artifacts/lsp-darwin-arm64/tish-lsp     "tish-lsp-darwin-arm64"   "tish-lsp macOS (Apple Silicon)" "application/octet-stream"
+          upload_asset artifacts/lsp-darwin-x64/tish-lsp       "tish-lsp-darwin-x64"     "tish-lsp macOS (Intel)"         "application/octet-stream"
+          upload_asset artifacts/lsp-win32-x64/tish-lsp.exe    "tish-lsp-win32-x64.exe"  "tish-lsp Windows (x64)"         "application/octet-stream"
           upload_asset tish-npm-package.tgz "tish-npm-package.tgz" "npm package (publish with: npm publish)" "application/octet-stream"
           upload_asset cargo-bindgen-npm-package.tgz "cargo-bindgen-npm-package.tgz" "npm @tishlang/cargo-bindgen (publish with: npm publish)" "application/octet-stream"
           upload_asset tish-format-npm-package.tgz "tish-format-npm-package.tgz" "npm @tishlang/tish-format (publish with: npm publish)" "application/octet-stream"

--- a/crates/tish_resolve/src/lib.rs
+++ b/crates/tish_resolve/src/lib.rs
@@ -435,6 +435,7 @@ fn collect_expr(
             collect_expr(value, source, lsp_line, lsp_char, best);
         }
         Expr::TypeOf { operand, .. } => collect_expr(operand, source, lsp_line, lsp_char, best),
+        Expr::Delete { target: del, .. } => collect_expr(del, source, lsp_line, lsp_char, best),
         Expr::PostfixInc { name, span } | Expr::PostfixDec { name, span } => {
             let sp = synthetic_name_span(span.start, name.as_ref());
             consider(source, lsp_line, lsp_char, &sp, name.clone(), best);
@@ -694,6 +695,9 @@ fn member_chain_collect_expr(
         }
         Expr::TypeOf { operand, .. } => {
             member_chain_collect_expr(operand, source, lsp_line, lsp_char, best)
+        }
+        Expr::Delete { target: del, .. } => {
+            member_chain_collect_expr(del, source, lsp_line, lsp_char, best)
         }
         Expr::PostfixInc { .. }
         | Expr::PostfixDec { .. }
@@ -1127,6 +1131,7 @@ fn walk_expr_resolve(
             None
         }
         Expr::TypeOf { operand, .. } => walk_expr_resolve(operand, scopes, target),
+        Expr::Delete { target: del, .. } => walk_expr_resolve(del, scopes, target),
         Expr::MemberAssign { object, value, .. } => walk_expr_resolve(object, scopes, target)
             .or_else(|| walk_expr_resolve(value, scopes, target)),
         Expr::IndexAssign {
@@ -1669,6 +1674,7 @@ fn check_unresolved_expr(expr: &Expr, scopes: &ScopeStack, out: &mut Vec<Unresol
             }
         }
         Expr::TypeOf { operand, .. } => check_unresolved_expr(operand, scopes, out),
+        Expr::Delete { target: del, .. } => check_unresolved_expr(del, scopes, out),
         Expr::MemberAssign { object, value, .. } => {
             check_unresolved_expr(object, scopes, out);
             check_unresolved_expr(value, scopes, out);
@@ -2142,6 +2148,7 @@ fn enumerate_expr(expr: &Expr, exported: bool, out: &mut Vec<BindingSite>) {
         | Expr::PrefixInc { .. }
         | Expr::PrefixDec { .. } => {}
         Expr::TypeOf { operand, .. } => enumerate_expr(operand, exported, out),
+        Expr::Delete { target: del, .. } => enumerate_expr(del, exported, out),
         Expr::MemberAssign { object, value, .. } => {
             enumerate_expr(object, exported, out);
             enumerate_expr(value, exported, out);
@@ -2801,6 +2808,9 @@ fn walk_expr_completion(
         Expr::TypeOf { operand, .. } => {
             walk_expr_completion(operand, source, lsp_line, lsp_char, stack, best)
         }
+        Expr::Delete { target: del, .. } => {
+            walk_expr_completion(del, source, lsp_line, lsp_char, stack, best)
+        }
         Expr::MemberAssign { object, value, .. } => {
             walk_expr_completion(object, source, lsp_line, lsp_char, stack, best);
             walk_expr_completion(value, source, lsp_line, lsp_char, stack, best);
@@ -3384,6 +3394,7 @@ fn refs_expr(
             refs_expr(value, program, source, name, def_span, out);
         }
         Expr::TypeOf { operand, .. } => refs_expr(operand, program, source, name, def_span, out),
+        Expr::Delete { target: del, .. } => refs_expr(del, program, source, name, def_span, out),
         Expr::PostfixInc { name: n, span } | Expr::PostfixDec { name: n, span } => {
             let sp = synthetic_name_span(span.start, n.as_ref());
             maybe_push(&sp, n, out);


### PR DESCRIPTION
## Why

The **tish-vscode** extension is pure-LSP: it downloads a prebuilt `tish-lsp-<platform>` binary from this repo's GitHub Releases and runs it as the language server. That one binary provides **both** linting (diagnostics via `tishlang_lint::lint_program`) and formatting (`tishlang_fmt::format_source`) — they're statically linked into `tish_lsp`.

**But no release has ever shipped `tish-lsp`** — `build-npm-binaries.yml` never built or uploaded it. Checked v2.0.1 / v2.0.0 / v1.18.3 / v1.13.1: none carry a `tish-lsp-*` asset. So the extension's language server (and therefore its lint + format) is dead on every version.

## What

Mirror the `tish` raw-binary pipeline for `tishlang_lsp` (bin `tish-lsp`):
- build it for all 5 targets (native + cross),
- stage it, upload a per-platform `lsp-<platform>` artifact,
- upload `tish-lsp-<platform>` (`.exe` on win32) raw-binary assets to the release.

Asset names match the extension's `platformServerId()` exactly: `linux-x64`, `linux-arm64`, `darwin-arm64`, `darwin-x64`, `win32-x64`.

## Follow-up

Once this merges and the next release is cut, that release will carry `tish-lsp-*` assets. The tish-vscode extension then just needs its `tishLsp.releaseTag` pinned to that tag (separate PR in tish-vscode).