### PR TITLE
fix(linter): point tish-duplicate-key at the duplicated key, not the object `{` (#143)

### DIFF
--- a/crates/js_to_tish/src/transform/expr.rs
+++ b/crates/js_to_tish/src/transform/expr.rs
@@ -350,7 +350,11 @@ fn convert_object_prop(
                 }
             });
             let value = convert_expr(&prop.value, ctx)?;
-            Ok(ObjectProp::KeyValue(Arc::from(key.as_str()), value))
+            Ok(ObjectProp::KeyValue(
+                Arc::from(key.as_str()),
+                value,
+                tishlang_ast::Span::default(),
+            ))
         }
     }
 }

--- a/crates/tish_ast/src/ast.rs
+++ b/crates/tish_ast/src/ast.rs
@@ -541,10 +541,14 @@ pub enum ArrayElement {
     Spread(Expr),
 }
 
-/// Object property: either a regular key-value pair or spread
+/// Object property: either a regular key-value pair or spread.
+///
+/// The `Span` on `KeyValue` is the key token's source span, so diagnostics (e.g. duplicate-key)
+/// can point at the key rather than the enclosing `{` (#143). Synthesized object literals use a
+/// zero span. Per AST convention the span participates in PartialEq.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ObjectProp {
-    KeyValue(Arc<str>, Expr),
+    KeyValue(Arc<str>, Expr, Span),
     Spread(Expr),
 }
 

--- a/crates/tish_bytecode/src/compiler.rs
+++ b/crates/tish_bytecode/src/compiler.rs
@@ -157,7 +157,7 @@ fn expr_is_param_only(e: &Expr, params: &HashSet<&str>) -> bool {
             ArrayElement::Spread(_) => false,
         }),
         Expr::Object { props, .. } => props.iter().all(|p| match p {
-            ObjectProp::KeyValue(_, x) => expr_is_param_only(x, params),
+            ObjectProp::KeyValue(_, x, _) => expr_is_param_only(x, params),
             ObjectProp::Spread(_) => false,
         }),
         Expr::TemplateLiteral { exprs, .. } => {
@@ -332,7 +332,7 @@ fn expr_rebinds(e: &Expr, name: &str) -> bool {
             ArrayElement::Expr(e) | ArrayElement::Spread(e) => expr_rebinds(e, name),
         }),
         Expr::Object { props, .. } => props.iter().any(|p| match p {
-            ObjectProp::KeyValue(_, e) | ObjectProp::Spread(e) => expr_rebinds(e, name),
+            ObjectProp::KeyValue(_, e, _) | ObjectProp::Spread(e) => expr_rebinds(e, name),
         }),
         Expr::MemberAssign { object, value, .. } => expr_rebinds(object, name) || expr_rebinds(value, name),
         Expr::IndexAssign { object, index, value, .. } => {
@@ -452,7 +452,7 @@ impl SlotScan {
                 ArrayElement::Expr(e) | ArrayElement::Spread(e) => self.expr(e, in_closure),
             }),
             Expr::Object { props, .. } => props.iter().all(|p| match p {
-                ObjectProp::KeyValue(_, e) | ObjectProp::Spread(e) => self.expr(e, in_closure),
+                ObjectProp::KeyValue(_, e, _) | ObjectProp::Spread(e) => self.expr(e, in_closure),
             }),
             Expr::Assign { name, value, .. }
             | Expr::CompoundAssign { name, value, .. }
@@ -2123,7 +2123,7 @@ impl<'a> Compiler<'a> {
                     self.emit_u16(Opcode::NewObject, 0); // start with {}
                     for prop in props {
                         match prop {
-                            ObjectProp::KeyValue(k, v) => {
+                            ObjectProp::KeyValue(k, v, _) => {
                                 let idx = self.constant_idx(Constant::String(Arc::clone(k)));
                                 self.emit(Opcode::LoadConst);
                                 self.chunk.write_u16(idx);
@@ -2139,7 +2139,7 @@ impl<'a> Compiler<'a> {
                     }
                 } else {
                     for prop in props {
-                        if let ObjectProp::KeyValue(k, v) = prop {
+                        if let ObjectProp::KeyValue(k, v, _) = prop {
                             let idx = self.constant_idx(Constant::String(Arc::clone(k)));
                             self.emit(Opcode::LoadConst);
                             self.chunk.write_u16(idx);

--- a/crates/tish_compile/src/check.rs
+++ b/crates/tish_compile/src/check.rs
@@ -590,7 +590,7 @@ impl CheckCtx {
                 let mut fields = Vec::new();
                 for p in props {
                     match p {
-                        ObjectProp::KeyValue(k, v) => {
+                        ObjectProp::KeyValue(k, v, _) => {
                             let t = self.synth(v)?;
                             fields.push((k.clone(), t));
                         }

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -179,7 +179,7 @@ impl UsageAnalyzer {
             Expr::Object { props, .. } => {
                 for prop in props {
                     match prop {
-                        ObjectProp::KeyValue(_, v) => self.analyze_expr(v),
+                        ObjectProp::KeyValue(_, v, _) => self.analyze_expr(v),
                         ObjectProp::Spread(e) => self.analyze_expr(e),
                     }
                 }
@@ -398,7 +398,7 @@ fn program_uses_async(program: &Program) -> bool {
                 ArrayElement::Expr(e) | ArrayElement::Spread(e) => expr_has_await(e),
             }),
             Expr::Object { props, .. } => props.iter().any(|p| match p {
-                ObjectProp::KeyValue(_, e) | ObjectProp::Spread(e) => expr_has_await(e),
+                ObjectProp::KeyValue(_, e, _) | ObjectProp::Spread(e) => expr_has_await(e),
             }),
             Expr::Assign { value, .. }
             | Expr::CompoundAssign { value, .. }
@@ -3868,7 +3868,7 @@ impl Codegen {
                     let mut parts = Vec::new();
                     for prop in props {
                         match prop {
-                            ObjectProp::KeyValue(k, v) => {
+                            ObjectProp::KeyValue(k, v, _) => {
                                 let val = self.emit_expr(v)?;
                                 if self.should_clone(v) {
                                     parts.push(format!("_obj.insert(Arc::from({:?}), ({}).clone());", k.as_ref(), val));
@@ -3886,7 +3886,7 @@ impl Codegen {
                 } else {
                     let mut parts = Vec::new();
                     for prop in props {
-                        if let ObjectProp::KeyValue(k, v) = prop {
+                        if let ObjectProp::KeyValue(k, v, _) = prop {
                             let val = self.emit_expr(v)?;
                             if self.should_clone(v) {
                                 parts.push(format!("(Arc::from({:?}), ({}).clone())", k.as_ref(), val));
@@ -4553,7 +4553,7 @@ impl Codegen {
             Expr::Object { props, .. } => {
                 for prop in props {
                     match prop {
-                        ObjectProp::KeyValue(_, e) | ObjectProp::Spread(e) => {
+                        ObjectProp::KeyValue(_, e, _) | ObjectProp::Spread(e) => {
                             Self::collect_expr_idents(e, idents)
                         }
                     }
@@ -4812,7 +4812,7 @@ impl Codegen {
             Expr::Object { props, .. } => {
                 for prop in props {
                     match prop {
-                        ObjectProp::KeyValue(_, e) | ObjectProp::Spread(e) => {
+                        ObjectProp::KeyValue(_, e, _) | ObjectProp::Spread(e) => {
                             Self::collect_assigned_idents_in_expr(e, names);
                         }
                     }
@@ -5026,7 +5026,7 @@ impl Codegen {
             Expr::Object { props, .. } => {
                 for prop in props {
                     match prop {
-                        ObjectProp::KeyValue(_, e) | ObjectProp::Spread(e) => {
+                        ObjectProp::KeyValue(_, e, _) | ObjectProp::Spread(e) => {
                             Self::collect_captured_block_vars_from_expr(e, block_vars, result);
                         }
                     }
@@ -5848,7 +5848,7 @@ impl Codegen {
             let mut bail = false;
             for prop in props {
                 match prop {
-                    ObjectProp::KeyValue(key, value) => {
+                    ObjectProp::KeyValue(key, value, _) => {
                         if let Some(field_ty) = field_types.get(key.as_ref()) {
                             let v = self.emit_native_expr(value, field_ty)?;
                             field_inits.insert(crate::types::field_ident(key.as_ref()), v);
@@ -6247,7 +6247,7 @@ impl Codegen {
             Expr::Object { props, .. } => {
                 for p in props {
                     match p {
-                        ObjectProp::KeyValue(_, v) => Self::collect_reassignments_expr(v, out),
+                        ObjectProp::KeyValue(_, v, _) => Self::collect_reassignments_expr(v, out),
                         ObjectProp::Spread(x) => Self::collect_reassignments_expr(x, out),
                     }
                 }

--- a/crates/tish_compile/src/infer.rs
+++ b/crates/tish_compile/src/infer.rs
@@ -558,7 +558,7 @@ pub(crate) fn pi_mentions(e: &Expr, name: &str) -> bool {
             }
         }),
         Object { props, .. } => props.iter().any(|p| match p {
-            tishlang_ast::ObjectProp::KeyValue(_, v) => pi_mentions(v, name),
+            tishlang_ast::ObjectProp::KeyValue(_, v, _) => pi_mentions(v, name),
             tishlang_ast::ObjectProp::Spread(x) => pi_mentions(x, name),
         }),
         TemplateLiteral { exprs, .. } => exprs.iter().any(|x| pi_mentions(x, name)),
@@ -634,7 +634,7 @@ fn infer_object_shape(
     let mut fields = Vec::with_capacity(props.len());
     for p in props {
         match p {
-            tishlang_ast::ObjectProp::KeyValue(k, v) => {
+            tishlang_ast::ObjectProp::KeyValue(k, v, _) => {
                 let ty = infer_expr_type(v, ctx)?;
                 // Only primitive field types in this conservative version.
                 if !matches!(&ty, TypeAnnotation::Simple(s, _)
@@ -1303,7 +1303,7 @@ fn arr_expr_safe(e: &Expr, name: &str) -> bool {
             }
         }),
         Object { props, .. } => props.iter().all(|p| match p {
-            tishlang_ast::ObjectProp::KeyValue(_, v) => arr_expr_safe(v, name),
+            tishlang_ast::ObjectProp::KeyValue(_, v, _) => arr_expr_safe(v, name),
             tishlang_ast::ObjectProp::Spread(v) => arr_expr_safe(v, name),
         }),
         // Anything else that mentions `name`: be safe, bail.
@@ -1423,7 +1423,7 @@ fn expr_name_safe(e: &Expr, name: &str, keys: &std::collections::HashSet<&str>) 
             }
         }),
         Object { props, .. } => props.iter().all(|p| match p {
-            tishlang_ast::ObjectProp::KeyValue(_, v) => expr_name_safe(v, name, keys),
+            tishlang_ast::ObjectProp::KeyValue(_, v, _) => expr_name_safe(v, name, keys),
             tishlang_ast::ObjectProp::Spread(e) => expr_name_safe(e, name, keys),
         }),
         TemplateLiteral { exprs, .. } => exprs.iter().all(|e| expr_name_safe(e, name, keys)),

--- a/crates/tish_compile/src/resolve.rs
+++ b/crates/tish_compile/src/resolve.rs
@@ -173,7 +173,7 @@ pub fn program_uses_document(program: &Program) -> bool {
                 ArrayElement::Expr(e) | ArrayElement::Spread(e) => expr_uses_document(e),
             }),
             Expr::Object { props, .. } => props.iter().any(|p| match p {
-                ObjectProp::KeyValue(_, e) | ObjectProp::Spread(e) => expr_uses_document(e),
+                ObjectProp::KeyValue(_, e, _) | ObjectProp::Spread(e) => expr_uses_document(e),
             }),
             Expr::Assign { value, .. }
             | Expr::CompoundAssign { value, .. }
@@ -1601,7 +1601,7 @@ fn rewrite_expr_scope(expr: &mut Expr, active: &HashMap<String, Arc<str>>) {
         Expr::Object { props, .. } => {
             for p in props {
                 match p {
-                    ObjectProp::KeyValue(_, e) | ObjectProp::Spread(e) => {
+                    ObjectProp::KeyValue(_, e, _) | ObjectProp::Spread(e) => {
                         rewrite_expr_scope(e, active) // key is a property name; value recurses
                     }
                 }
@@ -1819,6 +1819,7 @@ pub fn merge_modules(mut modules: Vec<ResolvedModule>) -> Result<MergedProgram, 
                                             name: Arc::from(v.clone()),
                                             span: *span,
                                         },
+                                        *name_span,
                                     ));
                                 }
                                 merge_push(

--- a/crates/tish_compile_js/src/codegen.rs
+++ b/crates/tish_compile_js/src/codegen.rs
@@ -629,7 +629,7 @@ impl Codegen {
                 let parts: Result<Vec<_>, _> = props
                     .iter()
                     .map(|p| match p {
-                        ObjectProp::KeyValue(k, v) => {
+                        ObjectProp::KeyValue(k, v, _) => {
                             let key = k.as_ref();
                             let val = self.emit_expr(v)?;
                             Ok(if key.chars().all(|c| c.is_alphanumeric() || c == '_') {

--- a/crates/tish_compiler_wasm/src/resolve_virtual.rs
+++ b/crates/tish_compiler_wasm/src/resolve_virtual.rs
@@ -394,6 +394,7 @@ pub fn merge_modules_virtual(modules: Vec<VirtualModule>) -> Result<Program, Str
                                             name: Arc::from(v.clone()),
                                             span: *span,
                                         },
+                                        *name_span,
                                     ));
                                 }
                                 statements.push(Statement::VarDecl {

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -2011,7 +2011,7 @@ impl Evaluator {
                 let mut data = EvalObjectData::default();
                 for prop in props {
                     match prop {
-                        tishlang_ast::ObjectProp::KeyValue(k, v) => {
+                        tishlang_ast::ObjectProp::KeyValue(k, v, _) => {
                             data
                                 .strings
                                 .insert(Arc::clone(k), self.eval_expr(v)?);

--- a/crates/tish_fmt/src/lib.rs
+++ b/crates/tish_fmt/src/lib.rs
@@ -248,7 +248,7 @@ impl Printer {
 
     fn object_prop(&mut self, pr: &ObjectProp) {
         match pr {
-            ObjectProp::KeyValue(k, v) => {
+            ObjectProp::KeyValue(k, v, _) => {
                 self.buf.push_str(k.as_ref());
                 self.buf.push_str(": ");
                 self.expr(v);

--- a/crates/tish_lint/src/lib.rs
+++ b/crates/tish_lint/src/lib.rs
@@ -170,16 +170,18 @@ fn stmt_span(s: &Statement) -> (u32, u32) {
 
 fn lint_expr(e: &Expr, out: &mut Vec<LintDiagnostic>) {
     match e {
-        Expr::Object { props, span, .. } => {
+        Expr::Object { props, .. } => {
             let mut seen: HashSet<&str> = HashSet::new();
             for p in props {
-                if let ObjectProp::KeyValue(k, v) = p {
+                if let ObjectProp::KeyValue(k, v, kspan) = p {
                     if !seen.insert(k.as_ref()) {
+                        // Point at the duplicated KEY, not the enclosing `{` — so distinct dupes get
+                        // distinct positions (#143).
                         out.push(LintDiagnostic {
                             code: "tish-duplicate-key",
                             message: format!("Duplicate object key `{}`", k),
-                            line: span.start.0 as u32,
-                            col: span.start.1 as u32,
+                            line: kspan.start.0 as u32,
+                            col: kspan.start.1 as u32,
                             severity: Severity::Warning,
                         });
                     }
@@ -362,5 +364,21 @@ mod tests {
     #[test]
     fn lints_inside_delete_target() {
         assert!(dup_keys("delete ({ a: 1, a: 2 }).a\n") >= 1, "delete target");
+    }
+}
+
+#[cfg(test)]
+mod dupkey_position_tests {
+    use super::*;
+    #[test]
+    fn dup_key_points_at_the_duplicated_key() {
+        // `let x = { a: 1, a: 2 }` — the duplicate `a` is at 1-indexed col 17; the object `{` is col 9.
+        let d: Vec<_> = lint_source("let x = { a: 1, a: 2 }\n")
+            .expect("parse")
+            .into_iter()
+            .filter(|d| d.code == "tish-duplicate-key")
+            .collect();
+        assert_eq!(d.len(), 1, "exactly one dup-key");
+        assert_eq!((d[0].line, d[0].col), (1, 17), "#143: must point at the duplicated key, not the `{{`");
     }
 }

--- a/crates/tish_opt/src/lib.rs
+++ b/crates/tish_opt/src/lib.rs
@@ -429,8 +429,8 @@ fn optimize_expr(expr: &Expr) -> Expr {
             props: props
                 .iter()
                 .map(|p| match p {
-                    tishlang_ast::ObjectProp::KeyValue(k, v) => {
-                        tishlang_ast::ObjectProp::KeyValue(Arc::clone(k), optimize_expr(v))
+                    tishlang_ast::ObjectProp::KeyValue(k, v, s) => {
+                        tishlang_ast::ObjectProp::KeyValue(Arc::clone(k), optimize_expr(v), *s)
                     }
                     tishlang_ast::ObjectProp::Spread(e) => {
                         tishlang_ast::ObjectProp::Spread(optimize_expr(e))

--- a/crates/tish_parser/src/lib.rs
+++ b/crates/tish_parser/src/lib.rs
@@ -62,7 +62,7 @@ mod tests {
         };
         assert_eq!(props.len(), 1);
         match &props[0] {
-            ObjectProp::KeyValue(k, v) => {
+            ObjectProp::KeyValue(k, v, _) => {
                 assert_eq!(k.as_ref(), "port");
                 if let Expr::Ident { ref name, .. } = v {
                     assert_eq!(name.as_ref(), "port");
@@ -92,11 +92,11 @@ mod tests {
         };
         assert_eq!(props.len(), 2);
         match &props[0] {
-            ObjectProp::KeyValue(k, _) => assert_eq!(k.as_ref(), "ai-a"),
+            ObjectProp::KeyValue(k, _, _) => assert_eq!(k.as_ref(), "ai-a"),
             _ => panic!("expected KeyValue prop"),
         }
         match &props[1] {
-            ObjectProp::KeyValue(k, _) => assert_eq!(k.as_ref(), "human"),
+            ObjectProp::KeyValue(k, _, _) => assert_eq!(k.as_ref(), "human"),
             _ => panic!("expected KeyValue prop"),
         }
     }
@@ -118,7 +118,7 @@ mod tests {
         };
         assert_eq!(props.len(), 2);
         match &props[0] {
-            ObjectProp::KeyValue(k, v) => {
+            ObjectProp::KeyValue(k, v, _) => {
                 assert_eq!(k.as_ref(), "port");
                 if let Expr::Ident { ref name, .. } = v {
                     assert_eq!(name.as_ref(), "port");
@@ -129,7 +129,7 @@ mod tests {
             _ => panic!("expected KeyValue prop"),
         }
         match &props[1] {
-            ObjectProp::KeyValue(k, v) => {
+            ObjectProp::KeyValue(k, v, _) => {
                 assert_eq!(k.as_ref(), "x");
                 if let Expr::Literal { .. } = v {
                     // x: 1

--- a/crates/tish_parser/src/parser.rs
+++ b/crates/tish_parser/src/parser.rs
@@ -2243,7 +2243,7 @@ impl<'a> Parser<'a> {
                                 return Err("String key in object literal requires explicit value (key: value)".to_string());
                             }
                         };
-                        props.push(ObjectProp::KeyValue(key, value));
+                        props.push(ObjectProp::KeyValue(key, value, key_span));
                     }
                     if !matches!(self.peek_kind(), Some(TokenKind::RBrace)) {
                         self.expect(TokenKind::Comma)?;

--- a/crates/tish_resolve/src/lib.rs
+++ b/crates/tish_resolve/src/lib.rs
@@ -457,7 +457,7 @@ fn collect_expr(
         Expr::Object { props, .. } => {
             for p in props {
                 match p {
-                    tishlang_ast::ObjectProp::KeyValue(_, e) => {
+                    tishlang_ast::ObjectProp::KeyValue(_, e, _) => {
                         collect_expr(e, source, lsp_line, lsp_char, best)
                     }
                     tishlang_ast::ObjectProp::Spread(e) => {
@@ -729,7 +729,7 @@ fn member_chain_collect_expr(
         Expr::Object { props, .. } => {
             for p in props {
                 match p {
-                    tishlang_ast::ObjectProp::KeyValue(_, e) => {
+                    tishlang_ast::ObjectProp::KeyValue(_, e, _) => {
                         member_chain_collect_expr(e, source, lsp_line, lsp_char, best)
                     }
                     tishlang_ast::ObjectProp::Spread(e) => {
@@ -1213,7 +1213,7 @@ fn walk_expr_resolve(
         Expr::Object { props, .. } => {
             for p in props {
                 let e = match p {
-                    tishlang_ast::ObjectProp::KeyValue(_, e) => e,
+                    tishlang_ast::ObjectProp::KeyValue(_, e, _) => e,
                     tishlang_ast::ObjectProp::Spread(e) => e,
                 };
                 if let Some(s) = walk_expr_resolve(e, scopes, target) {
@@ -1834,7 +1834,7 @@ fn check_unresolved_expr(expr: &Expr, scopes: &ScopeStack, out: &mut Vec<Unresol
         Expr::Object { props, .. } => {
             for p in props {
                 let e = match p {
-                    tishlang_ast::ObjectProp::KeyValue(_, e) => e,
+                    tishlang_ast::ObjectProp::KeyValue(_, e, _) => e,
                     tishlang_ast::ObjectProp::Spread(e) => e,
                 };
                 check_unresolved_expr(e, scopes, out);
@@ -2324,7 +2324,7 @@ fn enumerate_expr(expr: &Expr, exported: bool, out: &mut Vec<BindingSite>) {
         Expr::Object { props, .. } => {
             for p in props {
                 let e = match p {
-                    tishlang_ast::ObjectProp::KeyValue(_, e) => e,
+                    tishlang_ast::ObjectProp::KeyValue(_, e, _) => e,
                     tishlang_ast::ObjectProp::Spread(e) => e,
                 };
                 enumerate_expr(e, exported, out);
@@ -2829,7 +2829,7 @@ fn jsx_tags_expr(e: &Expr, out: &mut std::collections::HashSet<Arc<str>>) {
         Expr::Object { props, .. } => {
             for p in props {
                 match p {
-                    tishlang_ast::ObjectProp::KeyValue(_, e)
+                    tishlang_ast::ObjectProp::KeyValue(_, e, _)
                     | tishlang_ast::ObjectProp::Spread(e) => jsx_tags_expr(e, out),
                 }
             }
@@ -3238,7 +3238,7 @@ fn walk_expr_completion(
         Expr::Object { props, .. } => {
             for p in props {
                 let e = match p {
-                    tishlang_ast::ObjectProp::KeyValue(_, e) => e,
+                    tishlang_ast::ObjectProp::KeyValue(_, e, _) => e,
                     tishlang_ast::ObjectProp::Spread(e) => e,
                 };
                 walk_expr_completion(e, source, lsp_line, lsp_char, stack, best);
@@ -3714,7 +3714,7 @@ fn tref_expr(expr: &Expr, out: &mut Vec<TypeOcc>) {
         Expr::Object { props, .. } => {
             for p in props {
                 match p {
-                    tishlang_ast::ObjectProp::KeyValue(_, e)
+                    tishlang_ast::ObjectProp::KeyValue(_, e, _)
                     | tishlang_ast::ObjectProp::Spread(e) => tref_expr(e, out),
                 }
             }
@@ -4178,7 +4178,7 @@ fn refs_expr(
         Expr::Object { props, .. } => {
             for p in props {
                 match p {
-                    tishlang_ast::ObjectProp::KeyValue(_, e) => {
+                    tishlang_ast::ObjectProp::KeyValue(_, e, _) => {
                         refs_expr(e, program, source, name, def_span, out)
                     }
                     tishlang_ast::ObjectProp::Spread(e) => {

--- a/crates/tish_ui/src/jsx.rs
+++ b/crates/tish_ui/src/jsx.rs
@@ -302,7 +302,7 @@ fn collect_fun_decl_names_expr(expr: &Expr, names: &mut HashSet<String>) {
         Expr::Object { props, .. } => {
             for p in props {
                 match p {
-                    ObjectProp::KeyValue(_, e) | ObjectProp::Spread(e) => {
+                    ObjectProp::KeyValue(_, e, _) | ObjectProp::Spread(e) => {
                         collect_fun_decl_names_expr(e, names);
                     }
                 }
@@ -650,7 +650,7 @@ fn expr_contains_jsx(expr: &Expr) -> bool {
             ArrayElement::Expr(e) | ArrayElement::Spread(e) => expr_contains_jsx(e),
         }),
         Expr::Object { props, .. } => props.iter().any(|p| match p {
-            ObjectProp::KeyValue(_, e) | ObjectProp::Spread(e) => expr_contains_jsx(e),
+            ObjectProp::KeyValue(_, e, _) | ObjectProp::Spread(e) => expr_contains_jsx(e),
         }),
         Expr::ArrowFunction { body, .. } => match body {
             tishlang_ast::ArrowBody::Expr(e) => expr_contains_jsx(e),


### PR DESCRIPTION
Closes #143. The `tish-duplicate-key` diagnostic used the enclosing object literal's span, so every duplicate in an object collapsed to the same column (the `{`).

## Change
`ObjectProp::KeyValue` gains a **key span** (the key token's source span; synthesized object literals — namespace-import objects, JS-transpiled props — use a zero span). The parser populates it from the key token (already in scope), and the linter now reports at the key's line/col.

This is **behavior-preserving**: per the AST convention the span participates in `PartialEq`, nothing compares `ObjectProp` whole, and every other `KeyValue` consumer just ignores the new field (compiler-driven update of all match/construction sites, same approach as #131).

## TDD
`let x = { a: 1, a: 2 }` now reports the duplicate at **(1,17)** — the second `a` — instead of **(1,9)** (the `{`). Full workspace suite green (**330 passed**); the PR's perf-suite + native-build CI exercises the object-literal codegen paths.