### PR TITLE
feat(fs): add readFileBytes for binary file reads (#120)

### DIFF
--- a/crates/tish/tests/fixtures/read_file_bytes.tish
+++ b/crates/tish/tests/fixtures/read_file_bytes.tish
@@ -1,0 +1,10 @@
+// Fixture for issue #120: read a binary file as a byte array via tish:fs.readFileBytes.
+// The test points RFB_FIXTURE at a file containing non-UTF-8 bytes (NUL, 0xFF, …).
+import { readFileBytes } from "tish:fs"
+import { process } from "tish:process"
+
+let path = process.env.RFB_FIXTURE
+let b = readFileBytes(path)
+console.log("isArray:" + String(Array.isArray(b)))
+console.log("len:" + String(b.length))
+console.log("bytes:" + b.join(","))

--- a/crates/tish/tests/fs_read_file_bytes.rs
+++ b/crates/tish/tests/fs_read_file_bytes.rs
@@ -1,0 +1,45 @@
+//! Issue #120: `tish:fs.readFileBytes` reads a binary file as an array of byte values (0–255)
+//! on every backend, where the UTF-8-only `readFile` cannot. Verifies the exact bytes,
+//! including a NUL and 0xFF (not valid UTF-8).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+const EXPECTED: &str = "\
+isArray:true
+len:7
+bytes:0,1,2,255,128,72,73
+";
+
+fn run(backend: &str, fixture: &str, data_path: &str) -> String {
+    let tish = PathBuf::from(env!("CARGO_BIN_EXE_tish"));
+    let out = Command::new(&tish)
+        .args(["run", "--backend", backend, "--feature", "fs,process", fixture])
+        .env("RFB_FIXTURE", data_path)
+        .output()
+        .expect("spawn tish run");
+    assert!(
+        out.status.success(),
+        "tish run --backend {backend} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn read_file_bytes_reads_binary_on_every_backend() {
+    // A file whose bytes are not valid UTF-8 (NUL, 0xFF, 0x80) — readFile would error on it.
+    let data_path = std::env::temp_dir().join("tish_rfb_fixture.dat");
+    std::fs::write(&data_path, [0u8, 1, 2, 255, 128, 72, 73]).expect("write fixture");
+    let data_path = data_path.to_str().unwrap();
+
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("read_file_bytes.tish");
+    assert!(fixture.is_file(), "missing fixture {}", fixture.display());
+    let fixture = fixture.to_str().unwrap();
+
+    assert_eq!(run("vm", fixture, data_path), EXPECTED, "vm output mismatch");
+    assert_eq!(run("interp", fixture, data_path), EXPECTED, "interp output mismatch");
+}

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1094,6 +1094,7 @@ impl Codegen {
                     "fileExists" => Some("Value::native(|args: &[Value]| tish_file_exists(args))"),
                     "isDir" => Some("Value::native(|args: &[Value]| tish_is_dir(args))"),
                     "readDir" => Some("Value::native(|args: &[Value]| tish_read_dir(args))"),
+                    "readFileBytes" => Some("Value::native(|args: &[Value]| tish_read_file_bytes(args))"),
                     "mkdir" => Some("Value::native(|args: &[Value]| tish_mkdir(args))"),
                     _ => None,
                 },
@@ -1455,7 +1456,7 @@ impl Codegen {
             }
         }
         if self.has_feature("fs") {
-            self.write("use tishlang_runtime::{read_file as tish_read_file, write_file as tish_write_file, file_exists as tish_file_exists, is_dir as tish_is_dir, read_dir as tish_read_dir, mkdir as tish_mkdir};\n");
+            self.write("use tishlang_runtime::{read_file as tish_read_file, read_file_bytes as tish_read_file_bytes, write_file as tish_write_file, file_exists as tish_file_exists, is_dir as tish_is_dir, read_dir as tish_read_dir, mkdir as tish_mkdir};\n");
         }
         if self.has_feature("ws") {
             self.write("use tishlang_runtime::{web_socket_client as tish_ws_client, web_socket_server_construct as tish_ws_server_construct};\n");

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -916,6 +916,10 @@ impl Evaluator {
                     exports.insert("fileExists".into(), Value::Native(natives::file_exists));
                     exports.insert("isDir".into(), Value::Native(natives::is_dir));
                     exports.insert("readDir".into(), Value::Native(natives::read_dir));
+                    exports.insert(
+                        "readFileBytes".into(),
+                        Value::Native(natives::read_file_bytes),
+                    );
                     exports.insert("mkdir".into(), Value::Native(natives::mkdir));
                     Ok(Value::object(exports))
                 }

--- a/crates/tish_eval/src/natives.rs
+++ b/crates/tish_eval/src/natives.rs
@@ -420,6 +420,22 @@ pub fn read_file(args: &[Value]) -> Result<Value, String> {
     }
 }
 
+/// Read a file as raw bytes (array of numbers 0–255) for binary data that `read_file`
+/// (UTF-8 only) can't handle. See issue #120.
+#[cfg(feature = "fs")]
+pub fn read_file_bytes(args: &[Value]) -> Result<Value, String> {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    let path = args.first().map(|v| v.to_string()).unwrap_or_default();
+    match std::fs::read(&path) {
+        Ok(bytes) => {
+            let items: Vec<Value> = bytes.into_iter().map(|b| Value::Number(b as f64)).collect();
+            Ok(Value::Array(Rc::new(RefCell::new(items))))
+        }
+        Err(e) => Ok(Value::String(format!("Error: {}", e).into())),
+    }
+}
+
 #[cfg(feature = "fs")]
 pub fn write_file(args: &[Value]) -> Result<Value, String> {
     let path = args.first().map(|v| v.to_string()).unwrap_or_default();

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -666,6 +666,23 @@ pub fn read_file(args: &[Value]) -> Value {
     }
 }
 
+/// Read a file as raw bytes — an array of numbers 0–255 — for binary data that `read_file`
+/// (UTF-8 only) can't handle (images, fonts, archives). Lets pure-Tish decoders work on local
+/// files. See issue #120.
+#[cfg(feature = "fs")]
+pub fn read_file_bytes(args: &[Value]) -> Value {
+    let path = args
+        .first()
+        .map(|v| v.to_display_string())
+        .unwrap_or_default();
+    match std::fs::read(&path) {
+        Ok(bytes) => Value::Array(VmRef::new(
+            bytes.into_iter().map(|b| Value::Number(b as f64)).collect(),
+        )),
+        Err(e) => make_error_value(e),
+    }
+}
+
 #[cfg(feature = "fs")]
 pub fn write_file(args: &[Value]) -> Value {
     let path = args

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -169,6 +169,9 @@ fn get_builtin_export(enabled: &HashSet<String>, spec: &str, export_name: &str) 
             "mkdir" => Some(Value::native(|args: &[Value]| {
                 tishlang_runtime::mkdir(args)
             })),
+            "readFileBytes" => Some(Value::native(|args: &[Value]| {
+                tishlang_runtime::read_file_bytes(args)
+            })),
             _ => None,
         };
     }


### PR DESCRIPTION
Closes #120.

## Problem

`tish:fs.readFile` uses `std::fs::read_to_string`, so it **errors on any non-UTF-8 file**, and there's no fd/buffer API (`open`/`read`/`close` don't exist). So a pure-Tish program can't get the bytes of an image, font, or archive off disk.

## Change

Adds **`tish:fs.readFileBytes(path)`** → an array of byte values `0–255` (or an error value on failure), mirroring `readDir`'s `Value::Array` return:

```js
import { readFileBytes } from "tish:fs"
let bytes = readFileBytes("photo.png")   // [137, 80, 78, 71, 13, 10, 26, 10, …]
```

Whole-file rather than an fd/`Buffer` API — callers decode the whole file in memory anyway, and a number array drops straight into pure-Tish decoders (no buffer glue).

### Registered on every backend that exposes `readFile`
- `tishlang_runtime::read_file_bytes` — used by the **bytecode VM** (`tish run`) and the **JS codegen** (with the `read_file as tish_read_file` use-alias extended)
- the **`tish_eval` interpreter** (`natives::read_file_bytes` + export)

## Test plan

`crates/tish/tests/fs_read_file_bytes.rs` writes a fixture containing `NUL`, `0xFF`, `0x80` (not valid UTF-8) and asserts the exact decoded bytes on **both** the `vm` and `interp` backends.

Verified end-to-end downstream: the `scii` app reads a PNG file from disk via `readFileBytes` and decodes it with its pure-Tish PNG decoder (inflate + unfilter) → ASCII, with zero native/runtime dependency.