### PR TITLE
test: make fixed-port HTTP examples runnable + wire scoped @tishlang/lattish

### DIFF
--- a/examples/counter-api/src/main.tish
+++ b/examples/counter-api/src/main.tish
@@ -20,7 +20,8 @@ fn errorResponse(status, message) {
 }
 
 fn getCounter(name) {
-    if (counters[name] === undefined) {
+    // Missing object keys read back as `null` in tish (there is no `undefined`).
+    if (counters[name] === null) {
         counters[name] = 0
     }
     return counters[name]
@@ -86,6 +87,6 @@ fn handleRequest(req) {
     return errorResponse(404, "Not found: " + req.path)
 }
 
-let port = 3000
+let port = "PORT" in process.env ? parseInt(process.env.PORT) : 3000
 console.log(`Starting Counter API on port ${port}...`)
 serve(port, handleRequest)

--- a/examples/echo-server/src/main.tish
+++ b/examples/echo-server/src/main.tish
@@ -50,7 +50,7 @@ fn handleRequest(req) {
     }
 }
 
-let port = 3000
+let port = "PORT" in process.env ? parseInt(process.env.PORT) : 3000
 console.log(`Starting Echo Server on port ${port}...`)
 console.log("Endpoints: /echo, /mirror, /health")
 serve(port, handleRequest)

--- a/examples/json-api/src/main.tish
+++ b/examples/json-api/src/main.tish
@@ -56,6 +56,6 @@ fn handleRequest(req) {
     return errorResponse(404, "Not found: " + req.path)
 }
 
-let port = 3000
+let port = "PORT" in process.env ? parseInt(process.env.PORT) : 3000
 console.log(`Starting JSON API on port ${port}...`)
 serve(port, handleRequest)

--- a/regression/downstream/repos.tsv
+++ b/regression/downstream/repos.tsv
@@ -14,18 +14,22 @@ ffi-mathext	self:examples/ffi/mathext	.	ffi	cargo build --release	pass
 ffi-statext	self:examples/ffi/statext	.	ffi	cargo build --release	pass
 tish-unity	local:~/Projects/tish/tish-unity/native/tish_unity_bridge	.	ffi	cargo build --release	pass
 #
-# ── cargo: Rust extensions/embedders — broken by NativeFn→Callable / String→ArcStr / PropMap ──
-# (CONFIRMED broken by compiling against feature/perf: tish-pg, tish-callbacks. tish-apple-common
-# is CONFIRMED CLEAN — it is in the tish-program section below as pass; its tish-macos/tish-ios
-# crates are macOS-only + heavy Value-use, likely broken, but not Linux-checkable.)
+# ── cargo: Rust extensions/embedders — the NativeFn→Callable / String→ArcStr / PropMap migration ──
+# These were xfail while that migration was in flight. As of this run they build AND `cargo test`
+# clean against HEAD, so they are flipped to pass (`cargo test`, not `cargo check`, to validate full
+# codegen+link, not just type-check). NOTE: only tish-callbacks ships behavioral tests (3, passing);
+# tish-stripe/cedar/biscuit/webauthn/brainstorm-pg have no test fns, so for them `cargo test` is a
+# build/codegen guard. tish-oidc + tish-polars are still genuinely broken (kept xfail). tish-pg is a
+# local path absent on this machine (skips). tish-apple-common is CONFIRMED CLEAN (pass below); its
+# tish-macos/tish-ios crates are macOS-only + heavy Value-use, not Linux-checkable.
 tish-pg	local:~/Projects/tish-pg	.	rust	cargo test --no-run	xfail
-tish-callbacks	local:~/Projects/tish/tish-callbacks	.	rust	cargo test	xfail
+tish-callbacks	local:~/Projects/tish/tish-callbacks	.	rust	cargo test	pass
 tish-oidc	local:~/Projects/tish/tish-oidc	.	rust	cargo check	xfail
-tish-stripe	local:~/Projects/tish/tish-stripe	.	rust	cargo check	xfail
-tish-cedar	local:~/Projects/tish/tish-cedar	.	rust	cargo check	xfail
-tish-biscuit	local:~/Projects/tish/tish-biscuit	.	rust	cargo check	xfail
-tish-webauthn	local:~/Projects/tish/tish-webauthn	.	rust	cargo check	xfail
-brainstorm-pg	local:~/Projects/brainstorm/crates/brainstorm-pg	.	rust	cargo check	xfail
+tish-stripe	local:~/Projects/tish/tish-stripe	.	rust	cargo test	pass
+tish-cedar	local:~/Projects/tish/tish-cedar	.	rust	cargo test	pass
+tish-biscuit	local:~/Projects/tish/tish-biscuit	.	rust	cargo test	pass
+tish-webauthn	local:~/Projects/tish/tish-webauthn	.	rust	cargo test	pass
+brainstorm-pg	local:~/Projects/brainstorm/crates/brainstorm-pg	.	rust	cargo test	pass
 tish-polars	git:https://github.com/spacedevin/tish-polars.git@main	.	rust	cargo check	xfail
 tish-apple	git:https://github.com/tishlang/tish-apple.git@main	.	rust	cargo check -p tish-apple-common	pass
 #

--- a/regression/downstream/run.sh
+++ b/regression/downstream/run.sh
@@ -117,21 +117,24 @@ run_one() {
         if file "$bin" 2>/dev/null | rg -qi 'mach-o|elf|executable'; then cp -f "$TISH/target/release/tish" "$bin" 2>/dev/null || true; fi
       done
     fi
-    # Wire any `lattish` dependency to the LOCAL WORKSPACE lattish — the npm analog of rewrite_tish_paths
+    # Wire any lattish dependency to the LOCAL WORKSPACE lattish — the npm analog of rewrite_tish_paths
     # for the Rust crates. We test consumers against the lattish being DEVELOPED next to this tish
     # checkout, not the published package (else we'd only re-test already-released code). Consumers pin
     # lattish to a local monorepo path (file:../tish/lattish) absent in an isolated clone, so npm leaves a
-    # dangling symlink; replace it with the workspace copy. (Resolver matches node_modules by directory,
-    # so lattish's own @tishlang/lattish name is irrelevant.) Falls back to the cloned lattish in CI.
-    if [[ -f "$dir/$subdir/package.json" ]] && rg -q '"lattish"[[:space:]]*:' "$dir/$subdir/package.json" 2>/dev/null; then
+    # dangling symlink; replace it with the workspace copy. Wire BOTH the bare `lattish` dir (older
+    # consumers, e.g. tish-audio) and the scoped `@tishlang/lattish` dir — the resolver matches a scoped
+    # import (`from "@tishlang/lattish"`, e.g. tish-midi/deckard) ONLY at node_modules/@tishlang/lattish,
+    # so the bare dir alone leaves it unresolved. Falls back to the cloned lattish in CI.
+    if [[ -f "$dir/$subdir/package.json" ]] && rg -q '"(@tishlang/)?lattish"[[:space:]]*:' "$dir/$subdir/package.json" 2>/dev/null; then
       local lat_src=""
       if [[ -d "$TISH/../lattish" ]]; then lat_src="$(cd "$TISH/.." && pwd)/lattish"
       elif [[ -d "$WORKDIR/lattish" ]]; then lat_src="$WORKDIR/lattish"; fi
       if [[ -n "$lat_src" ]]; then
-        rm -rf "$dir/$subdir/node_modules/lattish"
-        mkdir -p "$dir/$subdir/node_modules"
+        rm -rf "$dir/$subdir/node_modules/lattish" "$dir/$subdir/node_modules/@tishlang/lattish"
+        mkdir -p "$dir/$subdir/node_modules/@tishlang"
         rsync -a --exclude node_modules --exclude .git "$lat_src/" "$dir/$subdir/node_modules/lattish/" >/dev/null 2>&1
-        echo "   wired LOCAL lattish ($lat_src) -> node_modules/lattish"
+        rsync -a --exclude node_modules --exclude .git "$lat_src/" "$dir/$subdir/node_modules/@tishlang/lattish/" >/dev/null 2>&1
+        echo "   wired LOCAL lattish ($lat_src) -> node_modules/{lattish,@tishlang/lattish}"
       else
         echo "   ⚠ depends on lattish but no local workspace ($TISH/../lattish) or clone ($WORKDIR/lattish) found"
       fi

--- a/regression/examples/examples.tsv
+++ b/regression/examples/examples.tsv
@@ -30,9 +30,9 @@ js-to-tish	examples/js-to-tish-example	src/main.tish	run	-	-	Average:	-	pass
 json-file-edit	examples/json-file-edit	src/main.tish	run	fs	-	version = 2	mutates	pass
 #
 # ── serve: HTTP server — start, probe, assert response, shut down ────────────────────────────────
-json-api	examples/json-api	src/main.tish	serve	http	GET:3000:/users	Alice	-	pass
-echo-server	examples/echo-server	src/main.tish	serve	http	GET:3000:/health	OK	-	pass
-counter-api	examples/counter-api	src/main.tish	serve	http	GET:3000:/health	healthy	-	pass
+json-api	examples/json-api	src/main.tish	serve	http,process	GET:auto:/users	Alice	-	pass
+echo-server	examples/echo-server	src/main.tish	serve	http,process	GET:auto:/health	OK	-	pass
+counter-api	examples/counter-api	src/main.tish	serve	http,process	GET:auto:/health	healthy	-	pass
 http-hello	examples/http-hello	src/main.tish	serve	http,process	GET:auto:/	Hello from Tish	-	pass
 http-modules	examples/http-modules-example	src/main.tish	serve	http,process	GET:auto:/	sup, World	-	pass
 http-env-var	examples/http-env-var-example	src/main.tish	serve	http,process	GET:auto:/	tishreg	-	pass


### PR DESCRIPTION
## What

Coverage gaps surfaced while running the full **example** and **downstream** suites (post-LSP validation pass). None are language regressions — they turn skips, false failures, and stale `xfail`s into real, green tests.

## Changes

**1. Fixed-port HTTP examples → auto-port (so they actually run)**
`examples/json-api`, `echo-server`, `counter-api` hardcoded `let port = 3000`, so the runner could only **SKIP** them (`port 3000 busy`). They now honor `$PORT` (default 3000 standalone) like `http-hello`, and their manifest rows use `GET:auto:` + the `process` feature so the runner relocates each to a free port. **Examples now run 22 (was 19); zero fixed-port skips.**

**2. counter-api `undefined` → `null` (latent bug)**
`getCounter` compared a missing key to `undefined`, but tish missing-keys read back as `null`, so the `/counter/:name` endpoints were broken (only `/health` worked). Fixed; verified counters increment.

**3. Downstream runner: wire the scoped `@tishlang/lattish`**
The runner only wired `node_modules/lattish` and only detected a bare `"lattish"` dep. lattish is now the scoped `@tishlang/lattish`, which consumers like **tish-midi** import scoped — resolved only at `node_modules/@tishlang/lattish`. Detect both dep forms, wire both dirs. **tish-midi flips from a false "✗ REGRESSION" to ✓ PASS; tish-audio stays green.**

**4. Flip 6 migrated consumers `xfail` → `pass`, validated by `cargo test`**
tish-callbacks, tish-stripe, tish-cedar, tish-biscuit, tish-webauthn, brainstorm-pg were `xfail` during the `NativeFn→Callable`/`String→ArcStr`/`PropMap` migration. They now build **and** `cargo test` clean against HEAD → flipped to `pass`, and upgraded `cargo check` → `cargo test` so the guard covers full codegen + link. Validated: all 6 pass; tish-callbacks runs 3 behavioral tests, the other 5 ship no test fns (so `cargo test` is a build/codegen guard for them — still stronger than `cargo check`). tish-oidc + tish-polars stay `xfail` (still genuinely broken).

## Full post-LSP validation

- **Perf gauntlet:** clean — no `TYPED≠BOXED`/`≠NODE` soundness regressions; 8/21 beat V8.
- **Core `cargo test --workspace`:** 345 passed, 0 failed (79 suites).
- **Examples:** 22/22 pass.
- **Downstream:** all consumers green (incl. the 6 flipped + tish-midi).