### PR TITLE
test: close fmt/LSP coverage holes (#163)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3422,6 +3422,7 @@ dependencies = [
  "tishlang_parser",
  "tishlang_resolve",
  "tokio",
+ "tower 0.4.13",
  "tower-lsp",
  "walkdir",
 ]
@@ -3699,6 +3700,7 @@ dependencies = [
  "pin-project-lite",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3786,6 +3788,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/crates/tish_fmt/src/lib.rs
+++ b/crates/tish_fmt/src/lib.rs
@@ -2235,4 +2235,48 @@ let x = add(1, 2)
         tishlang_parser::parse(&out).unwrap();
         assert_eq!(format_source(&out).unwrap(), out, "not idempotent:\n{out}");
     }
+
+    /// Broad idempotence guard (#163): the existing tests targeted specific constructs (JSX, new-
+    /// expr) that *had* regressed, leaving structural blind spots. This sweeps a diverse corpus and
+    /// asserts, for every snippet, that (a) the formatted output re-parses and (b) re-formatting is
+    /// a fixed point — so any future construct that formats non-idempotently is caught here.
+    #[test]
+    fn format_is_idempotent_over_a_corpus() {
+        let corpus = [
+            "let a = { x: 1, y: { z: [1, 2, 3] } }\n",
+            "let f = (a, b) => a + b\n",
+            "let g = (x) => { return x * 2 }\n",
+            "const e = <div class=\"x\">{a}<span>b</span></div>\n",
+            "let frag = <><a>1</a><b>2</b></>\n",
+            "let n = new Foo(1).bar().baz\n",
+            "let n2 = new (getCtor())(arg)\n",
+            "let t = `a${b}c${d}e`\n",
+            "let lit = \"has a literal $ and a ${notInterp}\"\n",
+            "if (x) { return 1 } else if (y) { return 2 } else { return 3 }\n",
+            "for (let i = 0; i < n; i = i + 1) { f(i) }\n",
+            "for (const k of items) { use(k) }\n",
+            "while (cond) { step() }\n",
+            "do { once() } while (again)\n",
+            "switch (x) { case 1: f(); break; default: g() }\n",
+            "let u: number | string = 1\n",
+            "type T = { a: number, b: string[] }\n",
+            "export fn h(x: T): T { return x }\n",
+            "let v = a ? b : c\n",
+            "let w = a ?? b\n",
+            "let arr = [{ k: 1 }, { k: 2 }, ...rest]\n",
+            "let obj = { ...base, x: 1, y: 2 }\n",
+            "let chain = a?.b?.c\n",
+            "let big = 1e400\n",
+            "try { risky() } catch (e) { handle(e) } finally { cleanup() }\n",
+            "async fn af() { return await thing() }\n",
+            "import { a, b as c } from \"./m\"\nexport default a\n",
+        ];
+        for src in corpus {
+            let once = format_source(src).expect("format");
+            tishlang_parser::parse(&once)
+                .unwrap_or_else(|e| panic!("formatted output must re-parse for {src:?}: {e}\n{once}"));
+            let twice = format_source(&once).expect("re-format");
+            assert_eq!(once, twice, "non-idempotent for {src:?}:\n{once:?}\n  ->\n{twice:?}");
+        }
+    }
 }

--- a/crates/tish_lsp/Cargo.toml
+++ b/crates/tish_lsp/Cargo.toml
@@ -23,3 +23,9 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "tim
 serde_json = "1"
 regex = "1"
 walkdir = "2"
+
+[dev-dependencies]
+# Drive `LspService` over JSON-RPC in tests (#163). Must match the `tower` major that tower-lsp 0.20
+# implements `Service` against (0.4), or the trait bound on `.call()` won't be satisfied. `util`
+# brings in `ServiceExt::ready`.
+tower = { version = "0.4", features = ["util"] }

--- a/crates/tish_lsp/src/main.rs
+++ b/crates/tish_lsp/src/main.rs
@@ -1888,3 +1888,129 @@ mod rename_target_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod jsonrpc_integration_tests {
+    //! End-to-end tests that drive the server the way an editor does — by feeding JSON-RPC requests
+    //! through `tower::Service` — rather than calling handler methods directly. This is the layer
+    //! #163 flagged as untested: it catches wiring regressions (a `didOpen` that never stored the
+    //! doc, a changed response shape, the whole-document formatting range) that unit tests on the
+    //! pure helpers structurally cannot see.
+    use super::*;
+    use tower::{Service, ServiceExt};
+    use tower_lsp::jsonrpc::Request;
+
+    fn new_service() -> LspService<Backend> {
+        // Mirrors the construction in `main`; the returned socket is the server's outbound channel
+        // (diagnostics, show_message). Tests don't read it, so dropping it is fine — the client
+        // tolerates a closed socket.
+        let (service, _socket) = LspService::new(|client| Backend {
+            client,
+            docs: Arc::new(RwLock::new(HashMap::new())),
+            edit_seq: Arc::new(RwLock::new(HashMap::new())),
+            roots: Arc::new(RwLock::new(Vec::new())),
+            cargo_src_cache: Arc::new(RwLock::new(HashMap::new())),
+            tishlang_source_root: Arc::new(RwLock::new(None)),
+        });
+        service
+    }
+
+    /// Drive one request/notification through the service. Returns the JSON-RPC `result` value, or
+    /// `None` when there is no response (notifications, or requests the router answers with none).
+    async fn call(service: &mut LspService<Backend>, req: Request) -> Option<serde_json::Value> {
+        let resp = service.ready().await.unwrap().call(req).await.unwrap()?;
+        let (_id, result) = resp.into_parts();
+        Some(result.expect("server returned a JSON-RPC error"))
+    }
+
+    async fn initialize(service: &mut LspService<Backend>) {
+        let init = Request::build("initialize")
+            .id(1)
+            .params(serde_json::json!({ "capabilities": {} }))
+            .finish();
+        call(service, init).await.expect("initialize must return a result");
+        let initialized = Request::build("initialized").params(serde_json::json!({})).finish();
+        let _ = call(service, initialized).await; // notification: no response
+    }
+
+    async fn did_open(service: &mut LspService<Backend>, uri: &str, text: &str) {
+        let req = Request::build("textDocument/didOpen")
+            .params(serde_json::json!({
+                "textDocument": { "uri": uri, "languageId": "tish", "version": 1, "text": text }
+            }))
+            .finish();
+        let _ = call(service, req).await; // notification: no response
+    }
+
+    fn formatting_request(uri: &str) -> Request {
+        Request::build("textDocument/formatting")
+            .id(2)
+            .params(serde_json::json!({
+                "textDocument": { "uri": uri },
+                "options": { "tabSize": 2, "insertSpaces": true }
+            }))
+            .finish()
+    }
+
+    // The headline guard #163 asks for: a `didOpen` → `formatting` round-trip over the wire must
+    // produce a single edit that replaces the WHOLE document, ending PAST the trailing newline. An
+    // end of (0, N) would leave a stale blank line — the trailing-newline regression — and a missing
+    // stored doc would surface here as `null` instead of an edit.
+    #[tokio::test]
+    async fn formatting_round_trip_replaces_whole_document() {
+        let mut service = new_service();
+        initialize(&mut service).await;
+        let uri = "file:///round_trip.tish";
+        did_open(&mut service, uri, "let  x=1\n").await;
+
+        let result = call(&mut service, formatting_request(uri))
+            .await
+            .expect("formatting must return a result");
+        let edits = result.as_array().expect("formatting result is an array of edits");
+        assert_eq!(edits.len(), 1, "a single whole-document edit");
+        let edit = &edits[0];
+        assert_eq!(edit["newText"], "let x = 1\n", "reformatted source");
+        assert_eq!(edit["range"]["start"], serde_json::json!({ "line": 0, "character": 0 }));
+        assert_eq!(
+            edit["range"]["end"],
+            serde_json::json!({ "line": 1, "character": 0 }),
+            "the edit must reach past the trailing newline, not stop at (0, N)"
+        );
+    }
+
+    // Formatting a document the server never saw must be a clean no-op (`null`), not a panic or a
+    // fabricated edit.
+    #[tokio::test]
+    async fn formatting_unknown_document_yields_no_edit() {
+        let mut service = new_service();
+        initialize(&mut service).await;
+        let result = call(&mut service, formatting_request("file:///never_opened.tish"))
+            .await
+            .expect("formatting must return a result");
+        assert!(result.is_null(), "unknown document must yield no edits, got {result}");
+    }
+
+    // A second `didOpen`/format after an in-place edit (via didChange) must reflect the new text —
+    // proves the doc store is actually keyed and updated, not stuck on first-open contents.
+    #[tokio::test]
+    async fn did_change_updates_the_stored_document() {
+        let mut service = new_service();
+        initialize(&mut service).await;
+        let uri = "file:///mutated.tish";
+        did_open(&mut service, uri, "let a=1\n").await;
+
+        let change = Request::build("textDocument/didChange")
+            .params(serde_json::json!({
+                "textDocument": { "uri": uri, "version": 2 },
+                "contentChanges": [ { "text": "let b=2\n" } ]
+            }))
+            .finish();
+        let _ = call(&mut service, change).await; // notification
+
+        let result = call(&mut service, formatting_request(uri))
+            .await
+            .expect("formatting must return a result");
+        let edits = result.as_array().expect("edits array");
+        assert_eq!(edits[0]["newText"], "let b = 2\n", "formatting must see the changed text");
+    }
+}


### PR DESCRIPTION
## What

Closes #163.

The fmt idempotence guards only exercised the constructs that had *already* regressed once (JSX, `new`-expressions), leaving structural blind spots — any new construct that formats non-idempotently would slip through. And the LSP had **no** tests driving it over JSON-RPC: trailing-newline, encoding, and doc-store wiring were only reachable through the pure helpers, never end-to-end.

## Changes

**`tish_fmt` — broad idempotence corpus guard**
`format_is_idempotent_over_a_corpus` sweeps a diverse corpus (objects, arrows, JSX + fragments, `new`, template literals, control flow, types, ternary/nullish, spreads, optional chaining, try/catch/finally, async, imports/exports) and asserts for every snippet that (a) the formatted output re-parses and (b) re-formatting is a fixed point. Any future construct that formats to invalid or non-idempotent output is now caught here, not in the field.

**`tish_lsp` — JSON-RPC integration tests**
New `jsonrpc_integration_tests` module drives `LspService` through `tower::Service` the way an editor does (no stdio):
- `formatting_round_trip_replaces_whole_document` — `didOpen` → `formatting` yields a single whole-document edit whose range ends **past** the trailing newline `(line 1, char 0)`, guarding the trailing-blank-line regression at the protocol level.
- `formatting_unknown_document_yields_no_edit` — a format request for an unseen document is a clean `null` no-op.
- `did_change_updates_the_stored_document` — `didChange` then `formatting` reflects the new text, proving the doc store is keyed and updated in place.

Adds `tower = "0.4"` (matching tower-lsp 0.20's `Service` major) as a dev-dependency.

## Test

`cargo test -p tishlang_fmt -p tishlang_lsp` — 31 fmt + 27 lsp tests green.