### PR TITLE
perf(core): cache TISH_PACKED_ARRAYS in a OnceLock instead of getenv per NewArray (#166)

### DIFF
--- a/crates/tish_builtins/src/typedarrays.rs
+++ b/crates/tish_builtins/src/typedarrays.rs
@@ -136,7 +136,14 @@ fn construct(kind: Kind, args: &[Value]) -> Value {
 /// construction-only-coercion gap for this one view). Any op without a packed fast path materialises
 /// it back to a boxed array, so every array method keeps working.
 pub fn float64_array_packed(args: &[Value]) -> Value {
-    if !Value::packed_arrays_enabled() {
+    float64_array_with(Value::packed_arrays_enabled(), args)
+}
+
+/// `float64_array_packed` with the packed/boxed choice made explicit, so tests exercise both paths
+/// without toggling the now-cached process env flag (#166). `packed = false` is byte-identical to
+/// the generic boxed `Value::Array` constructor.
+fn float64_array_with(packed: bool, args: &[Value]) -> Value {
+    if !packed {
         // Byte-identical fallback to the generic boxed `Value::Array` backing.
         return construct(Kind::F64, args);
     }
@@ -261,25 +268,26 @@ mod tests {
         assert_eq!(nums(&v), vec![0.0, 1.0]);
     }
 
-    // `float64_array_packed` toggles on a process-global env var. No other test in this crate reads
-    // `packed_arrays_enabled`, so the set/remove here can't perturb a concurrent test; we restore the
-    // default (off) on exit regardless.
+    // The packed/boxed selection is passed explicitly via `float64_array_with`, so this exercises
+    // both paths without touching the now-cached process env flag (#166) — no env mutation, no
+    // mid-test toggle race, parallel-safe.
     #[test]
     fn float64_packed_respects_flag() {
-        // Flag off (default): byte-identical boxed `Value::Array` fallback, no packed value produced.
-        std::env::remove_var("TISH_PACKED_ARRAYS");
-        let boxed = float64_array_packed(&[Value::Number(3.0)]);
+        // Packed off (the default): byte-identical boxed `Value::Array` fallback.
+        let boxed = float64_array_with(false, &[Value::Number(3.0)]);
         assert!(matches!(boxed, Value::Array(_)), "packed-off must return boxed Array");
         assert_eq!(nums(&boxed), vec![0.0, 0.0, 0.0]);
 
-        // Flag on: packed `Value::NumberArray`. F64 needs no coercion (exact), non-numeric → NaN
+        // Packed on: `Value::NumberArray`. F64 needs no coercion (exact), non-numeric → NaN
         // (matching the boxed `from_values(F64, …)`), and the length form zero-fills.
-        std::env::set_var("TISH_PACKED_ARRAYS", "1");
-        let packed = float64_array_packed(&[Value::Array(VmRef::new(vec![
-            Value::Number(1.1),
-            Value::Number(2.2),
-            Value::Null,
-        ]))]);
+        let packed = float64_array_with(
+            true,
+            &[Value::Array(VmRef::new(vec![
+                Value::Number(1.1),
+                Value::Number(2.2),
+                Value::Null,
+            ]))],
+        );
         match &packed {
             Value::NumberArray(a) => {
                 let v = a.borrow();
@@ -290,9 +298,8 @@ mod tests {
             _ => panic!("packed-on must return NumberArray"),
         }
         assert!(matches!(
-            float64_array_packed(&[Value::Number(2.0)]),
+            float64_array_with(true, &[Value::Number(2.0)]),
             Value::NumberArray(_)
         ));
-        std::env::remove_var("TISH_PACKED_ARRAYS");
     }
 }

--- a/crates/tish_core/src/value.rs
+++ b/crates/tish_core/src/value.rs
@@ -1148,12 +1148,18 @@ impl Value {
     // -------------------------------------------------------------------------
 
     /// Whether packed f64 arrays are enabled this run. Default: **off** (`TISH_PACKED_ARRAYS=1`
-    /// opts in). Checked at every creation site so flag changes take effect per-process.
+    /// opts in). Read once per process and cached — the VM calls this once per executed array
+    /// literal, and a `std::env::var` there is a libc env lock plus a `String` allocation per
+    /// `NewArray` for a flag that never changes after startup (#166). Set the variable before the
+    /// process starts (as the CI sweep does); mid-process toggling is not observed by design.
     /// The flag is intentionally backwards from the slot/JIT flags (those were default-on) to
     /// keep the default binary behaviour byte-identical while we validate coverage.
     #[inline]
     pub fn packed_arrays_enabled() -> bool {
-        std::env::var("TISH_PACKED_ARRAYS").map(|v| v == "1").unwrap_or(false)
+        static PACKED_ARRAYS: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *PACKED_ARRAYS.get_or_init(|| {
+            std::env::var("TISH_PACKED_ARRAYS").map(|v| v == "1").unwrap_or(false)
+        })
     }
 
     /// Wrap a `Vec<f64>` as a `Value::NumberArray`. Only call when `packed_arrays_enabled()`.


### PR DESCRIPTION
## What

Closes #166 — the first "land first" quick-win on the Beat-Node roadmap (#203).

`Value::packed_arrays_enabled()` re-read the `TISH_PACKED_ARRAYS` environment variable on **every call**, and the VM calls it once per executed array literal (`vm.rs` `NewArray`). On the VM hot path each array literal therefore paid a `std::env::var`: a libc environment lock plus a fresh `String` allocation, then a compare — for a flag that never changes after process start.

## Changes

- **`tish_core`** — cache the flag in a `OnceLock<bool>` (read once per process), same default-off semantics.
- **`tish_builtins`** — split `float64_array_packed` into `float64_array_with(packed, args)` + a thin public wrapper, and refactor the one test (`float64_packed_respects_flag`) to pass the flag explicitly instead of toggling the now-cached process env. That also removes the test's documented parallel-execution toggle race.

Setting the variable **before the process starts** (as the `TISH_PACKED_ARRAYS=1` CI parity sweep does, #199) still works — the `OnceLock` reads it at first use. Only mid-process toggling is no longer observed, and a grep confirms nothing but that one test ever did it.

## Test

`cargo test --workspace` — **345 passed, 0 failed** (the cross-backend `tests/core` parity suite — interp == vm == native == node — holds; default builds stay byte-identical). `cargo clippy` clean on both crates. The typed-vs-boxed gauntlet is unaffected (this is the separate packed-arrays flag, not a typed-codegen path).