### PR TITLE
chore: prune 14 unused deps + remove dead protoc/Lance build requirement (fixes #215)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,70 +2325,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "protoc-bin-vendored"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
-dependencies = [
- "protoc-bin-vendored-linux-aarch_64",
- "protoc-bin-vendored-linux-ppcle_64",
- "protoc-bin-vendored-linux-s390_64",
- "protoc-bin-vendored-linux-x86_32",
- "protoc-bin-vendored-linux-x86_64",
- "protoc-bin-vendored-macos-aarch_64",
- "protoc-bin-vendored-macos-x86_64",
- "protoc-bin-vendored-win32",
-]
-
-[[package]]
-name = "protoc-bin-vendored-linux-aarch_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
-
-[[package]]
-name = "protoc-bin-vendored-linux-ppcle_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
-
-[[package]]
-name = "protoc-bin-vendored-linux-s390_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
-
-[[package]]
-name = "protoc-bin-vendored-linux-x86_32"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
-
-[[package]]
-name = "protoc-bin-vendored-linux-x86_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
-
-[[package]]
-name = "protoc-bin-vendored-macos-aarch_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
-
-[[package]]
-name = "protoc-bin-vendored-macos-x86_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
-
-[[package]]
-name = "protoc-bin-vendored-win32"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
-
-[[package]]
 name = "psm"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3277,8 +3213,6 @@ dependencies = [
  "tishlang_eval",
  "tishlang_ffi",
  "tishlang_js_to_tish",
- "tishlang_lexer",
- "tishlang_llvm",
  "tishlang_native",
  "tishlang_opt",
  "tishlang_parser",
@@ -3295,9 +3229,6 @@ version = "0.1.0"
 [[package]]
 name = "tishlang_build_utils"
 version = "0.1.0"
-dependencies = [
- "protoc-bin-vendored",
-]
 
 [[package]]
 name = "tishlang_builtins"
@@ -3314,7 +3245,6 @@ name = "tishlang_bytecode"
 version = "0.1.0"
 dependencies = [
  "tishlang_ast",
- "tishlang_compile",
  "tishlang_core",
  "tishlang_opt",
  "tishlang_parser",
@@ -3392,15 +3322,11 @@ name = "tishlang_cranelift"
 version = "0.1.0"
 dependencies = [
  "cranelift",
- "cranelift-codegen",
- "cranelift-frontend",
  "cranelift-module",
  "cranelift-native",
  "cranelift-object",
- "target-lexicon",
  "tishlang_build_utils",
  "tishlang_bytecode",
- "tishlang_core",
 ]
 
 [[package]]
@@ -3408,7 +3334,6 @@ name = "tishlang_cranelift_runtime"
 version = "0.1.0"
 dependencies = [
  "tishlang_bytecode",
- "tishlang_core",
  "tishlang_vm",
 ]
 
@@ -3417,11 +3342,8 @@ name = "tishlang_eval"
 version = "0.1.0"
 dependencies = [
  "ahash",
- "fancy-regex",
- "futures",
  "indexmap",
  "rand 0.10.1",
- "reqwest",
  "stacker",
  "tiny_http",
  "tishlang_ast",
@@ -3569,13 +3491,11 @@ dependencies = [
  "crossterm",
  "futures",
  "futures-util",
- "http",
  "http-body-util",
  "hyper",
  "hyper-util",
  "lazy_static",
  "libc",
- "pin-project-lite",
  "reqwest",
  "socket2 0.5.10",
  "tiny_http",

--- a/crates/tish/Cargo.toml
+++ b/crates/tish/Cargo.toml
@@ -6,6 +6,12 @@ description = "Tish CLI - run, REPL, compile to native"
 license-file = { workspace = true }
 repository = { workspace = true }
 
+# tishlang_runtime has no direct source use here — it's required by the http/fs/process/
+# regex/ws/tty feature-forwards below (`tishlang_runtime/<feat>`). cargo-machete only scans
+# source, so it false-flags it; ignore it.
+[package.metadata.cargo-machete]
+ignored = ["tishlang_runtime"]
+
 [[bin]]
 name = "tish"
 path = "src/main.rs"
@@ -38,7 +44,6 @@ tty     = ["tishlang_eval/tty",     "tishlang_runtime/tty",     "tishlang_compil
 # GPU compute — Apple Silicon only
 [dependencies]
 rustyline = { version = "17", features = ["with-file-history"] }
-tishlang_lexer = { path = "../tish_lexer", version = ">=0.1" }
 tishlang_ast = { path = "../tish_ast", version = ">=0.1" }
 tishlang_parser = { path = "../tish_parser", version = ">=0.1" }
 tishlang_eval = { path = "../tish_eval", version = ">=0.1" }
@@ -49,7 +54,6 @@ tishlang_opt = { path = "../tish_opt", version = ">=0.1" }
 tishlang_vm = { path = "../tish_vm", version = ">=0.1" }
 tishlang_ffi = { path = "../tish_ffi", version = ">=0.1" }
 tishlang_native = { path = "../tish_native", version = ">=0.1" }
-tishlang_llvm = { path = "../tish_llvm", version = ">=0.1" }
 tishlang_wasm = { path = "../tish_wasm", version = ">=0.1" }
 tishlang_runtime = { path = "../tish_runtime", version = ">=0.1" }
 tishlang_core = { path = "../tish_core", version = ">=0.1" }

--- a/crates/tish_build_utils/Cargo.toml
+++ b/crates/tish_build_utils/Cargo.toml
@@ -5,7 +5,3 @@ edition = "2021"
 description = "Shared build utilities for Tish (workspace discovery, path resolution)"
 license-file = { workspace = true }
 repository = { workspace = true }
-
-[dependencies]
-# Bundled `protoc` for nested `cargo build` (Lance / prost-build) when none is on PATH.
-protoc-bin-vendored = "3"

--- a/crates/tish_build_utils/src/lib.rs
+++ b/crates/tish_build_utils/src/lib.rs
@@ -355,35 +355,6 @@ pub fn create_build_dir(prefix: &str, out_name: &str) -> Result<PathBuf, String>
     Ok(build_dir)
 }
 
-/// `PROTOC` for prost-build in transitive crates (e.g. lance-encoding) during nested `cargo build`.
-/// Respects an existing `PROTOC`, then `protoc` on `PATH`, then `protoc-bin-vendored`.
-fn protoc_for_nested_cargo() -> Option<PathBuf> {
-    // Empty or non-file PROTOC must not short-circuit: prost-build treats "" like a missing binary.
-    if let Some(v) = std::env::var_os("PROTOC") {
-        if !v.is_empty() {
-            let p = PathBuf::from(&v);
-            if p.is_file() {
-                return None;
-            }
-        }
-    }
-    // Prefer vendored protoc over PATH: a broken or non-executable `protoc` on PATH still passes `is_file()`.
-    if let Ok(p) = protoc_bin_vendored::protoc_bin_path() {
-        return Some(p);
-    }
-    let ext = if cfg!(windows) { ".exe" } else { "" };
-    let name = format!("protoc{}", ext);
-    if let Some(paths) = std::env::var_os("PATH") {
-        for dir in std::env::split_paths(&paths) {
-            let candidate = dir.join(&name);
-            if candidate.is_file() {
-                return Some(candidate);
-            }
-        }
-    }
-    None
-}
-
 /// Run cargo build in the given directory.
 /// If `cross_target` is Some, passes `--target` and skips `-C target-cpu=native`.
 pub fn run_cargo_build(
@@ -433,9 +404,6 @@ pub fn run_cargo_build(
     } else {
         cmd.env_remove("CARGO_INCREMENTAL");
     }
-    if let Some(protoc) = protoc_for_nested_cargo() {
-        cmd.env("PROTOC", protoc);
-    }
     let output = cmd
         .output()
         .map_err(|e| format!("Failed to run cargo: {}", e))?;
@@ -459,15 +427,6 @@ mod protoc_tests {
     fn cargo_target_name_replaces_hyphens() {
         assert_eq!(cargo_target_name("hello-ios"), "hello_ios");
         assert_eq!(cargo_target_name("tish_out"), "tish_out");
-    }
-
-    #[test]
-    fn protoc_for_nested_cargo_without_env_uses_vendored_or_path() {
-        let _lock = std::sync::Mutex::new(());
-        let _guard = _lock.lock().unwrap();
-        std::env::remove_var("PROTOC");
-        let p = protoc_for_nested_cargo().expect("expected vendored or PATH protoc");
-        assert!(p.exists(), "resolved protoc should exist: {}", p.display());
     }
 }
 

--- a/crates/tish_bytecode/Cargo.toml
+++ b/crates/tish_bytecode/Cargo.toml
@@ -11,7 +11,6 @@ tishlang_ast = { path = "../tish_ast", version = ">=0.1" }
 tishlang_core = { path = "../tish_core", version = ">=0.1" }
 
 [dev-dependencies]
-tishlang_compile = { path = "../tish_compile", version = ">=0.1" }
 tishlang_parser = { path = "../tish_parser", version = ">=0.1" }
 tishlang_opt = { path = "../tish_opt", version = ">=0.1" }
 tishlang_vm = { path = "../tish_vm", version = ">=0.1" }

--- a/crates/tish_cranelift/Cargo.toml
+++ b/crates/tish_cranelift/Cargo.toml
@@ -9,11 +9,7 @@ repository = { workspace = true }
 [dependencies]
 tishlang_build_utils = { path = "../tish_build_utils", version = ">=0.1" }
 cranelift = "0.130"
-cranelift-codegen = "0.130"
-cranelift-frontend = "0.130"
 cranelift-module = "0.130"
 cranelift-native = "0.130"
 cranelift-object = "0.130"
-target-lexicon = "0.13"
 tishlang_bytecode = { path = "../tish_bytecode", version = ">=0.1" }
-tishlang_core = { path = "../tish_core", version = ">=0.1" }

--- a/crates/tish_cranelift_runtime/Cargo.toml
+++ b/crates/tish_cranelift_runtime/Cargo.toml
@@ -23,4 +23,3 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 tishlang_bytecode = { path = "../tish_bytecode", version = ">=0.1" }
 tishlang_vm = { path = "../tish_vm", version = ">=0.1" }
-tishlang_core = { path = "../tish_core", version = ">=0.1" }

--- a/crates/tish_eval/Cargo.toml
+++ b/crates/tish_eval/Cargo.toml
@@ -13,8 +13,6 @@ timers = []
 http = [
     "timers",
     "tokio",
-    "reqwest",
-    "futures",
     "tiny_http",
     "tishlang_core/regex",
     "dep:tishlang_runtime",
@@ -27,7 +25,7 @@ http = [
 fs = []
 process = []
 tty = ["dep:tishlang_runtime", "tishlang_runtime/tty"]
-regex = ["dep:fancy-regex", "tishlang_core/regex"]
+regex = ["tishlang_core/regex"]
 tokio = ["dep:tokio"]
 ws = ["dep:tishlang_runtime", "tishlang_runtime/ws"]
 
@@ -43,9 +41,6 @@ tishlang_ast = { path = "../tish_ast", version = ">=0.1" }
 tishlang_builtins = { path = "../tish_builtins", version = ">=0.1" }
 tishlang_parser = { path = "../tish_parser", version = ">=0.1" }
 tishlang_core = { path = "../tish_core", version = ">=0.1" }
-reqwest = { version = "0.13.2", default-features = false, features = ["rustls", "json", "stream"], optional = true }
-futures = { version = "0.3.32", optional = true }
 tiny_http = { version = "0.12.0", optional = true }
-fancy-regex = { version = "0.17.0", optional = true }
 tokio = { version = "1.50.0", features = ["rt-multi-thread", "time", "sync"], optional = true }
 tishlang_runtime = { path = "../tish_runtime", version = ">=0.1", optional = true }

--- a/crates/tish_runtime/Cargo.toml
+++ b/crates/tish_runtime/Cargo.toml
@@ -47,8 +47,6 @@ http-hyper = [
     "dep:hyper",
     "dep:hyper-util",
     "dep:http-body-util",
-    "dep:http",
-    "dep:pin-project-lite",
     "dep:core_affinity",
     "tokio/net",
     "tokio/rt",
@@ -92,8 +90,6 @@ crossterm = { version = "0.28", optional = true }
 hyper = { version = "1", default-features = false, features = ["server", "http1", "http2"], optional = true }
 hyper-util = { version = "0.1", features = ["server", "tokio"], optional = true }
 http-body-util = { version = "0.1", optional = true }
-http = { version = "1", optional = true }
-pin-project-lite = { version = "0.2", optional = true }
 core_affinity = { version = "0.8", optional = true }
 tokio-tungstenite = { version = "0.29", optional = true }
 futures-util = { version = "0.3", optional = true }

--- a/crates/tishlang_cargo_bindgen/Cargo.toml
+++ b/crates/tishlang_cargo_bindgen/Cargo.toml
@@ -6,6 +6,11 @@ description = "Generate Rust glue for Tish cargo: imports (bindgen-style, pre-co
 license-file = { workspace = true }
 repository = { workspace = true }
 
+# proc-macro2 is enabled for its `span-locations` feature, not used by name (Span comes
+# via syn). cargo-machete can't see feature-only deps, so it's ignored here.
+[package.metadata.cargo-machete]
+ignored = ["proc-macro2"]
+
 [[bin]]
 name = "tishlang-cargo-bindgen"
 path = "src/main.rs"
@@ -18,6 +23,8 @@ path = "src/lib.rs"
 cargo_metadata = "0.19"
 clap = { version = "4.6", features = ["derive", "color"] }
 pathdiff = "0.2"
+# Not referenced by name (Span comes via syn's re-export), but the `span-locations`
+# feature is load-bearing: it enables Span::start()/end() used in src/lib.rs.
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 serde_json = "1"
 syn = { version = "2.0", features = ["full", "extra-traits"] }


### PR DESCRIPTION
Resolves #215.

Drops **14 declared-but-unused dependencies** across 8 crates and removes the **protoc/Lance build machinery** that made `tish build --target native` fail out of the box.

## protoc/Lance (#215)
`tish_build_utils` pulled `protoc-bin-vendored` to supply a `protoc` for a Lance/prost-build dependency that never landed — **nothing in the graph uses protoc** (no prost/tonic/lance/protobuf consumer in `Cargo.lock`). The vendored resolver baked a CI-only path into the released binary and panicked on it, so native builds needed a manual `PROTOC` env var (undocumented; regressed since v1.8.0). Removing the dep + `protoc_for_nested_cargo()` makes native builds work with **zero protoc dependency**.

## Unused deps removed
- **tish**: `tishlang_lexer`, `tishlang_llvm` (reached via `tishlang_parser` / `tishlang_native`)
- **tish_bytecode**: `tishlang_compile` (dev-dep — tests use this crate's own `compile`)
- **tish_cranelift**: `cranelift-codegen`, `cranelift-frontend`, `target-lexicon`, `tishlang_core` (codegen/ISA come via the `cranelift` umbrella + `cranelift-native`)
- **tish_cranelift_runtime**: `tishlang_core`
- **tish_eval**: `reqwest`, `futures`, `fancy-regex` (the fetch client + regex live in `tishlang_runtime` / `_core`; eval only forwarded the features)
- **tish_runtime**: `http`, `pin-project-lite` (the `http-hyper` backend uses neither)
- **tish_build_utils**: `protoc-bin-vendored`

`protoc-bin-vendored` (+8 platform sub-crates) is dropped entirely from `Cargo.lock`; the rest stay via legitimate transitive users.

## Kept (documented cargo-machete false positives)
Feature-only deps a source-scanner can't see, now annotated with `[package.metadata.cargo-machete] ignored`:
- **`tishlang_runtime` in tish** — required by the six `tishlang_runtime/<feat>` feature-forwards.
- **`proc-macro2` in tishlang_cargo_bindgen** — its `span-locations` feature is load-bearing for `Span::start()` (removing it broke the build — caught by the compile step, not the scanners).

## How removals were validated
`cargo-machete` + a per-crate source audit, then — authoritatively — **compiling each affected crate with the exact features that gate the dep**, since Rust tolerates unused deps:
- `cargo check --workspace --all-targets`
- `cargo check -p tishlang_runtime --features http-hyper`
- `cargo check -p tishlang_eval --features http,regex,ws,tty,timers,process,fs`
- `cargo test -p tishlang_bytecode --no-run`
- `cargo machete` → clean
- a native binary built with **no `PROTOC`** set, runs.

No functional/runtime behavior changes — dependency graph pruning only.
