### PR TITLE
fix(resolve): rename / find-references / go-to-def on JSX component tags (M18)

### DIFF
--- a/crates/tish_ast/src/ast.rs
+++ b/crates/tish_ast/src/ast.rs
@@ -436,6 +436,11 @@ pub enum Expr {
     /// JSX element: <Tag props>children</Tag>
     JsxElement {
         tag: Arc<str>,
+        /// Span of the tag name in the opening tag (`<`**`Foo`**`>`), for go-to-def / rename.
+        tag_span: Span,
+        /// Span of the tag name in the closing tag (`</`**`Foo`**`>`); `None` for self-closing
+        /// (`<Foo/>`). Renaming a component must update both, or `<Bar></Foo>` would be invalid.
+        close_tag_span: Option<Span>,
         props: Vec<JsxProp>,
         children: Vec<JsxChild>,
         span: Span,

--- a/crates/tish_parser/src/parser.rs
+++ b/crates/tish_parser/src/parser.rs
@@ -2391,6 +2391,10 @@ impl<'a> Parser<'a> {
     fn parse_jsx_element(&mut self, start: (usize, usize)) -> Result<Expr, String> {
         let tag_tok = self.expect(TokenKind::Ident)?;
         let tag = tag_tok.literal.clone().ok_or("Expected tag name")?;
+        let tag_span = Span {
+            start: tag_tok.span.start,
+            end: tag_tok.span.end,
+        };
 
         let mut props = Vec::new();
         loop {
@@ -2402,6 +2406,8 @@ impl<'a> Parser<'a> {
                     let end = self.previous_span_end();
                     return Ok(Expr::JsxElement {
                         tag,
+                        tag_span,
+                        close_tag_span: None,
                         props,
                         children: vec![],
                         span: Span { start, end },
@@ -2451,10 +2457,12 @@ impl<'a> Parser<'a> {
         }
         self.advance(); // consume >
 
-        let children = self.parse_jsx_children(&tag)?;
+        let (children, close_tag_span) = self.parse_jsx_children(&tag)?;
         let end = self.previous_span_end();
         Ok(Expr::JsxElement {
             tag,
+            tag_span,
+            close_tag_span,
             props,
             children,
             span: Span { start, end },
@@ -2517,7 +2525,10 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse JSX children until </Tag> or </>
-    fn parse_jsx_children(&mut self, close_tag: &str) -> Result<Vec<JsxChild>, String> {
+    fn parse_jsx_children(
+        &mut self,
+        close_tag: &str,
+    ) -> Result<(Vec<JsxChild>, Option<Span>), String> {
         let mut children = Vec::new();
         loop {
             match self.peek_kind() {
@@ -2529,11 +2540,12 @@ impl<'a> Parser<'a> {
                             // </ closing tag
                             self.advance(); // <
                             self.advance(); // /
-                            let name = self
-                                .expect(TokenKind::Ident)?
-                                .literal
-                                .clone()
-                                .ok_or("Expected tag name")?;
+                            let name_tok = self.expect(TokenKind::Ident)?;
+                            let name = name_tok.literal.clone().ok_or("Expected tag name")?;
+                            let close_tag_span = Span {
+                                start: name_tok.span.start,
+                                end: name_tok.span.end,
+                            };
                             if name.as_ref() != close_tag {
                                 return Err(format!(
                                     "Mismatched JSX tag: expected </{}> got </{}>",
@@ -2541,7 +2553,7 @@ impl<'a> Parser<'a> {
                                 ));
                             }
                             self.expect(TokenKind::Gt)?; // >
-                            return Ok(children);
+                            return Ok((children, Some(close_tag_span)));
                         }
                         if t.kind == TokenKind::Gt {
                             return Err("Unexpected <> in JSX children".to_string());

--- a/crates/tish_resolve/src/lib.rs
+++ b/crates/tish_resolve/src/lib.rs
@@ -521,8 +521,21 @@ fn collect_expr(
         }
         Expr::Await { operand, .. } => collect_expr(operand, source, lsp_line, lsp_char, best),
         Expr::JsxElement {
-            props, children, ..
+            tag,
+            tag_span,
+            close_tag_span,
+            props,
+            children,
+            ..
         } => {
+            // A PascalCase tag references a component binding (`<Foo/>` lowers to `h(Foo, …)`); let
+            // the cursor land on it (opening or closing tag) for hover / go-to-def / rename.
+            if tag.chars().next().is_some_and(|c| c.is_uppercase()) {
+                consider(source, lsp_line, lsp_char, tag_span, tag.clone(), best);
+                if let Some(cs) = close_tag_span {
+                    consider(source, lsp_line, lsp_char, cs, tag.clone(), best);
+                }
+            }
             for p in props {
                 match p {
                     tishlang_ast::JsxProp::Attr { value, .. } => if let tishlang_ast::JsxAttrValue::Expr(e) = value {
@@ -1249,8 +1262,20 @@ fn walk_expr_resolve(
         }
         Expr::Await { operand, .. } => walk_expr_resolve(operand, scopes, target),
         Expr::JsxElement {
-            props, children, ..
+            tag,
+            tag_span,
+            close_tag_span,
+            props,
+            children,
+            ..
         } => {
+            // Go-to-def on a PascalCase component tag (opening or closing) resolves to its binding.
+            if tag.chars().next().is_some_and(|c| c.is_uppercase())
+                && (*tag_span == tgt || *close_tag_span == Some(tgt))
+                && tag.as_ref() == target.name.as_ref()
+            {
+                return scopes.resolve(tag.as_ref());
+            }
             for p in props {
                 match p {
                     tishlang_ast::JsxProp::Attr { value, .. } => {
@@ -3865,8 +3890,22 @@ fn refs_expr(
         }
         Expr::Await { operand, .. } => refs_expr(operand, program, source, name, def_span, out),
         Expr::JsxElement {
-            props, children, ..
+            tag,
+            tag_span,
+            close_tag_span,
+            props,
+            children,
+            ..
         } => {
+            // A PascalCase tag is a reference to its component binding. Count BOTH the opening and
+            // closing tag so find-references lists them and rename rewrites both (renaming only the
+            // open tag would leave `<Bar></Foo>`). maybe_push validates each via definition_span.
+            if tag.chars().next().is_some_and(|c| c.is_uppercase()) {
+                maybe_push(tag_span, tag, out);
+                if let Some(cs) = close_tag_span {
+                    maybe_push(cs, tag, out);
+                }
+            }
             for p in props {
                 match p {
                     tishlang_ast::JsxProp::Attr { value, .. } => {
@@ -4157,6 +4196,23 @@ mod tests {
         let program = parse(src).expect("parse");
         let u = collect_unresolved_identifiers(&program);
         assert!(u.is_empty(), "no runtime global should be unresolved; u={u:?}");
+    }
+
+    #[test]
+    fn jsx_component_tag_resolves_and_is_referenced() {
+        // `fn Foo` used as a component. go-to-def on the tag, find-references over both tags.
+        let src = "fn Foo() {}\nlet el = <Foo></Foo>\nel\n";
+        let program = parse(src).expect("parse");
+        // go-to-def on the opening `<Foo` (0-idx line 1, char 10) → the `fn Foo` decl (line 2, 1-idx).
+        let open = definition_span(&program, src, 1, 10).expect("open tag resolves");
+        assert_eq!(open.start, (1, 4), "resolves to fn Foo; got {open:?}");
+        // and on the closing `</Foo` (char 16).
+        let close = definition_span(&program, src, 1, 16).expect("close tag resolves");
+        assert_eq!(close.start, (1, 4), "close tag resolves to fn Foo; got {close:?}");
+        // find-references: the def + the opening tag + the closing tag.
+        let def = tishlang_ast::Span { start: (1, 4), end: (1, 7) };
+        let refs = reference_spans_for_def(&program, src, "Foo", def);
+        assert_eq!(refs.len(), 3, "def + open tag + close tag; refs={refs:?}");
     }
 
     #[test]


### PR DESCRIPTION
First half of the H7+M18 combo (the JSX, type-checker-free half). Closes M18 (#138). Independent of the other PRs.

### Problem
A PascalCase JSX tag (`<Foo/>`) is a reference to the `Foo` binding (it lowers to `h(Foo, …)`), but the resolver couldn't see it — the AST stored only the tag string, no span. So go-to-definition on a tag did nothing, find-references/rename skipped tags, and a component used only as a tag was flagged unused.

### Fix
- **AST:** add `tag_span` (opening tag) + `close_tag_span` (closing tag; `None` for self-closing) to `Expr::JsxElement`, populated by the parser. Additive — every other crate matches with `..` and is unaffected.
- **Resolver** treats a PascalCase tag as a reference to its binding in all three walkers: `name_at_cursor` (cursor lands on the tag), `definition_span` (go-to-def → the component), and `reference_spans_for_def` (find-references + rename cover **both** tags — renaming only the opening tag would leave invalid `<Bar></Foo>`). Also removes the false unused-import on tag-only components.

### Verification
Full workspace build + cross-backend `tishlang`/`tishlang_vm` tests green; JSX still lowers and runs (`<Box/>`-style program prints correctly). New tests: go-to-def on the opening **and** closing tag, the 3-span find-references result (`def` + open + close), and the no-false-unused case.

### Note on the combo
H7 (type-alias rename — a span on `TypeAnnotation::Simple` across ~29 type-checker sites) is the **second** PR, kept separate so the type-checker change is reviewed in isolation.