### PR TITLE
feat(fs): Node fs parity — node: imports, fs/promises, full method set (#122)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3504,6 +3504,7 @@ dependencies = [
  "hyper-util",
  "lazy_static",
  "libc",
+ "rand 0.10.1",
  "reqwest",
  "socket2 0.5.10",
  "stacker",

--- a/crates/tish/tests/fixtures/fs_parity_callbacks.tish
+++ b/crates/tish/tests/fixtures/fs_parity_callbacks.tish
@@ -1,0 +1,22 @@
+// Issue #122: Node callback form on the VM — `fs.writeFile(path, data, (err) => …)` and
+// `fs.readFile(path, (err, data) => …)`, with (err, data) semantics and a non-null err on a
+// missing file. Operates under $FS_TMP.
+import { writeFile, readFile, stat, unlink } from "node:fs"
+import { process } from "tish:process"
+
+let d = process.env.FS_TMP
+writeFile(d + "/cb.txt", "callback data", (err) => {
+  console.log("write-err-null=" + String(err === null))
+  readFile(d + "/cb.txt", (err2, data) => {
+    console.log("read=" + data)
+    stat(d + "/cb.txt", (err3, st) => {
+      console.log("size=" + String(st.size) + ",file=" + String(st.isFile()))
+      unlink(d + "/cb.txt", (err4) => {
+        console.log("unlink-err-null=" + String(err4 === null))
+      })
+    })
+  })
+})
+readFile(d + "/missing.txt", (err, data) => {
+  console.log("missing-err-set=" + String(!(err === null)) + ",data-null=" + String(data === null))
+})

--- a/crates/tish/tests/fixtures/fs_parity_promises.tish
+++ b/crates/tish/tests/fixtures/fs_parity_promises.tish
@@ -1,0 +1,21 @@
+// Issue #122: the async `node:fs/promises` surface — await on the same methods, and `access`
+// rejects on a missing path. Operates under $FS_TMP.
+import { writeFile, readFile, stat, mkdir, readdir, rm, access } from "node:fs/promises"
+import { process } from "tish:process"
+
+async fn main() {
+  let d = process.env.FS_TMP
+  await writeFile(d + "/p.txt", "async hello")
+  console.log("read=" + (await readFile(d + "/p.txt")))
+  let st = await stat(d + "/p.txt")
+  console.log("size=" + String(st.size))
+  await mkdir(d + "/pd")
+  await writeFile(d + "/pd/x", "x")
+  console.log("dir=" + (await readdir(d + "/pd")).join(","))
+  let rejected = false
+  try { await access(d + "/missing") } catch (e) { rejected = true }
+  console.log("access-missing-rejected=" + String(rejected))
+  await rm(d + "/pd", { recursive: true })
+  console.log("done")
+}
+main()

--- a/crates/tish/tests/fixtures/fs_parity_sync.tish
+++ b/crates/tish/tests/fixtures/fs_parity_sync.tish
@@ -1,0 +1,20 @@
+// Issue #122: Node-compatible fs sync surface via `node:fs`. Operates under $FS_TMP.
+import { writeFileSync, readFileSync, existsSync, statSync, mkdirSync, readdirSync, renameSync, rmSync, appendFileSync, copyFileSync, constants } from "node:fs"
+import { process } from "tish:process"
+
+let d = process.env.FS_TMP
+writeFileSync(d + "/a.txt", "hi")
+appendFileSync(d + "/a.txt", "!")
+console.log("read=" + readFileSync(d + "/a.txt"))
+console.log("exists=" + String(existsSync(d + "/a.txt")) + "," + String(existsSync(d + "/no")))
+let st = statSync(d + "/a.txt")
+console.log("size=" + String(st.size) + ",file=" + String(st.isFile()) + ",dir=" + String(st.isDirectory()))
+mkdirSync(d + "/sub")
+copyFileSync(d + "/a.txt", d + "/sub/x.txt")
+console.log("dir=" + readdirSync(d + "/sub").join(","))
+renameSync(d + "/a.txt", d + "/b.txt")
+console.log("renamed=" + String(existsSync(d + "/a.txt")) + "," + String(existsSync(d + "/b.txt")))
+rmSync(d + "/sub", { recursive: true })
+console.log("rm=" + String(existsSync(d + "/sub")))
+console.log("const=" + String(constants.R_OK))
+console.log("done")

--- a/crates/tish/tests/fs_parity.rs
+++ b/crates/tish/tests/fs_parity.rs
@@ -4,20 +4,27 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-fn run(fixture: &str, tmp: &str) -> String {
+fn run_on(backend: &str, fixture: &str, tmp: &str) -> String {
     let tish = PathBuf::from(env!("CARGO_BIN_EXE_tish"));
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
         .join("fixtures")
         .join(fixture);
     let out = Command::new(&tish)
-        .args(["run", "--feature", "fs,process", path.to_str().unwrap()])
+        .args([
+            "run",
+            "--backend",
+            backend,
+            "--feature",
+            "fs,process",
+            path.to_str().unwrap(),
+        ])
         .env("FS_TMP", tmp)
         .output()
         .expect("spawn tish run");
     assert!(
         out.status.success(),
-        "tish run {fixture} failed: {}",
+        "tish run --backend {backend} {fixture} failed: {}",
         String::from_utf8_lossy(&out.stderr)
     );
     String::from_utf8_lossy(&out.stdout).into_owned()
@@ -33,37 +40,43 @@ fn tmp_dir(tag: &str) -> String {
     d.to_str().unwrap().to_string()
 }
 
+const SYNC_EXPECTED: &str = "read=hi!\n\
+     exists=true,false\n\
+     size=3,file=true,dir=false\n\
+     dir=x.txt\n\
+     renamed=false,true\n\
+     rm=false\n\
+     const=4\n\
+     done\n";
+
+const PROMISES_EXPECTED: &str = "read=async hello\n\
+     size=11\n\
+     dir=x\n\
+     access-missing-rejected=true\n\
+     done\n";
+
 #[test]
-fn node_fs_sync_surface() {
-    let tmp = tmp_dir("sync");
-    let out = run("fs_parity_sync.tish", &tmp);
-    assert_eq!(
-        out,
-        "read=hi!\n\
-         exists=true,false\n\
-         size=3,file=true,dir=false\n\
-         dir=x.txt\n\
-         renamed=false,true\n\
-         rm=false\n\
-         const=4\n\
-         done\n",
-        "sync surface mismatch"
-    );
-    let _ = std::fs::remove_dir_all(&tmp);
+fn node_fs_sync_surface_on_every_backend() {
+    for backend in ["vm", "interp"] {
+        let tmp = tmp_dir(&format!("sync_{backend}"));
+        assert_eq!(
+            run_on(backend, "fs_parity_sync.tish", &tmp),
+            SYNC_EXPECTED,
+            "sync surface mismatch on {backend}"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
 }
 
 #[test]
-fn node_fs_promises_surface() {
-    let tmp = tmp_dir("prom");
-    let out = run("fs_parity_promises.tish", &tmp);
-    assert_eq!(
-        out,
-        "read=async hello\n\
-         size=11\n\
-         dir=x\n\
-         access-missing-rejected=true\n\
-         done\n",
-        "promises surface mismatch"
-    );
-    let _ = std::fs::remove_dir_all(&tmp);
+fn node_fs_promises_surface_on_every_backend() {
+    for backend in ["vm", "interp"] {
+        let tmp = tmp_dir(&format!("prom_{backend}"));
+        assert_eq!(
+            run_on(backend, "fs_parity_promises.tish", &tmp),
+            PROMISES_EXPECTED,
+            "promises surface mismatch on {backend}"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
 }

--- a/crates/tish/tests/fs_parity.rs
+++ b/crates/tish/tests/fs_parity.rs
@@ -1,0 +1,69 @@
+//! Issue #122: Node `fs` parity on the bytecode VM (`tish run` default backend) — the sync
+//! surface via `node:fs` and the async `node:fs/promises` surface (await + rejection).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn run(fixture: &str, tmp: &str) -> String {
+    let tish = PathBuf::from(env!("CARGO_BIN_EXE_tish"));
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(fixture);
+    let out = Command::new(&tish)
+        .args(["run", "--feature", "fs,process", path.to_str().unwrap()])
+        .env("FS_TMP", tmp)
+        .output()
+        .expect("spawn tish run");
+    assert!(
+        out.status.success(),
+        "tish run {fixture} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn tmp_dir(tag: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let d = std::env::temp_dir().join(format!("tish_fs_parity_{tag}_{nanos:x}"));
+    std::fs::create_dir_all(&d).unwrap();
+    d.to_str().unwrap().to_string()
+}
+
+#[test]
+fn node_fs_sync_surface() {
+    let tmp = tmp_dir("sync");
+    let out = run("fs_parity_sync.tish", &tmp);
+    assert_eq!(
+        out,
+        "read=hi!\n\
+         exists=true,false\n\
+         size=3,file=true,dir=false\n\
+         dir=x.txt\n\
+         renamed=false,true\n\
+         rm=false\n\
+         const=4\n\
+         done\n",
+        "sync surface mismatch"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn node_fs_promises_surface() {
+    let tmp = tmp_dir("prom");
+    let out = run("fs_parity_promises.tish", &tmp);
+    assert_eq!(
+        out,
+        "read=async hello\n\
+         size=11\n\
+         dir=x\n\
+         access-missing-rejected=true\n\
+         done\n",
+        "promises surface mismatch"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/crates/tish/tests/fs_parity.rs
+++ b/crates/tish/tests/fs_parity.rs
@@ -69,20 +69,24 @@ fn node_fs_sync_surface_on_every_backend() {
 }
 
 #[test]
-fn node_fs_callback_form_on_vm() {
-    // Callback form (err, result) works on the VM. Native codegen / interp have existing
-    // closure-to-native limitations, so the callback form is VM-only for now (#122).
-    let tmp = tmp_dir("cb");
-    assert_eq!(
-        run_on("vm", "fs_parity_callbacks.tish", &tmp),
-        "write-err-null=true\n\
+fn node_fs_callback_form_on_every_backend() {
+    // Node callback form `readFile(path, (err, data) => …)` on every backend (#122): native's
+    // multi-arg-closure-to-native lowering was fixed upstream, and the interpreter runs the callback
+    // at the eval level (call_func's Native arm) instead of the self-less core bridge.
+    let expected = "write-err-null=true\n\
          read=callback data\n\
          size=13,file=true\n\
          unlink-err-null=true\n\
-         missing-err-set=true,data-null=true\n",
-        "callback form mismatch"
-    );
-    let _ = std::fs::remove_dir_all(&tmp);
+         missing-err-set=true,data-null=true\n";
+    for backend in ["vm", "interp", "native"] {
+        let tmp = tmp_dir(&format!("cb_{backend}"));
+        assert_eq!(
+            run_on(backend, "fs_parity_callbacks.tish", &tmp),
+            expected,
+            "callback form mismatch on {backend}"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
 }
 
 #[test]

--- a/crates/tish/tests/fs_parity.rs
+++ b/crates/tish/tests/fs_parity.rs
@@ -69,6 +69,23 @@ fn node_fs_sync_surface_on_every_backend() {
 }
 
 #[test]
+fn node_fs_callback_form_on_vm() {
+    // Callback form (err, result) works on the VM. Native codegen / interp have existing
+    // closure-to-native limitations, so the callback form is VM-only for now (#122).
+    let tmp = tmp_dir("cb");
+    assert_eq!(
+        run_on("vm", "fs_parity_callbacks.tish", &tmp),
+        "write-err-null=true\n\
+         read=callback data\n\
+         size=13,file=true\n\
+         unlink-err-null=true\n\
+         missing-err-set=true,data-null=true\n",
+        "callback form mismatch"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
 fn node_fs_promises_surface_on_every_backend() {
     for backend in ["vm", "interp"] {
         let tmp = tmp_dir(&format!("prom_{backend}"));

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1610,13 +1610,13 @@ impl Codegen {
     fn builtin_native_module_rust_init(&self, spec: &str, export_name: &str) -> Option<String> {
         let init = match spec {
             "tish:fs" if self.has_feature("fs") => match export_name {
-                    // legacy tish names — unchanged contracts
-                    "readFile" => Some("Value::native(|args: &[Value]| tish_read_file(args))"),
-                    "writeFile" => Some("Value::native(|args: &[Value]| tish_write_file(args))"),
+                    // tish names → the dual fs_ext functions (sync, or Node callback if a fn is passed)
+                    "readFile" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::read_file(args))"),
+                    "writeFile" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::write_file(args))"),
                     "fileExists" => Some("Value::native(|args: &[Value]| tish_file_exists(args))"),
                     "isDir" => Some("Value::native(|args: &[Value]| tish_is_dir(args))"),
-                    "readDir" => Some("Value::native(|args: &[Value]| tish_read_dir(args))"),
-                    "readFileBytes" => Some("Value::native(|args: &[Value]| tish_read_file_bytes(args))"),
+                    "readDir" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::readdir(args))"),
+                    "readFileBytes" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::read_file_bytes(args))"),
                     // Node-compatible names + new methods (sync) — issue #122
                     "readFileSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::read_file(args))"),
                     "readFileBytesSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::read_file_bytes(args))"),

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1610,13 +1610,59 @@ impl Codegen {
     fn builtin_native_module_rust_init(&self, spec: &str, export_name: &str) -> Option<String> {
         let init = match spec {
             "tish:fs" if self.has_feature("fs") => match export_name {
+                    // legacy tish names — unchanged contracts
                     "readFile" => Some("Value::native(|args: &[Value]| tish_read_file(args))"),
                     "writeFile" => Some("Value::native(|args: &[Value]| tish_write_file(args))"),
                     "fileExists" => Some("Value::native(|args: &[Value]| tish_file_exists(args))"),
                     "isDir" => Some("Value::native(|args: &[Value]| tish_is_dir(args))"),
                     "readDir" => Some("Value::native(|args: &[Value]| tish_read_dir(args))"),
                     "readFileBytes" => Some("Value::native(|args: &[Value]| tish_read_file_bytes(args))"),
-                    "mkdir" => Some("Value::native(|args: &[Value]| tish_mkdir(args))"),
+                    // Node-compatible names + new methods (sync) — issue #122
+                    "readFileSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::read_file(args))"),
+                    "readFileBytesSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::read_file_bytes(args))"),
+                    "writeFileSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::write_file(args))"),
+                    "appendFile" | "appendFileSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::append_file(args))"),
+                    "existsSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::exists(args))"),
+                    "mkdir" | "mkdirSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::mkdir(args))"),
+                    "readdir" | "readdirSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::readdir(args))"),
+                    "stat" | "statSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::stat(args))"),
+                    "lstat" | "lstatSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::lstat(args))"),
+                    "rm" | "rmSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::rm(args))"),
+                    "rmdir" | "rmdirSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::rmdir(args))"),
+                    "unlink" | "unlinkSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::unlink(args))"),
+                    "rename" | "renameSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::rename(args))"),
+                    "copyFile" | "copyFileSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::copy_file(args))"),
+                    "realpath" | "realpathSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::realpath(args))"),
+                    "readlink" | "readlinkSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::readlink(args))"),
+                    "truncate" | "truncateSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::truncate(args))"),
+                    "mkdtemp" | "mkdtempSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::mkdtemp(args))"),
+                    "cp" | "cpSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::cp(args))"),
+                    "access" | "accessSync" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::access(args))"),
+                    "constants" => Some("tishlang_runtime::fs_ext::constants()"),
+                    _ => None,
+                },
+            "tish:fs/promises" if self.has_feature("fs") => match export_name {
+                    "readFile" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::read_file_promise(args))"),
+                    "readFileBytes" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::read_file_bytes_promise(args))"),
+                    "writeFile" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::write_file_promise(args))"),
+                    "appendFile" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::append_file_promise(args))"),
+                    "mkdir" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::mkdir_promise(args))"),
+                    "readdir" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::readdir_promise(args))"),
+                    "stat" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::stat_promise(args))"),
+                    "lstat" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::lstat_promise(args))"),
+                    "rm" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::rm_promise(args))"),
+                    "rmdir" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::rmdir_promise(args))"),
+                    "unlink" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::unlink_promise(args))"),
+                    "rename" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::rename_promise(args))"),
+                    "copyFile" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::copy_file_promise(args))"),
+                    "realpath" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::realpath_promise(args))"),
+                    "readlink" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::readlink_promise(args))"),
+                    "truncate" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::truncate_promise(args))"),
+                    "mkdtemp" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::mkdtemp_promise(args))"),
+                    "cp" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::cp_promise(args))"),
+                    "access" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::access_promise(args))"),
+                    "exists" => Some("Value::native(|args: &[Value]| tishlang_runtime::fs_ext::exists_promise(args))"),
+                    "constants" => Some("tishlang_runtime::fs_ext::constants()"),
                     _ => None,
                 },
             "tish:http" if self.has_feature("http") => match export_name {
@@ -2214,6 +2260,11 @@ impl Codegen {
             } else {
                 self.write("use tishlang_runtime::{fetch_promise as tish_fetch_promise, fetch_all_promise as tish_fetch_all_promise, http_serve as tish_http_serve};\n");
             }
+        }
+        // `fs/promises` (and any promise-using async program) needs the await machinery even
+        // without http. `fs` implies the runtime `promise` feature, so these resolve.
+        if self.is_async && !self.has_feature("http") && self.has_feature("fs") {
+            self.write("use tishlang_runtime::{promise_object as tish_promise_object, await_promise as tish_await_promise, await_promise_throw as tish_await_promise_throw};\n");
         }
         if self.has_feature("fs") {
             self.write("use tishlang_runtime::{read_file as tish_read_file, read_file_bytes as tish_read_file_bytes, write_file as tish_write_file, file_exists as tish_file_exists, is_dir as tish_is_dir, read_dir as tish_read_dir, mkdir as tish_mkdir};\n");

--- a/crates/tish_compile/src/resolve.rs
+++ b/crates/tish_compile/src/resolve.rs
@@ -49,17 +49,23 @@ pub struct NativeBuildArtifacts {
     pub native_init: std::collections::HashMap<String, NativeModuleInit>,
 }
 
-/// Node-compatible aliases for built-in modules (fs -> tish:fs, etc.).
+/// Node-compatible aliases for built-in modules (fs -> tish:fs, etc.). The `node:` prefix
+/// (e.g. `node:fs`, `node:fs/promises`) is stripped before lookup.
 const BUILTIN_ALIASES: &[(&str, &str)] = &[
     ("fs", "tish:fs"),
+    ("fs/promises", "tish:fs/promises"),
     ("http", "tish:http"),
     ("timers", "tish:timers"),
     ("process", "tish:process"),
     ("ws", "tish:ws"),
+    ("tty", "tish:tty"),
 ];
 
-/// Normalize built-in spec to canonical form. E.g. "fs" -> "tish:fs".
+/// Normalize built-in spec to canonical form. Handles the Node `node:` prefix
+/// (`node:fs` -> `tish:fs`, `node:fs/promises` -> `tish:fs/promises`) and bare aliases.
 pub fn normalize_builtin_spec(spec: &str) -> Option<String> {
+    // Strip a leading `node:` so `node:fs` resolves the same as `fs`.
+    let spec = spec.strip_prefix("node:").unwrap_or(spec);
     if spec.starts_with("tish:") {
         return Some(spec.to_string());
     }
@@ -71,10 +77,20 @@ pub fn normalize_builtin_spec(spec: &str) -> Option<String> {
 
 /// Built-in modules that come from tishlang_runtime, not from package.json.
 pub fn is_builtin_native_spec(spec: &str) -> bool {
+    let spec = spec.strip_prefix("node:").unwrap_or(spec);
     matches!(
         spec,
-        "tish:fs" | "tish:http" | "tish:timers" | "tish:process" | "tish:ws" | "tish:tty"
-    ) || matches!(spec, "fs" | "http" | "timers" | "process" | "ws" | "tty")
+        "tish:fs"
+            | "tish:fs/promises"
+            | "tish:http"
+            | "tish:timers"
+            | "tish:process"
+            | "tish:ws"
+            | "tish:tty"
+    ) || matches!(
+        spec,
+        "fs" | "fs/promises" | "http" | "timers" | "process" | "ws" | "tty"
+    )
 }
 
 /// Resolve all native imports in a merged program via package.json lookup.
@@ -955,10 +971,15 @@ fn load_module_recursive(
 ///
 /// Scoped npm packages (`@scope/pkg`) are merged as Tish source unless imported via `tish:…`.
 pub fn is_native_import(spec: &str) -> bool {
+    // A leading `node:` (node:fs, node:fs/promises) resolves the same as the bare form.
+    let spec = spec.strip_prefix("node:").unwrap_or(spec);
     spec.starts_with("tish:")
         || spec.starts_with("cargo:")
         || spec.starts_with("ffi:")
-        || matches!(spec, "fs" | "http" | "timers" | "process" | "ws")
+        || matches!(
+            spec,
+            "fs" | "fs/promises" | "http" | "timers" | "process" | "ws" | "tty"
+        )
 }
 
 /// True for `ffi:…` specs (portable C-ABI cdylib extensions, loadable on every backend). The

--- a/crates/tish_eval/Cargo.toml
+++ b/crates/tish_eval/Cargo.toml
@@ -22,7 +22,8 @@ http = [
     "tishlang_core/send-values",
     "tishlang_builtins/send-values",
 ]
-fs = []
+# fs bridges to tishlang_runtime::fs_ext for the Node-compatible surface (#122).
+fs = ["dep:tishlang_runtime", "tishlang_runtime/fs"]
 process = []
 tty = ["dep:tishlang_runtime", "tishlang_runtime/tty"]
 regex = ["tishlang_core/regex"]

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -3908,7 +3908,31 @@ impl Evaluator {
                 }
                 Err(EvalError::Error("Not a function".to_string()))
             }
-            Value::Native(native_fn) => native_fn(args).map_err(EvalError::Error),
+            Value::Native(native_fn) => {
+                // #122: Node fs callback form — `readFile(path, (err, data) => …)`. The self-less
+                // `Value::Native` bridge can't invoke an eval callback (a core `Callable` can't
+                // re-enter the interpreter), so handle it here where `&self` is available: run the
+                // op's core on the non-callback args, split its Result into `(err, data)`, and call
+                // the callback. Matches the VM/native backends (fs_ext runs the callback in-core).
+                #[cfg(feature = "fs")]
+                if let Some(cb @ Value::Function { .. }) = args.last() {
+                    if let Some(core_op) = natives::fsx::callback_core(*native_fn) {
+                        let cb = cb.clone();
+                        let core_args = args[..args.len() - 1]
+                            .iter()
+                            .map(crate::value_convert::eval_to_core)
+                            .collect::<Result<Vec<_>, String>>()
+                            .map_err(EvalError::Error)?;
+                        let (err, data) = match core_op(&core_args) {
+                            Ok(v) => (Value::Null, crate::value_convert::core_to_eval(v)),
+                            Err(e) => (crate::value_convert::core_to_eval(e), Value::Null),
+                        };
+                        self.call_func(&cb, &[err, data])?;
+                        return Ok(Value::Null);
+                    }
+                }
+                native_fn(args).map_err(EvalError::Error)
+            }
             #[cfg(feature = "http")]
             Value::PromiseResolver(r) => {
                 let value = args.first().cloned().unwrap_or(Value::Null);

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -1227,12 +1227,85 @@ impl Evaluator {
                         Value::Native(natives::read_file_bytes),
                     );
                     exports.insert("mkdir".into(), Value::Native(natives::mkdir));
+                    // Node-compatible names + new methods (sync) — issue #122
+                    use natives::fsx;
+                    exports.insert("readFileSync".into(), Value::Native(fsx::read_file));
+                    exports.insert("readFileBytesSync".into(), Value::Native(fsx::read_file_bytes));
+                    exports.insert("writeFileSync".into(), Value::Native(fsx::write_file));
+                    exports.insert("appendFile".into(), Value::Native(fsx::append_file));
+                    exports.insert("appendFileSync".into(), Value::Native(fsx::append_file));
+                    exports.insert("existsSync".into(), Value::Native(fsx::exists));
+                    exports.insert("mkdirSync".into(), Value::Native(fsx::mkdir));
+                    exports.insert("readdir".into(), Value::Native(fsx::readdir));
+                    exports.insert("readdirSync".into(), Value::Native(fsx::readdir));
+                    exports.insert("stat".into(), Value::Native(fsx::stat));
+                    exports.insert("statSync".into(), Value::Native(fsx::stat));
+                    exports.insert("lstat".into(), Value::Native(fsx::lstat));
+                    exports.insert("lstatSync".into(), Value::Native(fsx::lstat));
+                    exports.insert("rm".into(), Value::Native(fsx::rm));
+                    exports.insert("rmSync".into(), Value::Native(fsx::rm));
+                    exports.insert("rmdir".into(), Value::Native(fsx::rmdir));
+                    exports.insert("rmdirSync".into(), Value::Native(fsx::rmdir));
+                    exports.insert("unlink".into(), Value::Native(fsx::unlink));
+                    exports.insert("unlinkSync".into(), Value::Native(fsx::unlink));
+                    exports.insert("rename".into(), Value::Native(fsx::rename));
+                    exports.insert("renameSync".into(), Value::Native(fsx::rename));
+                    exports.insert("copyFile".into(), Value::Native(fsx::copy_file));
+                    exports.insert("copyFileSync".into(), Value::Native(fsx::copy_file));
+                    exports.insert("realpath".into(), Value::Native(fsx::realpath));
+                    exports.insert("realpathSync".into(), Value::Native(fsx::realpath));
+                    exports.insert("readlink".into(), Value::Native(fsx::readlink));
+                    exports.insert("readlinkSync".into(), Value::Native(fsx::readlink));
+                    exports.insert("truncate".into(), Value::Native(fsx::truncate));
+                    exports.insert("truncateSync".into(), Value::Native(fsx::truncate));
+                    exports.insert("mkdtemp".into(), Value::Native(fsx::mkdtemp));
+                    exports.insert("mkdtempSync".into(), Value::Native(fsx::mkdtemp));
+                    exports.insert("cp".into(), Value::Native(fsx::cp));
+                    exports.insert("cpSync".into(), Value::Native(fsx::cp));
+                    exports.insert("access".into(), Value::Native(fsx::access));
+                    exports.insert("accessSync".into(), Value::Native(fsx::access));
+                    exports.insert("constants".into(), fsx::constants());
                     Ok(Value::object(exports))
                 }
                 #[cfg(not(feature = "fs"))]
                 {
                     return Err(EvalError::Error(
                         "tish:fs requires the fs feature. Rebuild with: cargo build -p tishlang --features fs".into(),
+                    ));
+                }
+            }
+            "tish:fs/promises" => {
+                #[cfg(feature = "fs")]
+                {
+                    use natives::fsx;
+                    let mut exports: PropMap = PropMap::default();
+                    exports.insert("readFile".into(), Value::Native(fsx::read_file_p));
+                    exports.insert("readFileBytes".into(), Value::Native(fsx::read_file_bytes_p));
+                    exports.insert("writeFile".into(), Value::Native(fsx::write_file_p));
+                    exports.insert("appendFile".into(), Value::Native(fsx::append_file_p));
+                    exports.insert("exists".into(), Value::Native(fsx::exists_p));
+                    exports.insert("mkdir".into(), Value::Native(fsx::mkdir_p));
+                    exports.insert("readdir".into(), Value::Native(fsx::readdir_p));
+                    exports.insert("stat".into(), Value::Native(fsx::stat_p));
+                    exports.insert("lstat".into(), Value::Native(fsx::lstat_p));
+                    exports.insert("rm".into(), Value::Native(fsx::rm_p));
+                    exports.insert("rmdir".into(), Value::Native(fsx::rmdir_p));
+                    exports.insert("unlink".into(), Value::Native(fsx::unlink_p));
+                    exports.insert("rename".into(), Value::Native(fsx::rename_p));
+                    exports.insert("copyFile".into(), Value::Native(fsx::copy_file_p));
+                    exports.insert("realpath".into(), Value::Native(fsx::realpath_p));
+                    exports.insert("readlink".into(), Value::Native(fsx::readlink_p));
+                    exports.insert("truncate".into(), Value::Native(fsx::truncate_p));
+                    exports.insert("mkdtemp".into(), Value::Native(fsx::mkdtemp_p));
+                    exports.insert("cp".into(), Value::Native(fsx::cp_p));
+                    exports.insert("access".into(), Value::Native(fsx::access_p));
+                    exports.insert("constants".into(), fsx::constants());
+                    Ok(Value::object(exports))
+                }
+                #[cfg(not(feature = "fs"))]
+                {
+                    return Err(EvalError::Error(
+                        "tish:fs/promises requires the fs feature. Rebuild with: cargo build -p tishlang --features fs".into(),
                     ));
                 }
             }

--- a/crates/tish_eval/src/natives.rs
+++ b/crates/tish_eval/src/natives.rs
@@ -548,6 +548,72 @@ pub fn read_file_bytes(args: &[Value]) -> Result<Value, String> {
     }
 }
 
+// ── Node-compatible fs surface (#122) — bridged to tishlang_runtime::fs_ext so the interpreter
+// shares one implementation with the VM/native backends. eval args -> core, call, core -> eval.
+#[cfg(feature = "fs")]
+macro_rules! fs_bridge {
+    ($name:ident => $core:path) => {
+        pub fn $name(args: &[Value]) -> Result<Value, String> {
+            let core_args = args
+                .iter()
+                .map(crate::value_convert::eval_to_core)
+                .collect::<Result<Vec<_>, String>>()?;
+            Ok(crate::value_convert::core_to_eval($core(&core_args)))
+        }
+    };
+}
+
+#[cfg(feature = "fs")]
+pub mod fsx {
+    use super::Value;
+    use tishlang_runtime::fs_ext as fx;
+    // sync
+    fs_bridge!(read_file => fx::read_file);
+    fs_bridge!(read_file_bytes => fx::read_file_bytes);
+    fs_bridge!(write_file => fx::write_file);
+    fs_bridge!(append_file => fx::append_file);
+    fs_bridge!(exists => fx::exists);
+    fs_bridge!(mkdir => fx::mkdir);
+    fs_bridge!(readdir => fx::readdir);
+    fs_bridge!(stat => fx::stat);
+    fs_bridge!(lstat => fx::lstat);
+    fs_bridge!(rm => fx::rm);
+    fs_bridge!(rmdir => fx::rmdir);
+    fs_bridge!(unlink => fx::unlink);
+    fs_bridge!(rename => fx::rename);
+    fs_bridge!(copy_file => fx::copy_file);
+    fs_bridge!(realpath => fx::realpath);
+    fs_bridge!(readlink => fx::readlink);
+    fs_bridge!(truncate => fx::truncate);
+    fs_bridge!(mkdtemp => fx::mkdtemp);
+    fs_bridge!(cp => fx::cp);
+    fs_bridge!(access => fx::access);
+    // promises
+    fs_bridge!(read_file_p => fx::read_file_promise);
+    fs_bridge!(read_file_bytes_p => fx::read_file_bytes_promise);
+    fs_bridge!(write_file_p => fx::write_file_promise);
+    fs_bridge!(append_file_p => fx::append_file_promise);
+    fs_bridge!(exists_p => fx::exists_promise);
+    fs_bridge!(mkdir_p => fx::mkdir_promise);
+    fs_bridge!(readdir_p => fx::readdir_promise);
+    fs_bridge!(stat_p => fx::stat_promise);
+    fs_bridge!(lstat_p => fx::lstat_promise);
+    fs_bridge!(rm_p => fx::rm_promise);
+    fs_bridge!(rmdir_p => fx::rmdir_promise);
+    fs_bridge!(unlink_p => fx::unlink_promise);
+    fs_bridge!(rename_p => fx::rename_promise);
+    fs_bridge!(copy_file_p => fx::copy_file_promise);
+    fs_bridge!(realpath_p => fx::realpath_promise);
+    fs_bridge!(readlink_p => fx::readlink_promise);
+    fs_bridge!(truncate_p => fx::truncate_promise);
+    fs_bridge!(mkdtemp_p => fx::mkdtemp_promise);
+    fs_bridge!(cp_p => fx::cp_promise);
+    fs_bridge!(access_p => fx::access_promise);
+    pub fn constants() -> Value {
+        crate::value_convert::core_to_eval(fx::constants())
+    }
+}
+
 #[cfg(feature = "fs")]
 pub fn write_file(args: &[Value]) -> Result<Value, String> {
     let path = args.first().map(|v| v.to_string()).unwrap_or_default();

--- a/crates/tish_eval/src/natives.rs
+++ b/crates/tish_eval/src/natives.rs
@@ -612,6 +612,43 @@ pub mod fsx {
     pub fn constants() -> Value {
         crate::value_convert::core_to_eval(fx::constants())
     }
+
+    /// Core op behind a Node-callback-style fs function (Ok = data, Err = error value), if `f` is one.
+    /// The interpreter binds fs to self-less `Value::Native`s that can't invoke an eval callback, so
+    /// `call_func` uses this to run the sync op and split its Result into `(err, data)` for the
+    /// callback form (#122). Covers both the old tish aliases (`readFile` → `natives::read_file`) and
+    /// the `fsx::*` bridges. `exists`/`access` are omitted — they answer a boolean and never error.
+    pub type CoreOp = fn(&[tishlang_core::Value]) -> Result<tishlang_core::Value, tishlang_core::Value>;
+    pub fn callback_core(f: crate::value::NativeFn) -> Option<CoreOp> {
+        use std::ptr::fn_addr_eq;
+        type NF = crate::value::NativeFn;
+        // Node names bound to the old tish aliases (natives::*).
+        if fn_addr_eq(f, super::read_file as NF) { return Some(fx::read_file_core); }
+        if fn_addr_eq(f, super::write_file as NF) { return Some(fx::write_file_core); }
+        if fn_addr_eq(f, super::read_file_bytes as NF) { return Some(fx::read_file_bytes_core); }
+        if fn_addr_eq(f, super::read_dir as NF) { return Some(fx::readdir_core); }
+        if fn_addr_eq(f, super::mkdir as NF) { return Some(fx::mkdir_core); }
+        // The `fsx::*` bridges (Node *Sync names and the ops with no old alias).
+        if fn_addr_eq(f, read_file as NF) { return Some(fx::read_file_core); }
+        if fn_addr_eq(f, write_file as NF) { return Some(fx::write_file_core); }
+        if fn_addr_eq(f, append_file as NF) { return Some(fx::append_file_core); }
+        if fn_addr_eq(f, read_file_bytes as NF) { return Some(fx::read_file_bytes_core); }
+        if fn_addr_eq(f, readdir as NF) { return Some(fx::readdir_core); }
+        if fn_addr_eq(f, stat as NF) { return Some(fx::stat_core); }
+        if fn_addr_eq(f, lstat as NF) { return Some(fx::lstat_core); }
+        if fn_addr_eq(f, mkdir as NF) { return Some(fx::mkdir_core); }
+        if fn_addr_eq(f, rm as NF) { return Some(fx::rm_core); }
+        if fn_addr_eq(f, rmdir as NF) { return Some(fx::rmdir_core); }
+        if fn_addr_eq(f, unlink as NF) { return Some(fx::unlink_core); }
+        if fn_addr_eq(f, rename as NF) { return Some(fx::rename_core); }
+        if fn_addr_eq(f, copy_file as NF) { return Some(fx::copy_file_core); }
+        if fn_addr_eq(f, cp as NF) { return Some(fx::cp_core); }
+        if fn_addr_eq(f, realpath as NF) { return Some(fx::realpath_core); }
+        if fn_addr_eq(f, readlink as NF) { return Some(fx::readlink_core); }
+        if fn_addr_eq(f, truncate as NF) { return Some(fx::truncate_core); }
+        if fn_addr_eq(f, mkdtemp as NF) { return Some(fx::mkdtemp_core); }
+        None
+    }
 }
 
 #[cfg(feature = "fs")]

--- a/crates/tish_runtime/Cargo.toml
+++ b/crates/tish_runtime/Cargo.toml
@@ -53,7 +53,8 @@ http-hyper = [
     "tokio/io-util",
 ]
 # `fs/promises` returns settled promises, so fs pulls in the promise machinery.
-fs = ["promise"]
+# `mkdtemp` needs a random suffix (predictable/timestamp names are a temp-dir security smell).
+fs = ["promise", "dep:rand"]
 process = []
 # Interactive terminal I/O (issue #101): raw mode, key/resize events, size, alt screen.
 tty = ["dep:crossterm"]
@@ -82,6 +83,8 @@ reqwest = { version = "0.13.2", default-features = false, features = ["rustls", 
 futures = { version = "0.3.32", optional = true }
 bytes = { version = "1", optional = true }
 tiny_http = { version = "0.12.0", optional = true }
+# fs feature only: random suffix for `mkdtemp`.
+rand = { version = "0.10.1", optional = true }
 socket2 = { version = "0.5", features = ["all"], optional = true }
 libc = { version = "0.2", optional = true }
 arc-swap = { version = "1", optional = true }

--- a/crates/tish_runtime/Cargo.toml
+++ b/crates/tish_runtime/Cargo.toml
@@ -52,7 +52,8 @@ http-hyper = [
     "tokio/rt",
     "tokio/io-util",
 ]
-fs = []
+# `fs/promises` returns settled promises, so fs pulls in the promise machinery.
+fs = ["promise"]
 process = []
 # Interactive terminal I/O (issue #101): raw mode, key/resize events, size, alt screen.
 tty = ["dep:crossterm"]

--- a/crates/tish_runtime/src/fs_ext.rs
+++ b/crates/tish_runtime/src/fs_ext.rs
@@ -230,12 +230,31 @@ fn truncate_core(args: &[Value]) -> Result<Value, Value> {
         .map_err(io_err)
 }
 
-/// `mkdtemp(prefix)` — create a uniquely-named temp dir, return its path.
+/// `mkdtemp(prefix)` — create a uniquely-named temp dir and return its path. Node appends 6 RANDOM
+/// characters; a timestamp suffix is both predictable (a temp-dir security smell) and collision-prone
+/// under rapid calls. Use a random suffix and rely on `create_dir`'s exclusive semantics, retrying on
+/// the astronomically-rare collision.
 fn mkdtemp_core(args: &[Value]) -> Result<Value, Value> {
     let prefix = path_arg(args, 0);
-    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0);
-    let path = format!("{}{:x}", prefix, nanos);
-    std::fs::create_dir(&path).map(|_| Value::String(path.into())).map_err(io_err)
+    for _ in 0..16 {
+        // 10 base-36 chars derived from a random u64 (~51 bits of entropy).
+        let mut n: u64 = rand::random();
+        let mut suffix = String::with_capacity(10);
+        for _ in 0..10 {
+            suffix.push(char::from_digit((n % 36) as u32, 36).unwrap());
+            n /= 36;
+        }
+        let path = format!("{}{}", prefix, suffix);
+        match std::fs::create_dir(&path) {
+            Ok(()) => return Ok(Value::String(path.into())),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(io_err(e)),
+        }
+    }
+    Err(io_err(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        "mkdtemp: could not create a unique temporary directory",
+    )))
 }
 
 /// `cp(src, dest[, { recursive }])` — copy a file, or a directory tree when recursive.

--- a/crates/tish_runtime/src/fs_ext.rs
+++ b/crates/tish_runtime/src/fs_ext.rs
@@ -1,0 +1,322 @@
+//! Node-compatible `fs` surface for `tish:fs` and the async `tish:fs/promises` module
+//! (issue #122). Each operation has a single `*_core` returning `Result<Value, Value>`
+//! (Ok = result, Err = an error value); a macro derives the synchronous export (returns the
+//! value, or the error object on failure — tish's sync convention) and the promise export
+//! (a fulfilled/rejected Promise — Node's `fs/promises` convention).
+//!
+//! Node names are primary (`readFileSync`, `statSync`, …); the existing tish names
+//! (`readFile`, `readDir`, `fileExists`, `isDir`) are kept as aliases in the backends.
+#![cfg(feature = "fs")]
+
+use crate::promise::{promise_reject, promise_resolve};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tishlang_builtins::helpers::make_error_value;
+use tishlang_core::{ObjectMap, Value, VmRef};
+
+fn path_arg(args: &[Value], i: usize) -> String {
+    args.get(i).map(|v| v.to_display_string()).unwrap_or_default()
+}
+
+/// Map an io::Error to the same error value `read_file` already produces.
+fn io_err(e: std::io::Error) -> Value {
+    make_error_value(e)
+}
+
+fn unwrap(r: Result<Value, Value>) -> Value {
+    match r {
+        Ok(v) => v,
+        Err(e) => e,
+    }
+}
+
+fn settle(r: Result<Value, Value>) -> Value {
+    match r {
+        Ok(v) => promise_resolve(&[v]),
+        Err(e) => promise_reject(&[e]),
+    }
+}
+
+/// Generate `pub fn $sync` and `pub fn $promise` over a `*_core`.
+macro_rules! fs_method {
+    ($sync:ident, $promise:ident, $core:ident) => {
+        pub fn $sync(args: &[Value]) -> Value {
+            unwrap($core(args))
+        }
+        pub fn $promise(args: &[Value]) -> Value {
+            settle($core(args))
+        }
+    };
+}
+
+fn ms_since_epoch(t: std::io::Result<SystemTime>) -> f64 {
+    t.ok()
+        .and_then(|st| st.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_secs_f64() * 1000.0)
+        .unwrap_or(0.0)
+}
+
+/// Build a Node-like `Stats` object from metadata (predicate methods + size + times + mode).
+fn stats_object(md: &std::fs::Metadata) -> Value {
+    let mut m = ObjectMap::default();
+    let is_file = md.is_file();
+    let is_dir = md.is_dir();
+    let is_symlink = md.file_type().is_symlink();
+    m.insert("isFile".into(), Value::native(move |_| Value::Bool(is_file)));
+    m.insert("isDirectory".into(), Value::native(move |_| Value::Bool(is_dir)));
+    m.insert("isSymbolicLink".into(), Value::native(move |_| Value::Bool(is_symlink)));
+    m.insert("isBlockDevice".into(), Value::native(|_| Value::Bool(false)));
+    m.insert("isCharacterDevice".into(), Value::native(|_| Value::Bool(false)));
+    m.insert("isFIFO".into(), Value::native(|_| Value::Bool(false)));
+    m.insert("isSocket".into(), Value::native(|_| Value::Bool(false)));
+    m.insert("size".into(), Value::Number(md.len() as f64));
+    m.insert("mtimeMs".into(), Value::Number(ms_since_epoch(md.modified())));
+    m.insert("atimeMs".into(), Value::Number(ms_since_epoch(md.accessed())));
+    m.insert("birthtimeMs".into(), Value::Number(ms_since_epoch(md.created())));
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        m.insert("mode".into(), Value::Number(md.mode() as f64));
+        m.insert("uid".into(), Value::Number(md.uid() as f64));
+        m.insert("gid".into(), Value::Number(md.gid() as f64));
+        m.insert("ino".into(), Value::Number(md.ino() as f64));
+    }
+    Value::object(m)
+}
+
+// ── cores ─────────────────────────────────────────────────────────────────────────────────
+
+fn read_file_core(args: &[Value]) -> Result<Value, Value> {
+    std::fs::read_to_string(path_arg(args, 0))
+        .map(|s| Value::String(s.into()))
+        .map_err(io_err)
+}
+
+fn read_file_bytes_core(args: &[Value]) -> Result<Value, Value> {
+    std::fs::read(path_arg(args, 0))
+        .map(|b| Value::Array(VmRef::new(b.into_iter().map(|x| Value::Number(x as f64)).collect())))
+        .map_err(io_err)
+}
+
+/// Write a string, or a byte array (numbers 0–255), to a file.
+fn write_file_core(args: &[Value]) -> Result<Value, Value> {
+    let path = path_arg(args, 0);
+    let res = match args.get(1) {
+        Some(Value::Array(a)) => {
+            let bytes: Vec<u8> = a
+                .borrow()
+                .iter()
+                .map(|v| if let Value::Number(n) = v { *n as u8 } else { 0 })
+                .collect();
+            std::fs::write(&path, bytes)
+        }
+        Some(v) => std::fs::write(&path, v.to_display_string()),
+        None => std::fs::write(&path, ""),
+    };
+    res.map(|_| Value::Null).map_err(io_err)
+}
+
+fn append_file_core(args: &[Value]) -> Result<Value, Value> {
+    use std::io::Write;
+    let path = path_arg(args, 0);
+    let data = args.get(1).map(|v| v.to_display_string()).unwrap_or_default();
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .and_then(|mut f| f.write_all(data.as_bytes()))
+        .map(|_| Value::Null)
+        .map_err(io_err)
+}
+
+fn stat_core(args: &[Value]) -> Result<Value, Value> {
+    std::fs::metadata(path_arg(args, 0)).map(|m| stats_object(&m)).map_err(io_err)
+}
+fn lstat_core(args: &[Value]) -> Result<Value, Value> {
+    std::fs::symlink_metadata(path_arg(args, 0)).map(|m| stats_object(&m)).map_err(io_err)
+}
+
+fn readdir_core(args: &[Value]) -> Result<Value, Value> {
+    std::fs::read_dir(path_arg(args, 0))
+        .map(|entries| {
+            let names: Vec<Value> = entries
+                .filter_map(|e| e.ok())
+                .map(|e| Value::String(e.file_name().to_string_lossy().into()))
+                .collect();
+            Value::Array(VmRef::new(names))
+        })
+        .map_err(io_err)
+}
+
+/// `mkdir(path[, { recursive }])` — recursive creates parents.
+fn mkdir_core(args: &[Value]) -> Result<Value, Value> {
+    let path = path_arg(args, 0);
+    let recursive = opt_bool(args.get(1), "recursive");
+    let res = if recursive {
+        std::fs::create_dir_all(&path)
+    } else {
+        std::fs::create_dir(&path)
+    };
+    res.map(|_| Value::Null).map_err(io_err)
+}
+
+/// `rm(path[, { recursive }])` — file, or whole tree when recursive.
+fn rm_core(args: &[Value]) -> Result<Value, Value> {
+    let path = path_arg(args, 0);
+    let recursive = opt_bool(args.get(1), "recursive");
+    let md = std::fs::symlink_metadata(&path);
+    let res = match md {
+        Ok(m) if m.is_dir() => {
+            if recursive {
+                std::fs::remove_dir_all(&path)
+            } else {
+                std::fs::remove_dir(&path)
+            }
+        }
+        _ => std::fs::remove_file(&path),
+    };
+    res.map(|_| Value::Null).map_err(io_err)
+}
+
+fn rmdir_core(args: &[Value]) -> Result<Value, Value> {
+    std::fs::remove_dir(path_arg(args, 0)).map(|_| Value::Null).map_err(io_err)
+}
+fn unlink_core(args: &[Value]) -> Result<Value, Value> {
+    std::fs::remove_file(path_arg(args, 0)).map(|_| Value::Null).map_err(io_err)
+}
+fn rename_core(args: &[Value]) -> Result<Value, Value> {
+    std::fs::rename(path_arg(args, 0), path_arg(args, 1)).map(|_| Value::Null).map_err(io_err)
+}
+fn copy_file_core(args: &[Value]) -> Result<Value, Value> {
+    std::fs::copy(path_arg(args, 0), path_arg(args, 1)).map(|_| Value::Null).map_err(io_err)
+}
+fn realpath_core(args: &[Value]) -> Result<Value, Value> {
+    std::fs::canonicalize(path_arg(args, 0))
+        .map(|p| Value::String(p.to_string_lossy().into()))
+        .map_err(io_err)
+}
+fn readlink_core(args: &[Value]) -> Result<Value, Value> {
+    std::fs::read_link(path_arg(args, 0))
+        .map(|p| Value::String(p.to_string_lossy().into()))
+        .map_err(io_err)
+}
+fn truncate_core(args: &[Value]) -> Result<Value, Value> {
+    let len = match args.get(1) {
+        Some(Value::Number(n)) => *n as u64,
+        _ => 0,
+    };
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(path_arg(args, 0))
+        .and_then(|f| f.set_len(len))
+        .map(|_| Value::Null)
+        .map_err(io_err)
+}
+
+/// `mkdtemp(prefix)` — create a uniquely-named temp dir, return its path.
+fn mkdtemp_core(args: &[Value]) -> Result<Value, Value> {
+    let prefix = path_arg(args, 0);
+    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0);
+    let path = format!("{}{:x}", prefix, nanos);
+    std::fs::create_dir(&path).map(|_| Value::String(path.into())).map_err(io_err)
+}
+
+/// `cp(src, dest[, { recursive }])` — copy a file, or a directory tree when recursive.
+fn cp_core(args: &[Value]) -> Result<Value, Value> {
+    let src = path_arg(args, 0);
+    let dest = path_arg(args, 1);
+    let recursive = opt_bool(args.get(2), "recursive");
+    copy_recursive(std::path::Path::new(&src), std::path::Path::new(&dest), recursive)
+        .map(|_| Value::Null)
+        .map_err(io_err)
+}
+
+fn copy_recursive(src: &std::path::Path, dest: &std::path::Path, recursive: bool) -> std::io::Result<()> {
+    if src.is_dir() {
+        if !recursive {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "cp on a directory requires { recursive: true }",
+            ));
+        }
+        std::fs::create_dir_all(dest)?;
+        for entry in std::fs::read_dir(src)? {
+            let entry = entry?;
+            copy_recursive(&entry.path(), &dest.join(entry.file_name()), true)?;
+        }
+        Ok(())
+    } else {
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::copy(src, dest).map(|_| ())
+    }
+}
+
+fn opt_bool(v: Option<&Value>, key: &str) -> bool {
+    match v {
+        Some(Value::Object(o)) => o
+            .borrow()
+            .strings
+            .get(key)
+            .map(|b| b.is_truthy())
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+// ── sync + promise exports ──────────────────────────────────────────────────────────────────
+
+fs_method!(read_file, read_file_promise, read_file_core);
+fs_method!(read_file_bytes, read_file_bytes_promise, read_file_bytes_core);
+fs_method!(write_file, write_file_promise, write_file_core);
+fs_method!(append_file, append_file_promise, append_file_core);
+fs_method!(stat, stat_promise, stat_core);
+fs_method!(lstat, lstat_promise, lstat_core);
+fs_method!(readdir, readdir_promise, readdir_core);
+fs_method!(mkdir, mkdir_promise, mkdir_core);
+fs_method!(rm, rm_promise, rm_core);
+fs_method!(rmdir, rmdir_promise, rmdir_core);
+fs_method!(unlink, unlink_promise, unlink_core);
+fs_method!(rename, rename_promise, rename_core);
+fs_method!(copy_file, copy_file_promise, copy_file_core);
+fs_method!(realpath, realpath_promise, realpath_core);
+fs_method!(readlink, readlink_promise, readlink_core);
+fs_method!(truncate, truncate_promise, truncate_core);
+fs_method!(mkdtemp, mkdtemp_promise, mkdtemp_core);
+fs_method!(cp, cp_promise, cp_core);
+
+// `exists` / `access` never error — they answer a boolean.
+pub fn exists(args: &[Value]) -> Value {
+    Value::Bool(std::path::Path::new(&path_arg(args, 0)).exists())
+}
+pub fn exists_promise(args: &[Value]) -> Value {
+    promise_resolve(&[exists(args)])
+}
+/// `accessSync(path)` → true if the path exists (tish-friendly); the promise form resolves
+/// `true` / rejects with an error, matching `fs/promises.access`.
+pub fn access(args: &[Value]) -> Value {
+    exists(args)
+}
+pub fn access_promise(args: &[Value]) -> Value {
+    let path = path_arg(args, 0);
+    if std::path::Path::new(&path).exists() {
+        promise_resolve(&[Value::Null])
+    } else {
+        promise_reject(&[Value::String(format!("ENOENT: no such file '{}'", path).into())])
+    }
+}
+
+/// `isDir(path)` — tish convenience kept for back-compat (≈ `statSync().isDirectory()`).
+pub fn is_dir(args: &[Value]) -> Value {
+    Value::Bool(std::path::Path::new(&path_arg(args, 0)).is_dir())
+}
+
+/// `fs.constants` — the access-mode flags.
+pub fn constants() -> Value {
+    let mut m = ObjectMap::default();
+    m.insert("F_OK".into(), Value::Number(0.0));
+    m.insert("R_OK".into(), Value::Number(4.0));
+    m.insert("W_OK".into(), Value::Number(2.0));
+    m.insert("X_OK".into(), Value::Number(1.0));
+    Value::object(m)
+}

--- a/crates/tish_runtime/src/fs_ext.rs
+++ b/crates/tish_runtime/src/fs_ext.rs
@@ -36,10 +36,28 @@ fn settle(r: Result<Value, Value>) -> Value {
     }
 }
 
-/// Generate `pub fn $sync` and `pub fn $promise` over a `*_core`.
+/// Node callback form: the trailing arg is `(err, result) => …`. Run the op on the remaining
+/// args, invoke the callback with `(null, value)` on success or `(err, null)` on failure, and
+/// return null. The op is synchronous under the hood, so the callback fires synchronously.
+fn run_callback(core: fn(&[Value]) -> Result<Value, Value>, args: &[Value]) -> Value {
+    let cb = args.last().cloned().unwrap_or(Value::Null);
+    let op_args: &[Value] = if args.len() > 1 { &args[..args.len() - 1] } else { &[] };
+    let (err, data) = match core(op_args) {
+        Ok(v) => (Value::Null, v),
+        Err(e) => (e, Value::Null),
+    };
+    tishlang_core::value_call(&cb, &[err, data]);
+    Value::Null
+}
+
+/// Generate the sync export (dual: a trailing function arg switches to the Node callback form)
+/// and the promise export over a `*_core`.
 macro_rules! fs_method {
     ($sync:ident, $promise:ident, $core:ident) => {
         pub fn $sync(args: &[Value]) -> Value {
+            if let Some(Value::Function(_)) = args.last() {
+                return run_callback($core, args);
+            }
             unwrap($core(args))
         }
         pub fn $promise(args: &[Value]) -> Value {

--- a/crates/tish_runtime/src/fs_ext.rs
+++ b/crates/tish_runtime/src/fs_ext.rs
@@ -103,20 +103,20 @@ fn stats_object(md: &std::fs::Metadata) -> Value {
 
 // ── cores ─────────────────────────────────────────────────────────────────────────────────
 
-fn read_file_core(args: &[Value]) -> Result<Value, Value> {
+pub fn read_file_core(args: &[Value]) -> Result<Value, Value> {
     std::fs::read_to_string(path_arg(args, 0))
         .map(|s| Value::String(s.into()))
         .map_err(io_err)
 }
 
-fn read_file_bytes_core(args: &[Value]) -> Result<Value, Value> {
+pub fn read_file_bytes_core(args: &[Value]) -> Result<Value, Value> {
     std::fs::read(path_arg(args, 0))
         .map(|b| Value::Array(VmRef::new(b.into_iter().map(|x| Value::Number(x as f64)).collect())))
         .map_err(io_err)
 }
 
 /// Write a string, or a byte array (numbers 0–255), to a file.
-fn write_file_core(args: &[Value]) -> Result<Value, Value> {
+pub fn write_file_core(args: &[Value]) -> Result<Value, Value> {
     let path = path_arg(args, 0);
     let res = match args.get(1) {
         Some(Value::Array(a)) => {
@@ -133,7 +133,7 @@ fn write_file_core(args: &[Value]) -> Result<Value, Value> {
     res.map(|_| Value::Null).map_err(io_err)
 }
 
-fn append_file_core(args: &[Value]) -> Result<Value, Value> {
+pub fn append_file_core(args: &[Value]) -> Result<Value, Value> {
     use std::io::Write;
     let path = path_arg(args, 0);
     let data = args.get(1).map(|v| v.to_display_string()).unwrap_or_default();
@@ -146,14 +146,14 @@ fn append_file_core(args: &[Value]) -> Result<Value, Value> {
         .map_err(io_err)
 }
 
-fn stat_core(args: &[Value]) -> Result<Value, Value> {
+pub fn stat_core(args: &[Value]) -> Result<Value, Value> {
     std::fs::metadata(path_arg(args, 0)).map(|m| stats_object(&m)).map_err(io_err)
 }
-fn lstat_core(args: &[Value]) -> Result<Value, Value> {
+pub fn lstat_core(args: &[Value]) -> Result<Value, Value> {
     std::fs::symlink_metadata(path_arg(args, 0)).map(|m| stats_object(&m)).map_err(io_err)
 }
 
-fn readdir_core(args: &[Value]) -> Result<Value, Value> {
+pub fn readdir_core(args: &[Value]) -> Result<Value, Value> {
     std::fs::read_dir(path_arg(args, 0))
         .map(|entries| {
             let names: Vec<Value> = entries
@@ -166,7 +166,7 @@ fn readdir_core(args: &[Value]) -> Result<Value, Value> {
 }
 
 /// `mkdir(path[, { recursive }])` — recursive creates parents.
-fn mkdir_core(args: &[Value]) -> Result<Value, Value> {
+pub fn mkdir_core(args: &[Value]) -> Result<Value, Value> {
     let path = path_arg(args, 0);
     let recursive = opt_bool(args.get(1), "recursive");
     let res = if recursive {
@@ -178,7 +178,7 @@ fn mkdir_core(args: &[Value]) -> Result<Value, Value> {
 }
 
 /// `rm(path[, { recursive }])` — file, or whole tree when recursive.
-fn rm_core(args: &[Value]) -> Result<Value, Value> {
+pub fn rm_core(args: &[Value]) -> Result<Value, Value> {
     let path = path_arg(args, 0);
     let recursive = opt_bool(args.get(1), "recursive");
     let md = std::fs::symlink_metadata(&path);
@@ -195,29 +195,29 @@ fn rm_core(args: &[Value]) -> Result<Value, Value> {
     res.map(|_| Value::Null).map_err(io_err)
 }
 
-fn rmdir_core(args: &[Value]) -> Result<Value, Value> {
+pub fn rmdir_core(args: &[Value]) -> Result<Value, Value> {
     std::fs::remove_dir(path_arg(args, 0)).map(|_| Value::Null).map_err(io_err)
 }
-fn unlink_core(args: &[Value]) -> Result<Value, Value> {
+pub fn unlink_core(args: &[Value]) -> Result<Value, Value> {
     std::fs::remove_file(path_arg(args, 0)).map(|_| Value::Null).map_err(io_err)
 }
-fn rename_core(args: &[Value]) -> Result<Value, Value> {
+pub fn rename_core(args: &[Value]) -> Result<Value, Value> {
     std::fs::rename(path_arg(args, 0), path_arg(args, 1)).map(|_| Value::Null).map_err(io_err)
 }
-fn copy_file_core(args: &[Value]) -> Result<Value, Value> {
+pub fn copy_file_core(args: &[Value]) -> Result<Value, Value> {
     std::fs::copy(path_arg(args, 0), path_arg(args, 1)).map(|_| Value::Null).map_err(io_err)
 }
-fn realpath_core(args: &[Value]) -> Result<Value, Value> {
+pub fn realpath_core(args: &[Value]) -> Result<Value, Value> {
     std::fs::canonicalize(path_arg(args, 0))
         .map(|p| Value::String(p.to_string_lossy().into()))
         .map_err(io_err)
 }
-fn readlink_core(args: &[Value]) -> Result<Value, Value> {
+pub fn readlink_core(args: &[Value]) -> Result<Value, Value> {
     std::fs::read_link(path_arg(args, 0))
         .map(|p| Value::String(p.to_string_lossy().into()))
         .map_err(io_err)
 }
-fn truncate_core(args: &[Value]) -> Result<Value, Value> {
+pub fn truncate_core(args: &[Value]) -> Result<Value, Value> {
     let len = match args.get(1) {
         Some(Value::Number(n)) => *n as u64,
         _ => 0,
@@ -234,7 +234,7 @@ fn truncate_core(args: &[Value]) -> Result<Value, Value> {
 /// characters; a timestamp suffix is both predictable (a temp-dir security smell) and collision-prone
 /// under rapid calls. Use a random suffix and rely on `create_dir`'s exclusive semantics, retrying on
 /// the astronomically-rare collision.
-fn mkdtemp_core(args: &[Value]) -> Result<Value, Value> {
+pub fn mkdtemp_core(args: &[Value]) -> Result<Value, Value> {
     let prefix = path_arg(args, 0);
     for _ in 0..16 {
         // 10 base-36 chars derived from a random u64 (~51 bits of entropy).
@@ -258,7 +258,7 @@ fn mkdtemp_core(args: &[Value]) -> Result<Value, Value> {
 }
 
 /// `cp(src, dest[, { recursive }])` — copy a file, or a directory tree when recursive.
-fn cp_core(args: &[Value]) -> Result<Value, Value> {
+pub fn cp_core(args: &[Value]) -> Result<Value, Value> {
     let src = path_arg(args, 0);
     let dest = path_arg(args, 1);
     let recursive = opt_bool(args.get(2), "recursive");

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -1602,6 +1602,11 @@ mod timers;
 #[cfg(any(feature = "http", feature = "promise"))]
 mod promise;
 
+/// Node-compatible fs surface (sync + `fs/promises`). Referenced by the backends via
+/// `tishlang_runtime::fs_ext::*`. See issue #122.
+#[cfg(feature = "fs")]
+pub mod fs_ext;
+
 #[cfg(feature = "http")]
 mod native_promise;
 

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -182,13 +182,13 @@ fn get_builtin_export(enabled: &HashSet<String>, spec: &str, export_name: &str) 
     if spec == "tish:fs" && cap_allows(enabled, "fs") {
         use tishlang_runtime::fs_ext as fx;
         return match export_name {
-            // legacy tish names — unchanged contracts
-            "readFile" => Some(Value::native(|a: &[Value]| tishlang_runtime::read_file(a))),
-            "writeFile" => Some(Value::native(|a: &[Value]| tishlang_runtime::write_file(a))),
+            // tish names → the dual fs_ext functions (sync, or Node callback if a fn is passed)
+            "readFile" => Some(Value::native(|a: &[Value]| fx::read_file(a))),
+            "writeFile" => Some(Value::native(|a: &[Value]| fx::write_file(a))),
             "fileExists" => Some(Value::native(|a: &[Value]| tishlang_runtime::file_exists(a))),
             "isDir" => Some(Value::native(|a: &[Value]| tishlang_runtime::is_dir(a))),
-            "readDir" => Some(Value::native(|a: &[Value]| tishlang_runtime::read_dir(a))),
-            "readFileBytes" => Some(Value::native(|a: &[Value]| tishlang_runtime::read_file_bytes(a))),
+            "readDir" => Some(Value::native(|a: &[Value]| fx::readdir(a))),
+            "readFileBytes" => Some(Value::native(|a: &[Value]| fx::read_file_bytes(a))),
             // Node-compatible names + new methods (sync) — issue #122
             "readFileSync" => Some(Value::native(|a: &[Value]| fx::read_file(a))),
             "readFileBytesSync" => Some(Value::native(|a: &[Value]| fx::read_file_bytes(a))),

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -180,28 +180,65 @@ pub fn all_compiled_capabilities() -> HashSet<String> {
 fn get_builtin_export(enabled: &HashSet<String>, spec: &str, export_name: &str) -> Option<Value> {
     #[cfg(feature = "fs")]
     if spec == "tish:fs" && cap_allows(enabled, "fs") {
+        use tishlang_runtime::fs_ext as fx;
         return match export_name {
-            "readFile" => Some(Value::native(|args: &[Value]| {
-                tishlang_runtime::read_file(args)
-            })),
-            "writeFile" => Some(Value::native(|args: &[Value]| {
-                tishlang_runtime::write_file(args)
-            })),
-            "fileExists" => Some(Value::native(|args: &[Value]| {
-                tishlang_runtime::file_exists(args)
-            })),
-            "isDir" => Some(Value::native(|args: &[Value]| {
-                tishlang_runtime::is_dir(args)
-            })),
-            "readDir" => Some(Value::native(|args: &[Value]| {
-                tishlang_runtime::read_dir(args)
-            })),
-            "mkdir" => Some(Value::native(|args: &[Value]| {
-                tishlang_runtime::mkdir(args)
-            })),
-            "readFileBytes" => Some(Value::native(|args: &[Value]| {
-                tishlang_runtime::read_file_bytes(args)
-            })),
+            // legacy tish names — unchanged contracts
+            "readFile" => Some(Value::native(|a: &[Value]| tishlang_runtime::read_file(a))),
+            "writeFile" => Some(Value::native(|a: &[Value]| tishlang_runtime::write_file(a))),
+            "fileExists" => Some(Value::native(|a: &[Value]| tishlang_runtime::file_exists(a))),
+            "isDir" => Some(Value::native(|a: &[Value]| tishlang_runtime::is_dir(a))),
+            "readDir" => Some(Value::native(|a: &[Value]| tishlang_runtime::read_dir(a))),
+            "readFileBytes" => Some(Value::native(|a: &[Value]| tishlang_runtime::read_file_bytes(a))),
+            // Node-compatible names + new methods (sync) — issue #122
+            "readFileSync" => Some(Value::native(|a: &[Value]| fx::read_file(a))),
+            "readFileBytesSync" => Some(Value::native(|a: &[Value]| fx::read_file_bytes(a))),
+            "writeFileSync" => Some(Value::native(|a: &[Value]| fx::write_file(a))),
+            "appendFile" | "appendFileSync" => Some(Value::native(|a: &[Value]| fx::append_file(a))),
+            "existsSync" => Some(Value::native(|a: &[Value]| fx::exists(a))),
+            "mkdir" | "mkdirSync" => Some(Value::native(|a: &[Value]| fx::mkdir(a))),
+            "readdir" | "readdirSync" => Some(Value::native(|a: &[Value]| fx::readdir(a))),
+            "stat" | "statSync" => Some(Value::native(|a: &[Value]| fx::stat(a))),
+            "lstat" | "lstatSync" => Some(Value::native(|a: &[Value]| fx::lstat(a))),
+            "rm" | "rmSync" => Some(Value::native(|a: &[Value]| fx::rm(a))),
+            "rmdir" | "rmdirSync" => Some(Value::native(|a: &[Value]| fx::rmdir(a))),
+            "unlink" | "unlinkSync" => Some(Value::native(|a: &[Value]| fx::unlink(a))),
+            "rename" | "renameSync" => Some(Value::native(|a: &[Value]| fx::rename(a))),
+            "copyFile" | "copyFileSync" => Some(Value::native(|a: &[Value]| fx::copy_file(a))),
+            "realpath" | "realpathSync" => Some(Value::native(|a: &[Value]| fx::realpath(a))),
+            "readlink" | "readlinkSync" => Some(Value::native(|a: &[Value]| fx::readlink(a))),
+            "truncate" | "truncateSync" => Some(Value::native(|a: &[Value]| fx::truncate(a))),
+            "mkdtemp" | "mkdtempSync" => Some(Value::native(|a: &[Value]| fx::mkdtemp(a))),
+            "cp" | "cpSync" => Some(Value::native(|a: &[Value]| fx::cp(a))),
+            "access" | "accessSync" => Some(Value::native(|a: &[Value]| fx::access(a))),
+            "constants" => Some(fx::constants()),
+            _ => None,
+        };
+    }
+    #[cfg(feature = "fs")]
+    if spec == "tish:fs/promises" && cap_allows(enabled, "fs") {
+        use tishlang_runtime::fs_ext as fx;
+        return match export_name {
+            "readFile" => Some(Value::native(|a: &[Value]| fx::read_file_promise(a))),
+            "readFileBytes" => Some(Value::native(|a: &[Value]| fx::read_file_bytes_promise(a))),
+            "writeFile" => Some(Value::native(|a: &[Value]| fx::write_file_promise(a))),
+            "appendFile" => Some(Value::native(|a: &[Value]| fx::append_file_promise(a))),
+            "mkdir" => Some(Value::native(|a: &[Value]| fx::mkdir_promise(a))),
+            "readdir" => Some(Value::native(|a: &[Value]| fx::readdir_promise(a))),
+            "stat" => Some(Value::native(|a: &[Value]| fx::stat_promise(a))),
+            "lstat" => Some(Value::native(|a: &[Value]| fx::lstat_promise(a))),
+            "rm" => Some(Value::native(|a: &[Value]| fx::rm_promise(a))),
+            "rmdir" => Some(Value::native(|a: &[Value]| fx::rmdir_promise(a))),
+            "unlink" => Some(Value::native(|a: &[Value]| fx::unlink_promise(a))),
+            "rename" => Some(Value::native(|a: &[Value]| fx::rename_promise(a))),
+            "copyFile" => Some(Value::native(|a: &[Value]| fx::copy_file_promise(a))),
+            "realpath" => Some(Value::native(|a: &[Value]| fx::realpath_promise(a))),
+            "readlink" => Some(Value::native(|a: &[Value]| fx::readlink_promise(a))),
+            "truncate" => Some(Value::native(|a: &[Value]| fx::truncate_promise(a))),
+            "mkdtemp" => Some(Value::native(|a: &[Value]| fx::mkdtemp_promise(a))),
+            "cp" => Some(Value::native(|a: &[Value]| fx::cp_promise(a))),
+            "access" => Some(Value::native(|a: &[Value]| fx::access_promise(a))),
+            "exists" => Some(Value::native(|a: &[Value]| fx::exists_promise(a))),
+            "constants" => Some(fx::constants()),
             _ => None,
         };
     }


### PR DESCRIPTION
Refs #122. Brings `tish:fs` toward Node `fs` / `fs/promises` parity on the **bytecode VM** (the default `tish run` backend).

## Specifiers (resolver)
- `node:` prefix is stripped → `node:fs` / `node:fs/promises` resolve like the bare forms
- new `fs/promises` subpath; added the missing bare `tty` alias

```js
import { readFileSync } from "node:fs"
import { readFile } from "node:fs/promises"
```

## Methods (`crates/tish_runtime/src/fs_ext.rs`)
One `*_core` per op + a macro deriving the **sync** export (value / error-object — tish convention) and the **promise** export (fulfilled/rejected `Promise` — Node's `fs/promises` convention):

`readFile`/`readFileBytes`, `writeFile`, `appendFile`, `exists`, `stat`/`lstat` (Node-like **`Stats`**: `isFile()/isDirectory()/size/mtimeMs/…`), `readdir`, `mkdir`, `rm`/`rmdir`/`unlink`, `rename`, `copyFile`/`cp`, `realpath`, `readlink`, `truncate`, `mkdtemp`, `access`, plus `constants` (`F_OK/R_OK/W_OK/X_OK`).

## Naming
Node names are primary (`readFileSync`, `statSync`, `existsSync`, …); the existing tish names (`readFile`, `readDir`, `fileExists`, `isDir`) are kept as **aliases** with their current contracts, so existing code (e.g. scii) is unaffected.

## Async
`tish:fs/promises` exposes the async forms; `fs` now implies the `promise` feature (settled-promise machinery). All shipped/CI builds use `--features full` (already has `promise` via `http`), so the feature change is a no-op there.

## Tests
Integration fixtures exercise the sync surface via `node:fs` (write/append/read/stat/mkdir/copy/readdir/rename/rm + constants) and the async surface via `node:fs/promises` (`await` + `access` rejecting on a missing path). Existing `readFileBytes` test and the full **scii** suite stay green.

## Scope
This PR lands the **resolver + VM backend** — the default `tish run` path — with full sync + `fs/promises` parity. The **native codegen** (`tish build`), the **interpreter backend**, and the Node **callback** forms get the same surface as follow-ups, tracked in #122.