### PR TITLE
ci(release): bump every crate version at build time so binaries self-report it

### DIFF
--- a/.github/workflows/build-npm-binaries.yml
+++ b/.github/workflows/build-npm-binaries.yml
@@ -315,13 +315,22 @@ jobs:
       - name: Set Cargo version for binaries
         shell: bash
         run: |
-          # Bump EVERY crate's [package] version, not just crates/tish — so the built binaries
+          VERSION="${{ needs.version.outputs.version }}"
+          # Bump EVERY crate's [package] version (not just crates/tish) so the built binaries
           # (tish, tish-lsp, tish-fmt, tish-lint, ...) report the release version via
-          # env!("CARGO_PKG_VERSION") (e.g. tish-lsp serverInfo.version, used by tish-vscode) instead
-          # of their committed dev version. Each crate Cargo.toml has exactly one top-level `version =`
-          # line, so `^version =` only ever matches the package version. (crates-release.yml does the same.)
-          find crates -name Cargo.toml -exec sed -i.bak "s/^version = .*/version = \"${{ needs.version.outputs.version }}\"/" {} +
-          find crates -name 'Cargo.toml.bak' -delete
+          # env!("CARGO_PKG_VERSION") instead of their committed dev version. ONLY for a real release:
+          # on PRs the version job falls back to crates/tish's committed 0.0.0-dev placeholder, and
+          # bumping every crate to a prerelease (anything with a `-`) violates the 100 inter-crate
+          # `version = ">=0.1"` path-dep requirements (prereleases don't satisfy them) and breaks the
+          # build. Each crate Cargo.toml has exactly one top-level `version =` line.
+          case "$VERSION" in
+            "" | *-*)
+              echo "Dev/prerelease version ('$VERSION') — leaving committed crate versions (PR/dev build)." ;;
+            *)
+              find crates -name Cargo.toml -exec sed -i.bak "s/^version = .*/version = \"$VERSION\"/" {} +
+              find crates -name 'Cargo.toml.bak' -delete
+              echo "Bumped all crate versions to $VERSION." ;;
+          esac
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9

--- a/.github/workflows/build-npm-binaries.yml
+++ b/.github/workflows/build-npm-binaries.yml
@@ -312,11 +312,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set Cargo version for binary
+      - name: Set Cargo version for binaries
         shell: bash
         run: |
-          sed -i.bak "s/^version = .*/version = \"${{ needs.version.outputs.version }}\"/" crates/tish/Cargo.toml
-          rm -f crates/tish/Cargo.toml.bak
+          # Bump EVERY crate's [package] version, not just crates/tish — so the built binaries
+          # (tish, tish-lsp, tish-fmt, tish-lint, ...) report the release version via
+          # env!("CARGO_PKG_VERSION") (e.g. tish-lsp serverInfo.version, used by tish-vscode) instead
+          # of their committed dev version. Each crate Cargo.toml has exactly one top-level `version =`
+          # line, so `^version =` only ever matches the package version. (crates-release.yml does the same.)
+          find crates -name Cargo.toml -exec sed -i.bak "s/^version = .*/version = \"${{ needs.version.outputs.version }}\"/" {} +
+          find crates -name 'Cargo.toml.bak' -delete
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9


### PR DESCRIPTION
## Problem

The `tish-lsp` binary in **v2.0.3** reports `serverInfo.version: "0.1.1"` instead of `2.0.3`. `tish_lsp` sets it via `env!("CARGO_PKG_VERSION")`, but the build job's version-bump step only seds `crates/tish/Cargo.toml`. So every *other* binary built from the workspace (`tish-lsp`, `tish-fmt`, `tish-lint`) embeds its committed dev version.

## Fix

Bump **every** `crates/*/Cargo.toml` `[package] version` at build time (mirroring what `crates-release.yml` already does for publishing), so the released binaries self-report the release version.

Verified safe: every crate `Cargo.toml` has exactly one top-level `version =` line (no `[dependencies.x]` tables), so `s/^version = .*/…/` only ever rewrites the package version — dry-run on a copy bumped all 33 crate Cargo.tomls and changed no dependency lines.

Cosmetic (the tish-vscode extension pins by release tag, not `serverInfo`), but it makes `tish-lsp`/`tish-fmt`/`tish-lint` report the right version. Lands on the next release.