### PR TITLE
feat(npm): publish @tishlang/tish-lsp — a pinnable language-server package

### DIFF
--- a/.github/workflows/build-npm-binaries.yml
+++ b/.github/workflows/build-npm-binaries.yml
@@ -471,7 +471,7 @@ jobs:
           chmod +x npm/cargo-bindgen/platform/darwin-x64/tish-bindgen
 
           # dir:artifactPrefix:binary — mirror the tish/cargo-bindgen layout for the two wrapper packages
-          for entry in tish-format:fmt:tish-fmt tish-lint:lint:tish-lint; do
+          for entry in tish-format:fmt:tish-fmt tish-lint:lint:tish-lint tish-lsp:lsp:tish-lsp; do
             dir="${entry%%:*}"; rest="${entry#*:}"; pref="${rest%%:*}"; bin="${rest##*:}"
             for plat in darwin-arm64 darwin-x64 linux-x64 linux-arm64 win32-x64; do
               mkdir -p "npm/$dir/platform/$plat"
@@ -548,7 +548,7 @@ jobs:
       - name: Set @tishlang/tish-format + @tishlang/tish-lint package versions for npm pack
         if: steps.next_version.outputs.published == 'true'
         run: |
-          for dir in tish-format tish-lint; do
+          for dir in tish-format tish-lint tish-lsp; do
             node -e "
             const fs = require('fs');
             const f = './npm/$dir/package.json';
@@ -574,7 +574,7 @@ jobs:
         if: steps.next_version.outputs.published == 'true'
         run: |
           # dir:crate — each wrapper bundles the workspace so `postinstall` can cargo-build its bin if no prebuilt platform binary fits
-          for entry in tish-format:tish_fmt tish-lint:tish_lint; do
+          for entry in tish-format:tish_fmt tish-lint:tish_lint tish-lsp:tish_lsp; do
             dir="${entry%%:*}"; crate="${entry##*:}"
             cp Cargo.toml "npm/$dir/"
             cp LICENSE "npm/$dir/"
@@ -602,11 +602,14 @@ jobs:
           cd npm/cargo-bindgen && npm pack && cd ../..
           mv npm/cargo-bindgen/tishlang-cargo-bindgen-*.tgz cargo-bindgen-npm-package.tgz
 
-      - name: Create @tishlang/tish-format + @tishlang/tish-lint npm package tarballs
+      - name: Create @tishlang/tish-format + @tishlang/tish-lint + @tishlang/tish-lsp npm package tarballs
         if: steps.next_version.outputs.published == 'true'
         env:
           TISH_NPM_PACK_REQUIRE: "1"
         run: |
+          node npm/tish-lsp/scripts/install-bin.js
+          cd npm/tish-lsp && npm pack && cd ../..
+          mv npm/tish-lsp/tishlang-tish-lsp-*.tgz tish-lsp-npm-package.tgz
           node npm/tish-format/scripts/install-bin.js
           cd npm/tish-format && npm pack && cd ../..
           mv npm/tish-format/tishlang-tish-format-*.tgz tish-format-npm-package.tgz
@@ -733,3 +736,4 @@ jobs:
           upload_asset cargo-bindgen-npm-package.tgz "cargo-bindgen-npm-package.tgz" "npm @tishlang/cargo-bindgen (publish with: npm publish)" "application/octet-stream"
           upload_asset tish-format-npm-package.tgz "tish-format-npm-package.tgz" "npm @tishlang/tish-format (publish with: npm publish)" "application/octet-stream"
           upload_asset tish-lint-npm-package.tgz "tish-lint-npm-package.tgz" "npm @tishlang/tish-lint (publish with: npm publish)" "application/octet-stream"
+          upload_asset tish-lsp-npm-package.tgz "tish-lsp-npm-package.tgz" "npm @tishlang/tish-lsp (publish with: npm publish)" "application/octet-stream"

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -56,6 +56,10 @@ jobs:
             npm: "@tishlang/tish-lint"
             type: tarball
             asset: tish-lint-npm-package.tgz
+          - label: "@tishlang/tish-lsp"
+            npm: "@tishlang/tish-lsp"
+            type: tarball
+            asset: tish-lsp-npm-package.tgz
           # Source packages: publish straight from the npm/<dir> source tree.
           - label: "@tishlang/pg"
             npm: "@tishlang/pg"

--- a/npm/tish-lsp/README.md
+++ b/npm/tish-lsp/README.md
@@ -1,0 +1,18 @@
+# @tishlang/tish-lsp
+
+The [Tish](https://github.com/tishlang/tish) language server (`tish-lsp`) as an npm package — prebuilt native binaries for macOS/Linux/Windows, with a cargo source-build fallback.
+
+It speaks LSP over stdio and provides diagnostics (`tishlang_lint`), formatting (`tishlang_fmt`), completion, hover, go-to-definition, references, and rename.
+
+```sh
+npm i @tishlang/tish-lsp        # installs the prebuilt tish-lsp for your platform
+```
+
+Pin a specific version the same way you pin `@tishlang/tish`:
+
+```jsonc
+// package.json
+"dependencies": { "@tishlang/tish-lsp": "2.0.3" }
+```
+
+The `tish-lsp` binary is exposed on `bin`, and the per-platform binaries live under `platform/<os>-<arch>/`.

--- a/npm/tish-lsp/package.json
+++ b/npm/tish-lsp/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@tishlang/tish-lsp",
+  "version": "1.0.12",
+  "description": "Tish language server — diagnostics, completion, formatting, hover, go-to-definition (LSP over stdio)",
+  "license": "PIF",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tishlang/tish.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": {
+    "tish-lsp": "./bin/tish-lsp"
+  },
+  "scripts": {
+    "postinstall": "node scripts/install-bin.js"
+  },
+  "files": [
+    "bin",
+    "scripts/install-bin.js",
+    "platform",
+    "README.md",
+    "LICENSE",
+    "Cargo.toml",
+    "crates",
+    "justfile"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "keywords": [
+    "tish",
+    "lsp",
+    "language-server"
+  ]
+}

--- a/npm/tish-lsp/scripts/install-bin.js
+++ b/npm/tish-lsp/scripts/install-bin.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Copy platform/<os>-<arch>/tish-lsp to bin/tish-lsp so the npm bin is the native binary.
+ * If not found, attempts to build it from source using cargo.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const platformKey = `${process.platform}-${process.arch}`;
+const binaryName = process.platform === 'win32' ? 'tish-lsp.exe' : 'tish-lsp';
+const crateName = 'tishlang_lsp';
+
+const root = path.join(__dirname, '..');
+const src = path.join(root, 'platform', platformKey, binaryName);
+const dest = path.join(root, 'bin', 'tish-lsp');
+
+fs.mkdirSync(path.dirname(dest), { recursive: true });
+
+if (!fs.existsSync(src)) {
+  if (process.env.TISH_NPM_PACK_REQUIRE === '1') {
+    console.error(`[tish-lsp] No prebuilt binary for this platform: ${platformKey}`);
+    console.error(`[tish-lsp] Expected: ${src}`);
+    process.exit(1);
+  }
+
+  console.warn(`[tish-lsp] No prebuilt binary for ${platformKey} found at: ${src}`);
+  console.warn(`[tish-lsp] Attempting to build from source via cargo...`);
+  try {
+    execSync(`cargo build --release -p ${crateName} --target-dir target`, { stdio: 'inherit', cwd: root });
+    const builtSrc = path.join(root, 'target', 'release', binaryName);
+    if (!fs.existsSync(builtSrc)) {
+      throw new Error(`Expected built binary at ${builtSrc}`);
+    }
+    fs.copyFileSync(builtSrc, dest);
+    console.log(`[tish-lsp] Successfully built from source.`);
+  } catch (err) {
+    console.error(`[tish-lsp] Failed to build from source.`);
+    console.error(`[tish-lsp] Make sure Rust and Cargo are installed (https://rustup.rs/).`);
+    console.error(err);
+    process.exit(1);
+  }
+} else {
+  fs.copyFileSync(src, dest);
+}
+
+try {
+  fs.chmodSync(dest, 0o755);
+} catch (_) {
+  /* Windows may ignore chmod */
+}


### PR DESCRIPTION
## Why

So every repo can **pin its own `tish-lsp` version**, exactly the way they pin `@tishlang/tish` — `tish-lsp` should be a first-class published npm package, not only raw GitHub-release binaries.

Currently `@tishlang/tish` / `tish-format` / `tish-lint` are published npm packages, but `tish-lsp` is only raw `tish-lsp-<platform>` assets (added in #117). This makes it a proper package too.

## What

- **`npm/tish-lsp/`** — `package.json` (`@tishlang/tish-lsp`, bin `tish-lsp`), `scripts/install-bin.js`, README — a near-exact mirror of `npm/tish-format`: prebuilt platform binaries with a cargo source-build fallback.
- **`build-npm-binaries.yml`** — `tish-lsp` added to the existing fmt/lint loops (stage into `npm/tish-lsp/platform/<plat>`, set version, bundle workspace source, `npm pack`, `upload_asset tish-lsp-npm-package.tgz`). The `tishlang_lsp` binary is already built per-target (#117), so this only adds packaging.
- **`npm-release.yml`** — `@tishlang/tish-lsp` added to the tarball publish matrix.

## Consumption

```jsonc
// any repo's package.json — pin like @tishlang/tish
"devDependencies": { "@tishlang/tish-lsp": "2.0.3" }
```

The tish-vscode extension (separate PR) will depend on this and extract the per-platform binary into its platform-specific `.vsix`.

## Verified

`npm pack` locally → `tishlang-tish-lsp-*.tgz` containing `bin/tish-lsp` + the platform binary; `install-bin.js` (with `TISH_NPM_PACK_REQUIRE=1`) populates `bin/tish-lsp` from the staged platform binary. Both workflows are valid YAML.

Lands on the next release (publishes `@tishlang/tish-lsp@<version>`).