### PR TITLE
fix(lsp): go-to-definition on imported names jumps into the source module (H8)

### DIFF
--- a/crates/tish_lsp/src/import_goto.rs
+++ b/crates/tish_lsp/src/import_goto.rs
@@ -450,6 +450,21 @@ fn resolve_relative_tish(from_dir: &Path, from_s: &str, imported: &str) -> Optio
     crate::find_export(&prog, imported, &u, &src)
 }
 
+/// Resolve a relative default import (`import X from "./m"`) to the `export default` in the source.
+fn resolve_relative_tish_default(from_dir: &Path, from_s: &str) -> Option<Location> {
+    let target = from_dir.join(from_s.trim_start_matches("./"));
+    let target = if target.extension().is_none() {
+        target.with_extension("tish")
+    } else {
+        target
+    };
+    let can = target.canonicalize().ok()?;
+    let u = Url::from_file_path(&can).ok()?;
+    let src = std::fs::read_to_string(&can).ok()?;
+    let prog = tishlang_parser::parse(&src).ok()?;
+    crate::find_default_export(&prog, &u, &src)
+}
+
 /// After same-file [`tishlang_resolve::definition_span`] misses, resolve import sites (Tish files,
 /// `node_modules` packages, and Rust `pub fn` for native / `cargo:` imports).
 pub fn definition_for_import(
@@ -474,12 +489,13 @@ pub fn definition_for_import(
         };
         let from_s = from.as_ref();
         for sp in specifiers {
-            let (imported, local) = match sp {
+            let (imported, local, is_default) = match sp {
                 ImportSpecifier::Named { name, alias, .. } => (
                     name.as_ref(),
                     alias.as_ref().map(|a| a.as_ref()).unwrap_or(name.as_ref()),
+                    false,
                 ),
-                ImportSpecifier::Default { name, .. } => (name.as_ref(), name.as_ref()),
+                ImportSpecifier::Default { name, .. } => (name.as_ref(), name.as_ref(), true),
                 ImportSpecifier::Namespace { .. } => continue,
             };
             if local != word {
@@ -487,7 +503,13 @@ pub fn definition_for_import(
             }
 
             if from_s.starts_with("./") || from_s.starts_with("../") {
-                return resolve_relative_tish(from_dir, from_s, imported);
+                // A default import binds the source module's `export default`, which has no name to
+                // match; resolve it directly. Named imports resolve by exported name.
+                return if is_default {
+                    resolve_relative_tish_default(from_dir, from_s)
+                } else {
+                    resolve_relative_tish(from_dir, from_s, imported)
+                };
             }
 
             if is_native_import(from_s) {

--- a/crates/tish_lsp/src/main.rs
+++ b/crates/tish_lsp/src/main.rs
@@ -410,6 +410,24 @@ impl LanguageServer for Backend {
         if let Some(def) =
             tishlang_resolve::definition_span(&program, &text, position.line, position.character)
         {
+            // If the use resolves to an import specifier, jump THROUGH the import into the source
+            // module (a relative .tish file) instead of to the local import line. Falls back to the
+            // specifier span when the source module can't be located.
+            if is_import_specifier_span(&program, &def) {
+                if let Ok(ref file_path) = uri.to_file_path() {
+                    let word = word_at_position(&text, position);
+                    let roots = self.roots.read().unwrap().clone();
+                    if let Some(loc) = import_goto::definition_for_import(
+                        &program,
+                        file_path,
+                        word.as_str(),
+                        &roots,
+                        self.cargo_src_cache.as_ref(),
+                    ) {
+                        return Ok(Some(GotoDefinitionResponse::Scalar(loc)));
+                    }
+                }
+            }
             let range = span_to_range(&def, &text);
             return Ok(Some(GotoDefinitionResponse::Scalar(Location {
                 uri: uri.clone(),
@@ -912,6 +930,28 @@ pub(crate) fn find_export(
     None
 }
 
+/// Locate the `export default …` statement in a module (the target of a default import).
+pub(crate) fn find_default_export(
+    program: &tishlang_ast::Program,
+    uri: &Url,
+    text: &str,
+) -> Option<Location> {
+    for s in &program.statements {
+        if let tishlang_ast::Statement::Export { declaration, span } = s {
+            if matches!(
+                declaration.as_ref(),
+                tishlang_ast::ExportDeclaration::Default(_)
+            ) {
+                return Some(Location {
+                    uri: uri.clone(),
+                    range: span_to_range(span, text),
+                });
+            }
+        }
+    }
+    None
+}
+
 fn find_decl_in_stmt(
     s: &tishlang_ast::Statement,
     word: &str,
@@ -961,6 +1001,31 @@ fn span_to_range(span: &tishlang_ast::Span, text: &str) -> Range {
             ),
         }
     }
+}
+
+/// Whether `span` is the local-name span of an import specifier — i.e. `definition_span` resolved a
+/// use to an `import { … }` line. Go-to-definition should follow such a result through to the source
+/// module rather than jumping to the import line itself.
+fn is_import_specifier_span(program: &tishlang_ast::Program, span: &tishlang_ast::Span) -> bool {
+    use tishlang_ast::{ImportSpecifier, Statement};
+    program.statements.iter().any(|s| {
+        if let Statement::Import { specifiers, .. } = s {
+            specifiers.iter().any(|sp| {
+                let local = match sp {
+                    ImportSpecifier::Named {
+                        name_span,
+                        alias_span,
+                        ..
+                    } => alias_span.as_ref().unwrap_or(name_span),
+                    ImportSpecifier::Namespace { name_span, .. }
+                    | ImportSpecifier::Default { name_span, .. } => name_span,
+                };
+                local == span
+            })
+        } else {
+            false
+        }
+    })
 }
 
 fn word_at_position(text: &str, position: Position) -> String {
@@ -1520,6 +1585,36 @@ mod hover_tests {
         for expected in ["foo", "Status", "a", "b", "ext", "plain"] {
             assert!(names.contains(&expected), "outline missing `{expected}`: {names:?}");
         }
+    }
+
+    #[test]
+    fn is_import_specifier_span_detects_imports() {
+        let src = "import { foo } from \"./m\"\nfoo()\nlet x = 1\nx\n";
+        let program = tishlang_parser::parse(src).unwrap();
+        // `foo()` (line 1) resolves to the import specifier → go-to-def should follow it cross-file.
+        let foo_def = tishlang_resolve::definition_span(&program, src, 1, 0).expect("foo resolves");
+        assert!(
+            is_import_specifier_span(&program, &foo_def),
+            "foo resolves to an import specifier"
+        );
+        // `x` (line 3) resolves to the local `let` → not an import, jump to the local def as usual.
+        let x_def = tishlang_resolve::definition_span(&program, src, 3, 0).expect("x resolves");
+        assert!(
+            !is_import_specifier_span(&program, &x_def),
+            "x is a local binding, not an import"
+        );
+    }
+
+    #[test]
+    fn find_default_export_locates_export_default() {
+        let src = "export fn foo() {}\nexport default 42\n";
+        let program = tishlang_parser::parse(src).unwrap();
+        let uri = Url::parse("file:///m.tish").unwrap();
+        let loc = find_default_export(&program, &uri, src).expect("default export found");
+        assert_eq!(loc.range.start.line, 1, "export default is on line 1");
+        let none_src = "export fn bar() {}\n";
+        let p2 = tishlang_parser::parse(none_src).unwrap();
+        assert!(find_default_export(&p2, &uri, none_src).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #206 (retarget to `main` after it merges). Closes the H8 audit finding (#132).

### Problem
Cmd-click / go-to-definition on a use of a relatively-imported name jumped to the local `import` line instead of opening the source module — and clicking the import specifier itself did nothing. `definition_span` resolves the use to the import specifier, so the handler returned that span and `import_goto::definition_for_import` (which opens `./m.tish` and finds the export) was effectively **dead code**, shadowed by the early return.

### Fix
When the resolved definition is an import specifier (`is_import_specifier_span`), follow the import through to the source module via `definition_for_import`, falling back to the specifier span if the module can't be located. Also handle **default imports**: `import X from "./m"` now resolves to the module's `export default` (new `find_default_export` + `resolve_relative_tish_default`), which `find_export` couldn't match by name.

### Tests
`tish_lsp` 18 passing, incl. `is_import_specifier_span` verified against a real resolved span (a `foo()` use resolves to the import specifier; a local `let` does not) and `find_default_export`.