### PR TITLE
ci: fix flaky perf suite (rustc SIGILL on target-cpu=native) (#223)

### DIFF
--- a/.github/workflows/build-npm-binaries.yml
+++ b/.github/workflows/build-npm-binaries.yml
@@ -213,6 +213,13 @@ jobs:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
       PERF_SUITE_STRICT: "1"
+      # Pin a fleet-safe baseline instead of the default `-C target-cpu=native` (#223): on the
+      # virtualized blacksmith fleet, `native` makes rustc trust host CPUID and emit instructions
+      # for a feature (e.g. AVX-512) the hypervisor advertises but doesn't honor, so the nested
+      # fat-LTO native build SIGILLs. x86-64-v3 (AVX2/FMA/BMI2) is supported by every x86 host here,
+      # so codegen stays near-native (perf numbers stay meaningful) without the crash. Since this
+      # RUSTFLAGS already contains `target-cpu`, tish_build_utils skips appending `native`.
+      RUSTFLAGS: "-C target-cpu=x86-64-v3"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/scripts/run_performance_suite.sh
+++ b/scripts/run_performance_suite.sh
@@ -630,8 +630,28 @@ if [ "$no_compile" != true ]; then
   echo "Compiling suite (rust / cranelift / llvm / wasi)..."
   echo -n "  $test_id: "
   _suite_build_log=$(mktemp)
+  # Build one native backend, retrying ONLY on a transient rustc SIGILL (#223). On the virtualized
+  # CI fleet a native build can crash the compiler (signal 4) when host CPUID over-advertises a CPU
+  # feature; it always succeeds on a re-run. A real compile error still fails fast — we retry only
+  # when the build log shows a SIGILL.
+  _perf_native_build() { # $1=out  $2=backend
+    local out="$1" backend="$2" tries="${PERF_NATIVE_BUILD_RETRIES:-2}" i
+    for i in $(seq 1 "$tries"); do
+      if "$tish_bin" build "$entry_tish" -o "$out" --native-backend "$backend" >"$_suite_build_log" 2>&1; then
+        return 0
+      fi
+      if [ "$i" -lt "$tries" ] && grep -qiE 'SIGILL|signal: 4|illegal instruction' "$_suite_build_log"; then
+        echo -n "${backend}-retry "
+        rm -f "$out"
+        sleep $((i * 5))
+      else
+        return 1
+      fi
+    done
+    return 1
+  }
   if want_runtime rust; then
-    if "$tish_bin" build "$entry_tish" -o "$native_bin" --native-backend rust >"$_suite_build_log" 2>&1; then
+    if _perf_native_build "$native_bin" rust; then
       echo -n "rust "
     else
       echo -n "rust-fail "
@@ -647,7 +667,7 @@ if [ "$no_compile" != true ]; then
     fi
   fi
   if want_runtime cranelift; then
-    if "$tish_bin" build "$entry_tish" -o "$cranelift_bin" --native-backend cranelift >"$_suite_build_log" 2>&1; then
+    if _perf_native_build "$cranelift_bin" cranelift; then
       echo -n "cranelift "
     else
       echo -n "cranelift-fail "
@@ -660,7 +680,7 @@ if [ "$no_compile" != true ]; then
     fi
   fi
   if want_runtime llvm; then
-    if "$tish_bin" build "$entry_tish" -o "$llvm_bin" --native-backend llvm >"$_suite_build_log" 2>&1; then
+    if _perf_native_build "$llvm_bin" llvm; then
       echo -n "llvm "
     else
       echo -n "llvm-fail "


### PR DESCRIPTION
Fixes #223. The **Bundled perf suite** intermittently failed with `rustc interrupted by SIGILL` while compiling the nested `ci_main_suite_native` crate — always green on a plain re-run, and it blocked #220 / #221 / #222 this week.

## Root cause
The `perf-suite` job set no `RUSTFLAGS` and no `TISH_FAST_NATIVE_BUILD`, so `tish_build_utils` appended **`-C target-cpu=native`** to the nested native build (which also uses `-C lto=fat -C codegen-units=1 -C opt-level=3`). On the virtualized/heterogeneous `blacksmith-4vcpu` fleet, `native` makes rustc/LLVM trust host CPUID and emit instructions for a feature (e.g. AVX-512) the hypervisor advertises but doesn't actually honor — so the heaviest (fat-LTO) compile traps with **signal 4 (SIGILL)**. Re-runs land on a differently-provisioned host and pass. (sccache isn't involved — the nested build unsets `RUSTC_WRAPPER`, so the existing `ci_build_retry.sh` never wrapped it.)

## Fix (defense-in-depth)
1. **Pin a fleet-safe baseline** — `RUSTFLAGS: "-C target-cpu=x86-64-v3"` in the `perf-suite` job env. This *removes the cause*: `x86-64-v3` (AVX2/FMA/BMI2, no AVX-512) is supported by every x86 host on the fleet, so rustc no longer assumes an over-advertised feature, while codegen stays near-native so the perf numbers remain meaningful. No Rust change — `tish_build_utils` already skips appending `native` when `RUSTFLAGS` contains a `target-cpu`.
2. **SIGILL-only retry** — the suite's nested rust/cranelift/llvm builds now go through a `_perf_native_build` helper that retries (×2) **only** when the build log shows a SIGILL; real compile errors still fail fast.

## Why not a matrix
A per-backend matrix only *contains* the flake (each shard still runs `target-cpu=native`) at notable CI cost — it doesn't remove the cause. Pin + retry does, more simply.

## Verified
- Helper unit-tested: SIGILL→retry→success (rc 0); real error → fail-fast (no retry).
- End-to-end: the suite builds + runs the bundle native binary through the helper locally (`bundle OK`, micro-tests 0/77 failed).
- `bash -n` clean; YAML valid. This PR's own perf-suite run exercises the pin.

Follow-up (separate, latent): the native build path passes no `--target`, so `RUSTFLAGS` also reach host build-scripts/proc-macros — worth scoping to target-only later.