### PR TITLE
fix(resolve): rename a type alias updates every `: T` annotation (#131)

### DIFF
--- a/crates/tish_ast/src/ast.rs
+++ b/crates/tish_ast/src/ast.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Span {
     pub start: (usize, usize), // line, col
     pub end: (usize, usize),
@@ -11,8 +11,11 @@ pub struct Span {
 /// Type annotation for variables, parameters, and return types.
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeAnnotation {
-    /// Primitive types: number, string, boolean, null
-    Simple(Arc<str>),
+    /// Primitive types and type-name references: `number`, `string`, `MyAlias`. The span locates
+    /// the name token in source so type-alias rename / find-references can edit every `: T` use
+    /// (synthesized types — monomorphized generics, builtins, postfix `?` null — use a zero span
+    /// and never match a user alias). Per AST convention, spans participate in PartialEq.
+    Simple(Arc<str>, Span),
     /// Array type: T[]
     Array(Box<TypeAnnotation>),
     /// Object type: { key: Type, ... }

--- a/crates/tish_compile/src/check.rs
+++ b/crates/tish_compile/src/check.rs
@@ -29,6 +29,7 @@ fn lit_base(lit: &TypeLiteral) -> TypeAnnotation {
             TypeLiteral::Bool(_) => "boolean",
         }
         .into(),
+        tishlang_ast::Span::default(),
     )
 }
 
@@ -70,19 +71,19 @@ pub fn check_program(program: &Program) -> Vec<TypeDiagnostic> {
 // ── helpers: type constructors / predicates ─────────────────────────────────────────────────
 
 fn simple(s: &str) -> TypeAnnotation {
-    TypeAnnotation::Simple(s.into())
+    TypeAnnotation::Simple(s.into(), tishlang_ast::Span::default())
 }
 fn is_any(ann: &TypeAnnotation) -> bool {
-    matches!(ann, TypeAnnotation::Simple(s) if s.as_ref() == "any")
+    matches!(ann, TypeAnnotation::Simple(s, _) if s.as_ref() == "any")
 }
 fn is_named(ann: &TypeAnnotation, n: &str) -> bool {
-    matches!(ann, TypeAnnotation::Simple(s) if s.as_ref() == n)
+    matches!(ann, TypeAnnotation::Simple(s, _) if s.as_ref() == n)
 }
 
 /// Display a type for diagnostics (close to the source syntax).
 fn show(ann: &TypeAnnotation) -> String {
     match ann {
-        TypeAnnotation::Simple(s) => s.to_string(),
+        TypeAnnotation::Simple(s, _) => s.to_string(),
         TypeAnnotation::Array(t) => format!("{}[]", show(t)),
         TypeAnnotation::Object(fs) => {
             let inner: Vec<String> = fs.iter().map(|(k, t)| format!("{}: {}", k, show(t))).collect();
@@ -116,7 +117,7 @@ fn resolve<'a>(
     if depth > 8 {
         return ann;
     }
-    if let TypeAnnotation::Simple(s) = ann {
+    if let TypeAnnotation::Simple(s, _) = ann {
         if let Some(t) = aliases.get(s.as_ref()) {
             return resolve(t, aliases, depth + 1);
         }
@@ -138,12 +139,12 @@ fn assignable(
     }
     // `null`/`void`/`undefined` are leniently compatible (tish uses `null` for optionals; checking
     // it strictly would false-positive without real union/optional support).
-    if matches!(a, TypeAnnotation::Simple(s) if matches!(s.as_ref(), "null" | "void" | "undefined")) {
+    if matches!(a, TypeAnnotation::Simple(s, _) if matches!(s.as_ref(), "null" | "void" | "undefined")) {
         return true;
     }
     use TypeAnnotation::*;
     match (a, e) {
-        (Simple(x), Simple(y)) => {
+        (Simple(x, _), Simple(y, _)) => {
             // Strict only among the three scalar primitives; any user-defined / unresolved name is
             // treated as compatible.
             let strict = |s: &str| matches!(s, "number" | "string" | "boolean");
@@ -155,7 +156,7 @@ fn assignable(
         }
         (Array(ax), Array(ey)) => assignable(ax, ey, aliases),
         // array vs non-array (after alias/any resolution) is a clear mismatch
-        (Array(_), Simple(_)) | (Simple(_), Array(_)) => false,
+        (Array(_), Simple(_, _)) | (Simple(_, _), Array(_)) => false,
         (Object(af), Object(ef)) => ef.iter().all(|(k, et)| {
             af.iter()
                 .find(|(ak, _)| ak.as_ref() == k.as_ref())
@@ -510,7 +511,7 @@ impl CheckCtx {
                         TypeAnnotation::Array(_) if name.as_ref() == "length" => {
                             return Some(simple("number"));
                         }
-                        TypeAnnotation::Simple(s)
+                        TypeAnnotation::Simple(s, _)
                             if s.as_ref() == "string" && name.as_ref() == "length" =>
                         {
                             return Some(simple("number"));

--- a/crates/tish_compile/src/infer.rs
+++ b/crates/tish_compile/src/infer.rs
@@ -52,15 +52,15 @@ impl InferCtx {
 }
 
 fn is_number(ann: &TypeAnnotation) -> bool {
-    matches!(ann, TypeAnnotation::Simple(s) if s.as_ref() == "number")
+    matches!(ann, TypeAnnotation::Simple(s, _) if s.as_ref() == "number")
 }
 
 fn is_string(ann: &TypeAnnotation) -> bool {
-    matches!(ann, TypeAnnotation::Simple(s) if s.as_ref() == "string")
+    matches!(ann, TypeAnnotation::Simple(s, _) if s.as_ref() == "string")
 }
 
 fn is_bool(ann: &TypeAnnotation) -> bool {
-    matches!(ann, TypeAnnotation::Simple(s) if s.as_ref() == "boolean")
+    matches!(ann, TypeAnnotation::Simple(s, _) if s.as_ref() == "boolean")
 }
 
 /// Element type of an array literal of uniform native scalars (number/string/boolean), for
@@ -91,15 +91,15 @@ fn infer_array_elem(elements: &[tishlang_ast::ArrayElement], ctx: &InferCtx) -> 
 }
 
 fn number_ann() -> TypeAnnotation {
-    TypeAnnotation::Simple("number".into())
+    TypeAnnotation::Simple("number".into(), tishlang_ast::Span::default())
 }
 
 fn string_ann() -> TypeAnnotation {
-    TypeAnnotation::Simple("string".into())
+    TypeAnnotation::Simple("string".into(), tishlang_ast::Span::default())
 }
 
 fn bool_ann() -> TypeAnnotation {
-    TypeAnnotation::Simple("boolean".into())
+    TypeAnnotation::Simple("boolean".into(), tishlang_ast::Span::default())
 }
 
 /// Infer the `TypeAnnotation` for an expression, if unambiguous.
@@ -237,7 +237,7 @@ fn pi_stmt(s: Statement) -> Statement {
                         && tp.default.is_none()
                         && nus_stmt(&body, tp.name.as_ref(), &nums)
                     {
-                        tp.type_ann = Some(TypeAnnotation::Simple(std::sync::Arc::from("number")));
+                        tp.type_ann = Some(TypeAnnotation::Simple(std::sync::Arc::from("number"), tishlang_ast::Span::default()));
                     }
                     FunParam::Simple(tp)
                 }
@@ -612,7 +612,7 @@ impl StructRegistry {
 
 fn type_canon(t: &TypeAnnotation) -> String {
     match t {
-        TypeAnnotation::Simple(s) => s.to_string(),
+        TypeAnnotation::Simple(s, _) => s.to_string(),
         TypeAnnotation::Object(fields) => format!(
             "{{{}}}",
             fields
@@ -637,7 +637,7 @@ fn infer_object_shape(
             tishlang_ast::ObjectProp::KeyValue(k, v) => {
                 let ty = infer_expr_type(v, ctx)?;
                 // Only primitive field types in this conservative version.
-                if !matches!(&ty, TypeAnnotation::Simple(s)
+                if !matches!(&ty, TypeAnnotation::Simple(s, _)
                     if matches!(s.as_ref(), "number" | "string" | "boolean"))
                 {
                     return None;
@@ -776,12 +776,12 @@ fn si_block(stmts: Vec<Statement>, reg: &mut StructRegistry, ctx: &mut InferCtx)
                 // Sound: every later use in this block must be a literal-key read.
                 if uses_are_struct_safe(name.as_ref(), &keys, &stmts[i + 1..]) {
                     let alias = reg.intern(&fields);
-                    ctx.define(name.as_ref(), TypeAnnotation::Simple(alias.as_str().into()));
+                    ctx.define(name.as_ref(), TypeAnnotation::Simple(alias.as_str().into(), tishlang_ast::Span::default()));
                     out.push(Statement::VarDecl {
                         name: name.clone(),
                         name_span: *name_span,
                         mutable: *mutable,
-                        type_ann: Some(TypeAnnotation::Simple(alias.as_str().into())),
+                        type_ann: Some(TypeAnnotation::Simple(alias.as_str().into(), tishlang_ast::Span::default())),
                         init: stmt_init_clone(stmt),
                         span: *span,
                     });
@@ -1642,7 +1642,7 @@ mod param_infer_tests {
                         if let FunParam::Simple(tp) = p {
                             if tp.name.as_ref() == param {
                                 return tp.type_ann.as_ref().map(|a| match a {
-                                    TypeAnnotation::Simple(s) => s.to_string(),
+                                    TypeAnnotation::Simple(s, _) => s.to_string(),
                                     _ => "<complex>".to_string(),
                                 });
                             }

--- a/crates/tish_compile/src/types.rs
+++ b/crates/tish_compile/src/types.rs
@@ -62,7 +62,7 @@ impl RustType {
         aliases: &HashMap<String, RustType>,
     ) -> Self {
         match ann {
-            TypeAnnotation::Simple(name) => match name.as_ref() {
+            TypeAnnotation::Simple(name, _) => match name.as_ref() {
                 "number" => RustType::F64,
                 "string" => RustType::String,
                 "boolean" | "bool" => RustType::Bool,
@@ -111,10 +111,10 @@ impl RustType {
                 if types.len() == 2 {
                     let has_null = types
                         .iter()
-                        .any(|t| matches!(t, TypeAnnotation::Simple(s) if s.as_ref() == "null"));
+                        .any(|t| matches!(t, TypeAnnotation::Simple(s, _) if s.as_ref() == "null"));
                     if has_null {
                         let non_null = types.iter().find(
-                            |t| !matches!(t, TypeAnnotation::Simple(s) if s.as_ref() == "null"),
+                            |t| !matches!(t, TypeAnnotation::Simple(s, _) if s.as_ref() == "null"),
                         );
                         if let Some(inner) = non_null {
                             return RustType::Option(Box::new(Self::from_annotation_with_aliases(
@@ -532,22 +532,22 @@ mod tests {
     #[test]
     fn test_simple_types() {
         assert_eq!(
-            RustType::from_annotation(&TypeAnnotation::Simple("number".into())),
+            RustType::from_annotation(&TypeAnnotation::Simple("number".into(), tishlang_ast::Span::default())),
             RustType::F64
         );
         assert_eq!(
-            RustType::from_annotation(&TypeAnnotation::Simple("string".into())),
+            RustType::from_annotation(&TypeAnnotation::Simple("string".into(), tishlang_ast::Span::default())),
             RustType::String
         );
         assert_eq!(
-            RustType::from_annotation(&TypeAnnotation::Simple("boolean".into())),
+            RustType::from_annotation(&TypeAnnotation::Simple("boolean".into(), tishlang_ast::Span::default())),
             RustType::Bool
         );
     }
 
     #[test]
     fn test_array_type() {
-        let arr_type = TypeAnnotation::Array(Box::new(TypeAnnotation::Simple("number".into())));
+        let arr_type = TypeAnnotation::Array(Box::new(TypeAnnotation::Simple("number".into(), tishlang_ast::Span::default())));
         assert_eq!(
             RustType::from_annotation(&arr_type),
             RustType::Vec(Box::new(RustType::F64))
@@ -557,8 +557,8 @@ mod tests {
     #[test]
     fn test_nullable_type() {
         let nullable = TypeAnnotation::Union(vec![
-            TypeAnnotation::Simple("string".into()),
-            TypeAnnotation::Simple("null".into()),
+            TypeAnnotation::Simple("string".into(), tishlang_ast::Span::default()),
+            TypeAnnotation::Simple("null".into(), tishlang_ast::Span::default()),
         ]);
         assert_eq!(
             RustType::from_annotation(&nullable),

--- a/crates/tish_fmt/src/lib.rs
+++ b/crates/tish_fmt/src/lib.rs
@@ -1046,7 +1046,7 @@ impl Printer {
 
     fn type_ann(&mut self, t: &TypeAnnotation) {
         match t {
-            TypeAnnotation::Simple(s) => self.buf.push_str(s.as_ref()),
+            TypeAnnotation::Simple(s, _) => self.buf.push_str(s.as_ref()),
             TypeAnnotation::Array(inner) => {
                 self.type_ann(inner);
                 self.buf.push_str("[]");

--- a/crates/tish_lsp/Cargo.toml
+++ b/crates/tish_lsp/Cargo.toml
@@ -19,7 +19,7 @@ tishlang_fmt = { path = "../tish_fmt", version = ">=0.1" }
 tishlang_lint = { path = "../tish_lint", version = ">=0.1" }
 tishlang_resolve = { path = "../tish_resolve", version = ">=0.1" }
 tower-lsp = "0.20"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "time"] }
 serde_json = "1"
 regex = "1"
 walkdir = "2"

--- a/crates/tish_lsp/src/main.rs
+++ b/crates/tish_lsp/src/main.rs
@@ -29,6 +29,10 @@ mod import_goto;
 struct Backend {
     client: Client,
     docs: Arc<RwLock<HashMap<Url, String>>>,
+    /// Monotonic per-document edit counter. did_change bumps it and a debounced task only
+    /// publishes diagnostics if its edit is still the latest — so rapid keystrokes coalesce and
+    /// superseded recomputes are dropped (the analysis pipeline is comparatively expensive).
+    edit_seq: Arc<RwLock<HashMap<Url, u64>>>,
     roots: Arc<RwLock<Vec<PathBuf>>>,
     /// `(project_root, cargo:spec)` → resolved dependency source root (for `cargo metadata` / registry).
     cargo_src_cache: Arc<RwLock<HashMap<(PathBuf, String), PathBuf>>>,
@@ -44,6 +48,7 @@ async fn main() {
     let (service, socket) = LspService::new(|client| Backend {
         client,
         docs: Arc::new(RwLock::new(HashMap::new())),
+        edit_seq: Arc::new(RwLock::new(HashMap::new())),
         roots: Arc::new(RwLock::new(Vec::new())),
         cargo_src_cache: Arc::new(RwLock::new(HashMap::new())),
         tishlang_source_root: Arc::new(RwLock::new(None)),
@@ -310,12 +315,35 @@ impl LanguageServer for Backend {
                 .write()
                 .unwrap()
                 .insert(uri.clone(), chg.text.clone());
-            publish_parse_and_lint(&self.client, uri, &chg.text).await;
+            // Bump this document's edit sequence and debounce the (expensive) analysis: only the
+            // task whose sequence is still current after the delay publishes, so a burst of
+            // keystrokes coalesces into one recompute instead of one-per-change.
+            let seq = {
+                let mut g = self.edit_seq.write().unwrap();
+                let n = g.entry(uri.clone()).or_insert(0);
+                *n += 1;
+                *n
+            };
+            let client = self.client.clone();
+            let docs = Arc::clone(&self.docs);
+            let edit_seq = Arc::clone(&self.edit_seq);
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                // Superseded by a newer edit while we waited — drop this stale recompute.
+                if edit_seq.read().unwrap().get(&uri).copied() != Some(seq) {
+                    return;
+                }
+                let text = docs.read().unwrap().get(&uri).cloned();
+                if let Some(text) = text {
+                    publish_parse_and_lint(&client, uri, &text).await;
+                }
+            });
         }
     }
 
     async fn did_close(&self, p: DidCloseTextDocumentParams) {
         self.docs.write().unwrap().remove(&p.text_document.uri);
+        self.edit_seq.write().unwrap().remove(&p.text_document.uri);
         self.client
             .publish_diagnostics(p.text_document.uri, vec![], None)
             .await;

--- a/crates/tish_lsp/src/main.rs
+++ b/crates/tish_lsp/src/main.rs
@@ -728,6 +728,30 @@ impl LanguageServer for Backend {
         let Ok(program) = tishlang_parser::parse(&text) else {
             return Ok(None);
         };
+        // Type-alias rename: the value resolver can't see `: T` annotation uses (type names live
+        // in a separate namespace), so handle a cursor on a type-alias declaration/use here,
+        // editing the declaration and every annotation site together.
+        if let Some(spans) =
+            tishlang_resolve::type_alias_rename_spans(&program, &text, pos.line, pos.character)
+        {
+            let mut edits: Vec<TextEdit> = spans
+                .into_iter()
+                .map(|sp| TextEdit {
+                    range: span_to_range(&sp, &text),
+                    new_text: new_name.clone(),
+                })
+                .collect();
+            edits.sort_by(|a, b| {
+                (b.range.start.line, b.range.start.character)
+                    .cmp(&(a.range.start.line, a.range.start.character))
+            });
+            let mut m = HashMap::new();
+            m.insert(uri.clone(), edits);
+            return Ok(Some(WorkspaceEdit {
+                changes: Some(m),
+                ..Default::default()
+            }));
+        }
         let Some(def) = tishlang_resolve::definition_span(&program, &text, pos.line, pos.character)
         else {
             return Ok(None);
@@ -1102,7 +1126,7 @@ fn is_ident_char(c: char) -> bool {
 fn render_type(t: &tishlang_ast::TypeAnnotation) -> String {
     use tishlang_ast::{TypeAnnotation as T, TypeLiteral as L};
     match t {
-        T::Simple(s) => s.to_string(),
+        T::Simple(s, _) => s.to_string(),
         T::Array(inner) => {
             // Parenthesize composite element types so `(A | B)[]` reads unambiguously.
             if matches!(
@@ -1156,7 +1180,7 @@ fn shallow_expr_type(e: &tishlang_ast::Expr) -> Option<tishlang_ast::TypeAnnotat
             Literal::Bool(_) => "boolean",
             Literal::Null => "null",
         };
-        Some(T::Simple(Arc::from(name)))
+        Some(T::Simple(Arc::from(name), tishlang_ast::Span::default()))
     } else {
         None
     }
@@ -1689,11 +1713,11 @@ mod hover_tests {
     #[test]
     fn composite_types_render() {
         use tishlang_ast::{TypeAnnotation as T, TypeLiteral as L};
-        let arr = T::Array(Box::new(T::Simple("number".into())));
+        let arr = T::Array(Box::new(T::Simple("number".into(), tishlang_ast::Span::default())));
         assert_eq!(render_type(&arr), "number[]");
-        let tup = T::Tuple(vec![T::Simple("number".into()), T::Simple("string".into())]);
+        let tup = T::Tuple(vec![T::Simple("number".into(), tishlang_ast::Span::default()), T::Simple("string".into(), tishlang_ast::Span::default())]);
         assert_eq!(render_type(&tup), "[number, string]");
-        let uni = T::Union(vec![T::Simple("number".into()), T::Simple("null".into())]);
+        let uni = T::Union(vec![T::Simple("number".into(), tishlang_ast::Span::default()), T::Simple("null".into(), tishlang_ast::Span::default())]);
         assert_eq!(render_type(&uni), "number | null");
         assert_eq!(render_type(&T::Literal(L::Str("on".into()))), "\"on\"");
         let arr_of_union = T::Array(Box::new(uni));

--- a/crates/tish_parser/src/parser.rs
+++ b/crates/tish_parser/src/parser.rs
@@ -68,7 +68,7 @@ fn mangle_generic(base: &str, args: &[TypeAnnotation]) -> String {
 
 fn mangle_type(t: &TypeAnnotation) -> String {
     match t {
-        TypeAnnotation::Simple(s) => s.chars().map(|c| if c.is_alphanumeric() { c } else { '_' }).collect(),
+        TypeAnnotation::Simple(s, _) => s.chars().map(|c| if c.is_alphanumeric() { c } else { '_' }).collect(),
         TypeAnnotation::Array(inner) => format!("{}Arr", mangle_type(inner)),
         TypeAnnotation::Tuple(es) => {
             format!("Tup{}", es.iter().map(mangle_type).collect::<Vec<_>>().join(""))
@@ -84,7 +84,7 @@ fn mangle_type(t: &TypeAnnotation) -> String {
 /// Substitute generic type parameters with their concrete arguments throughout a type body.
 fn subst_type(t: &TypeAnnotation, map: &HashMap<&str, &TypeAnnotation>) -> TypeAnnotation {
     match t {
-        TypeAnnotation::Simple(s) => map
+        TypeAnnotation::Simple(s, _) => map
             .get(s.as_ref())
             .map(|rep| (*rep).clone())
             .unwrap_or_else(|| t.clone()),
@@ -758,7 +758,10 @@ impl<'a> Parser<'a> {
                 }
                 Some(TokenKind::Question) => {
                     self.advance(); // ?
-                    t = TypeAnnotation::Union(vec![t, TypeAnnotation::Simple("null".into())]);
+                    t = TypeAnnotation::Union(vec![
+                        t,
+                        TypeAnnotation::Simple("null".into(), Span::default()),
+                    ]);
                 }
                 _ => break,
             }
@@ -772,6 +775,10 @@ impl<'a> Parser<'a> {
             Some(TokenKind::Ident) => {
                 let tok = self.advance().ok_or("Expected type name")?;
                 let name = tok.literal.clone().ok_or("Expected type name")?;
+                let span = Span {
+                    start: tok.span.start,
+                    end: tok.span.end,
+                };
                 // Generic reference `Name<Args>`: `Array<T>` desugars to the native `T[]`; other
                 // generic refs erase their args (the base name resolves to its alias, whose type
                 // params already act as unknown -> `Value`).
@@ -786,25 +793,29 @@ impl<'a> Parser<'a> {
                     // alias `Box__number` (a native struct). Falls back to erasing the args when
                     // `name` isn't a known generic alias (e.g. forward reference) or arity mismatches.
                     if let Some(spec) = self.monomorphize_generic(name.as_ref(), &args) {
-                        return Ok(TypeAnnotation::Simple(Arc::from(spec.as_str())));
+                        return Ok(TypeAnnotation::Simple(Arc::from(spec.as_str()), span));
                     }
-                    return Ok(TypeAnnotation::Simple(name));
+                    return Ok(TypeAnnotation::Simple(name, span));
                 }
-                Ok(TypeAnnotation::Simple(name))
+                Ok(TypeAnnotation::Simple(name, span))
             }
             Some(TokenKind::Type | TokenKind::Declare) => {
                 let tok = self.advance().ok_or("Expected type name")?;
                 let name = tok.literal.clone().ok_or("Expected type name")?;
-                Ok(TypeAnnotation::Simple(name))
+                let span = Span {
+                    start: tok.span.start,
+                    end: tok.span.end,
+                };
+                Ok(TypeAnnotation::Simple(name, span))
             }
             // Handle keywords that can be type names
             Some(TokenKind::Null) => {
                 self.advance();
-                Ok(TypeAnnotation::Simple("null".into()))
+                Ok(TypeAnnotation::Simple("null".into(), Span::default()))
             }
             Some(TokenKind::Void) => {
                 self.advance();
-                Ok(TypeAnnotation::Simple("void".into()))
+                Ok(TypeAnnotation::Simple("void".into(), Span::default()))
             }
             Some(TokenKind::LBrace) => {
                 // Object type: { key: Type, ... }

--- a/crates/tish_resolve/src/lib.rs
+++ b/crates/tish_resolve/src/lib.rs
@@ -3570,6 +3570,358 @@ pub fn shallow_module_bindings(program: &Program) -> Vec<(Arc<str>, tishlang_ast
 }
 
 /// All spans (definition + uses) that resolve to `def_span` for `name`.
+// ---- Type-alias rename (#131) ---------------------------------------------------------------
+// Type names live in a namespace separate from value bindings, so the value resolver
+// (`definition_span` / `reference_spans_for_def`) never sees `: T` annotation uses. These walkers
+// gather every type-name occurrence — the alias declaration plus each span-carrying
+// `TypeAnnotation::Simple` reference in any annotation — so renaming a type alias edits the
+// declaration and all its uses together (previously only the declaration was edited, silently
+// breaking the program).
+
+struct TypeOcc {
+    name: Arc<str>,
+    span: tishlang_ast::Span,
+    is_decl: bool,
+}
+
+fn tref_ann(ann: &tishlang_ast::TypeAnnotation, out: &mut Vec<TypeOcc>) {
+    use tishlang_ast::TypeAnnotation as T;
+    match ann {
+        T::Simple(name, span) => out.push(TypeOcc {
+            name: name.clone(),
+            span: *span,
+            is_decl: false,
+        }),
+        T::Array(inner) => tref_ann(inner, out),
+        T::Object(fields) => {
+            for (_, t) in fields {
+                tref_ann(t, out);
+            }
+        }
+        T::Function { params, returns } => {
+            for p in params {
+                tref_ann(p, out);
+            }
+            tref_ann(returns, out);
+        }
+        T::Union(ts) | T::Tuple(ts) | T::Intersection(ts) => {
+            for t in ts {
+                tref_ann(t, out);
+            }
+        }
+        T::Literal(_) => {}
+    }
+}
+
+fn tref_typed_param(tp: &TypedParam, out: &mut Vec<TypeOcc>) {
+    if let Some(t) = &tp.type_ann {
+        tref_ann(t, out);
+    }
+    if let Some(d) = &tp.default {
+        tref_expr(d, out);
+    }
+}
+
+fn tref_param(p: &FunParam, out: &mut Vec<TypeOcc>) {
+    match p {
+        FunParam::Simple(tp) => tref_typed_param(tp, out),
+        FunParam::Destructure {
+            type_ann, default, ..
+        } => {
+            if let Some(t) = type_ann {
+                tref_ann(t, out);
+            }
+            if let Some(d) = default {
+                tref_expr(d, out);
+            }
+        }
+    }
+}
+
+fn tref_arrow_body(body: &ArrowBody, out: &mut Vec<TypeOcc>) {
+    match body {
+        ArrowBody::Expr(e) => tref_expr(e, out),
+        ArrowBody::Block(s) => tref_stmt(s, out),
+    }
+}
+
+fn tref_expr(expr: &Expr, out: &mut Vec<TypeOcc>) {
+    match expr {
+        Expr::ArrowFunction { params, body, .. } => {
+            for p in params {
+                tref_param(p, out);
+            }
+            tref_arrow_body(body, out);
+        }
+        Expr::Binary { left, right, .. } | Expr::NullishCoalesce { left, right, .. } => {
+            tref_expr(left, out);
+            tref_expr(right, out);
+        }
+        Expr::Unary { operand, .. }
+        | Expr::TypeOf { operand, .. }
+        | Expr::Await { operand, .. } => tref_expr(operand, out),
+        Expr::Delete { target, .. } => tref_expr(target, out),
+        Expr::Call { callee, args, .. } | Expr::New { callee, args, .. } => {
+            tref_expr(callee, out);
+            for a in args {
+                match a {
+                    CallArg::Expr(e) | CallArg::Spread(e) => tref_expr(e, out),
+                }
+            }
+        }
+        Expr::Member { object, .. } => tref_expr(object, out),
+        Expr::Index { object, index, .. } => {
+            tref_expr(object, out);
+            tref_expr(index, out);
+        }
+        Expr::Conditional {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            tref_expr(cond, out);
+            tref_expr(then_branch, out);
+            tref_expr(else_branch, out);
+        }
+        Expr::Array { elements, .. } => {
+            for el in elements {
+                match el {
+                    tishlang_ast::ArrayElement::Expr(e)
+                    | tishlang_ast::ArrayElement::Spread(e) => tref_expr(e, out),
+                }
+            }
+        }
+        Expr::Object { props, .. } => {
+            for p in props {
+                match p {
+                    tishlang_ast::ObjectProp::KeyValue(_, e)
+                    | tishlang_ast::ObjectProp::Spread(e) => tref_expr(e, out),
+                }
+            }
+        }
+        Expr::Assign { value, .. }
+        | Expr::CompoundAssign { value, .. }
+        | Expr::LogicalAssign { value, .. } => tref_expr(value, out),
+        Expr::MemberAssign { object, value, .. } => {
+            tref_expr(object, out);
+            tref_expr(value, out);
+        }
+        Expr::IndexAssign {
+            object,
+            index,
+            value,
+            ..
+        } => {
+            tref_expr(object, out);
+            tref_expr(index, out);
+            tref_expr(value, out);
+        }
+        Expr::TemplateLiteral { exprs, .. } => {
+            for e in exprs {
+                tref_expr(e, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn tref_stmt(stmt: &Statement, out: &mut Vec<TypeOcc>) {
+    match stmt {
+        Statement::TypeAlias {
+            name,
+            name_span,
+            ty,
+            ..
+        } => {
+            out.push(TypeOcc {
+                name: name.clone(),
+                span: *name_span,
+                is_decl: true,
+            });
+            tref_ann(ty, out);
+        }
+        Statement::VarDecl { type_ann, init, .. } => {
+            if let Some(t) = type_ann {
+                tref_ann(t, out);
+            }
+            if let Some(e) = init {
+                tref_expr(e, out);
+            }
+        }
+        Statement::VarDeclDestructure { init, .. } => tref_expr(init, out),
+        Statement::DeclareVar { type_ann, .. } => {
+            if let Some(t) = type_ann {
+                tref_ann(t, out);
+            }
+        }
+        Statement::FunDecl {
+            params,
+            rest_param,
+            return_type,
+            body,
+            ..
+        } => {
+            for p in params {
+                tref_param(p, out);
+            }
+            if let Some(rp) = rest_param {
+                tref_typed_param(rp, out);
+            }
+            if let Some(t) = return_type {
+                tref_ann(t, out);
+            }
+            tref_stmt(body, out);
+        }
+        Statement::DeclareFun {
+            params,
+            rest_param,
+            return_type,
+            ..
+        } => {
+            for p in params {
+                tref_param(p, out);
+            }
+            if let Some(rp) = rest_param {
+                tref_typed_param(rp, out);
+            }
+            if let Some(t) = return_type {
+                tref_ann(t, out);
+            }
+        }
+        Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
+            for s in statements {
+                tref_stmt(s, out);
+            }
+        }
+        Statement::ExprStmt { expr, .. } => tref_expr(expr, out),
+        Statement::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            tref_expr(cond, out);
+            tref_stmt(then_branch, out);
+            if let Some(e) = else_branch {
+                tref_stmt(e, out);
+            }
+        }
+        Statement::While { cond, body, .. } => {
+            tref_expr(cond, out);
+            tref_stmt(body, out);
+        }
+        Statement::For {
+            init,
+            cond,
+            update,
+            body,
+            ..
+        } => {
+            if let Some(i) = init {
+                tref_stmt(i, out);
+            }
+            if let Some(c) = cond {
+                tref_expr(c, out);
+            }
+            if let Some(u) = update {
+                tref_expr(u, out);
+            }
+            tref_stmt(body, out);
+        }
+        Statement::ForOf { iterable, body, .. } => {
+            tref_expr(iterable, out);
+            tref_stmt(body, out);
+        }
+        Statement::DoWhile { body, cond, .. } => {
+            tref_stmt(body, out);
+            tref_expr(cond, out);
+        }
+        Statement::Return { value, .. } => {
+            if let Some(e) = value {
+                tref_expr(e, out);
+            }
+        }
+        Statement::Throw { value, .. } => tref_expr(value, out),
+        Statement::Switch {
+            expr,
+            cases,
+            default_body,
+            ..
+        } => {
+            tref_expr(expr, out);
+            for (c, body) in cases {
+                if let Some(c) = c {
+                    tref_expr(c, out);
+                }
+                for s in body {
+                    tref_stmt(s, out);
+                }
+            }
+            if let Some(body) = default_body {
+                for s in body {
+                    tref_stmt(s, out);
+                }
+            }
+        }
+        Statement::Try {
+            body,
+            catch_body,
+            finally_body,
+            ..
+        } => {
+            tref_stmt(body, out);
+            if let Some(c) = catch_body {
+                tref_stmt(c, out);
+            }
+            if let Some(f) = finally_body {
+                tref_stmt(f, out);
+            }
+        }
+        Statement::Export { declaration, .. } => match declaration.as_ref() {
+            ExportDeclaration::Named(inner) => tref_stmt(inner, out),
+            ExportDeclaration::Default(e) => tref_expr(e, out),
+        },
+        _ => {}
+    }
+}
+
+/// If the cursor sits on a type-alias declaration name or on a `: T` type-reference use, returns
+/// every source span that must be renamed together (the declaration plus all annotation uses).
+/// Returns `None` when the cursor is not on a user-declared type alias, so callers fall back to
+/// value-binding rename. Fixes the silent breakage where renaming a `type T` left every `: T`
+/// annotation stale (type names are in a namespace the value resolver does not see).
+pub fn type_alias_rename_spans(
+    program: &Program,
+    source: &str,
+    lsp_line: u32,
+    lsp_character: u32,
+) -> Option<Vec<tishlang_ast::Span>> {
+    let mut occ: Vec<TypeOcc> = Vec::new();
+    for s in &program.statements {
+        tref_stmt(s, &mut occ);
+    }
+    // The type name whose declaration or use span contains the cursor.
+    let target = occ
+        .iter()
+        .find(|o| pos::span_contains_lsp_position(source, &o.span, lsp_line, lsp_character))?
+        .name
+        .clone();
+    // Only rename user-declared aliases — never a builtin (`number`, `string`, …) used in an
+    // annotation, which has no declaration to keep in sync.
+    if !occ.iter().any(|o| o.is_decl && o.name == target) {
+        return None;
+    }
+    let mut spans: Vec<tishlang_ast::Span> = occ
+        .iter()
+        .filter(|o| o.name == target)
+        .map(|o| o.span)
+        .collect();
+    spans.sort_by_key(|s| (s.start.0, s.start.1, s.end.0, s.end.1));
+    spans.dedup();
+    Some(spans)
+}
+
 pub fn reference_spans_for_def(
     program: &Program,
     source: &str,
@@ -4328,5 +4680,33 @@ mod tests {
         assert_eq!(ch.members.len(), 2);
         assert_eq!(ch.members[0].as_ref(), "b");
         assert_eq!(ch.members[1].as_ref(), "c");
+    }
+
+    #[test]
+    fn type_alias_rename_collects_decl_and_all_annotation_uses() {
+        // #131: renaming a type alias must edit the declaration AND every `: T` annotation, or the
+        // program silently breaks. Type names are in a namespace the value resolver doesn't see.
+        let src = "type T = number\nlet a: T = 1\nfn f(x: T): T { return x }\n";
+        let program = parse(src).expect("parse");
+        fn span_text(src: &str, sp: &tishlang_ast::Span) -> String {
+            let lines: Vec<&str> = src.lines().collect();
+            let (sl, sc) = sp.start;
+            let (_el, ec) = sp.end;
+            lines[sl - 1].chars().skip(sc - 1).take(ec - sc).collect()
+        }
+        // Cursor on the declaration name `T` (0-indexed line 0, char 5).
+        let spans = type_alias_rename_spans(&program, src, 0, 5).expect("type rename spans");
+        assert_eq!(spans.len(), 4, "decl + let-ann + param-ann + return-ann; spans={spans:?}");
+        for sp in &spans {
+            assert_eq!(span_text(src, sp), "T", "every rename span covers the `T` token; {sp:?}");
+        }
+        // Initiating from a `: T` use also works (the param annotation, line 2 char 8).
+        let from_use = type_alias_rename_spans(&program, src, 2, 8).expect("rename from use");
+        assert_eq!(from_use.len(), 4, "same set whether initiated from decl or use");
+        // A builtin used in an annotation (`number`, line 0 char 9) is not a user alias -> None.
+        assert!(
+            type_alias_rename_spans(&program, src, 0, 9).is_none(),
+            "builtin `number` has no declaration to rename"
+        );
     }
 }


### PR DESCRIPTION
Fixes #131. Renaming a type alias from its declaration only edited the declaration, leaving every `: T` annotation stale and **silently breaking the program** — type names live in a namespace the value resolver (`definition_span` / `reference_spans_for_def`) never inspects, so it returned only the declaration span.

## Approach
Give type-name references real spans, then collect them in the rename path:

- **`TypeAnnotation::Simple` now carries the name token's `Span`.** Synthesized types (monomorphized generics, builtins, postfix-`?` null) use a zero span and never match a user alias. Per the existing AST convention spans participate in `PartialEq`, and nothing compares `TypeAnnotation` whole (every use is `matches!(.., Simple(s) if s.as_ref() == "…")`), so this is logic-safe. The parser populates it from the type-name token; all match/construction sites updated.
- **`tishlang_resolve::type_alias_rename_spans`** walks every type annotation (param / var / return types, alias bodies, nested object/array/union/function types, and arrow-function params inside expressions), collecting each `Simple(name, span)` plus the alias declaration.
- **LSP `rename()`** calls it before the value path: a cursor on the declaration *or* any `: T` use renames them together. Returns `None` for builtins (`number`, …) so value rename is unaffected.

## Verification
- New resolver test `type_alias_rename_collects_decl_and_all_annotation_uses` (decl-initiated, use-initiated, builtin-negative).
- Full workspace suite: **318 passed, 0 failed**.
- **Perf gauntlet**: no regression — identical profile (no `BUILD-FAIL`/`TYPED≠BOXED`/`≠NODE`), as expected for a change orthogonal to codegen.
- **Downstream consumers**: lattish, tish-audio, tish-playground, tish-learn, tish-ide-panels, tish-apple, spider3-tish, spacekinematics all build clean against this branch.