### PR TITLE
fix: && / || short-circuit and return the operand value, not a boolean (#240)

### DIFF
--- a/crates/tish_bytecode/src/compiler.rs
+++ b/crates/tish_bytecode/src/compiler.rs
@@ -1859,14 +1859,16 @@ impl<'a> Compiler<'a> {
             } => {
                 match op {
                     BinOp::And => {
-                        // Short-circuit: a && b => if !a then a else b
+                        // Short-circuit + value-returning (JS): `a && b` is `a` when `a` is falsy,
+                        // else `b` — NOT a coerced boolean (#240). Mirror the `||` lowering below:
+                        // keep the left operand on a falsy short-circuit, discard it and evaluate the
+                        // right otherwise. (The old `BinOp(And)` here coerced a truthy-left result to
+                        // a Bool, so `five() && 7` yielded `true` instead of `7`.)
                         self.compile_expr(left)?;
                         self.emit(Opcode::Dup);
-                        let jump_shortcut = self.emit_jump(Opcode::JumpIfFalse);
-                        self.compile_expr(right)?; // left still on stack from Dup
-                        self.emit_u8(Opcode::BinOp, binop_to_u8(BinOp::And));
-                        let jump_end = self.emit_jump(Opcode::Jump);
-                        self.patch_jump(jump_shortcut, self.chunk.code.len());
+                        let jump_end = self.emit_jump(Opcode::JumpIfFalse); // a falsy → keep a
+                        self.emit(Opcode::Pop); // a truthy → discard a …
+                        self.compile_expr(right)?; // … and yield b
                         self.patch_jump(jump_end, self.chunk.code.len());
                     }
                     BinOp::Or => {

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -7319,8 +7319,12 @@ impl Codegen {
             BinOp::Le => format!("tishlang_runtime::ops::le(&{}, &{})", l, r),
             BinOp::Gt => format!("tishlang_runtime::ops::gt(&{}, &{})", l, r),
             BinOp::Ge => format!("tishlang_runtime::ops::ge(&{}, &{})", l, r),
-            BinOp::And => format!("Value::Bool({}.is_truthy() && {}.is_truthy())", l, r),
-            BinOp::Or => format!("Value::Bool({}.is_truthy() || {}.is_truthy())", l, r),
+            // Short-circuit + value-returning && / || (JS, #240): yield the deciding OPERAND, not a
+            // coerced boolean (`five() && 7` is `7`, not `true`). The right operand sits inside the
+            // branch, so its side effects only run when reached. (Typed `bool && bool` uses Rust's
+            // own `&&`/`||` above, where returning the bool already IS the operand.)
+            BinOp::And => format!("{{ let __l = {}; if __l.is_truthy() {{ {} }} else {{ __l }} }}", l, r),
+            BinOp::Or => format!("{{ let __l = {}; if __l.is_truthy() {{ __l }} else {{ {} }} }}", l, r),
             BinOp::BitAnd => Self::emit_bitwise_binop(l, r, "&"),
             BinOp::BitOr => Self::emit_bitwise_binop(l, r, "|"),
             BinOp::BitXor => Self::emit_bitwise_binop(l, r, "^"),

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -1106,11 +1106,35 @@ impl Evaluator {
                 op,
                 right,
                 ..
-            } => {
-                let l = self.eval_expr(left)?;
-                let r = self.eval_expr(right)?;
-                self.eval_binop(&l, *op, &r).map_err(EvalError::Error)
-            }
+            } => match op {
+                // Short-circuit + value-returning && / || (JS, #240): evaluate the left; if it
+                // already decides the result, return IT without evaluating (and running the side
+                // effects of) the right. The result is always an operand value, never a coerced
+                // boolean. The generic path below eagerly evaluated both operands and `eval_binop`
+                // coerced And/Or to `Bool`, so `five() && 7` was `true` and `false && f()` still
+                // ran `f()`.
+                BinOp::And => {
+                    let l = self.eval_expr(left)?;
+                    if l.is_truthy() {
+                        self.eval_expr(right)
+                    } else {
+                        Ok(l)
+                    }
+                }
+                BinOp::Or => {
+                    let l = self.eval_expr(left)?;
+                    if l.is_truthy() {
+                        Ok(l)
+                    } else {
+                        self.eval_expr(right)
+                    }
+                }
+                _ => {
+                    let l = self.eval_expr(left)?;
+                    let r = self.eval_expr(right)?;
+                    self.eval_binop(&l, *op, &r).map_err(EvalError::Error)
+                }
+            },
             Expr::Unary { op, operand, .. } => {
                 let o = self.eval_expr(operand)?;
                 self.eval_unary(*op, &o).map_err(EvalError::Error)

--- a/tests/core/logical_operators.js
+++ b/tests/core/logical_operators.js
@@ -1,0 +1,77 @@
+// #240 / #167: && and || follow JS semantics — they SHORT-CIRCUIT (the dead operand's side effects
+// never run) and they RETURN THE OPERAND VALUE (not a coerced boolean). This pins the observable
+// behavior across interp == vm == native == node. Valid in both tish and node.
+
+function five() { return 5 }
+function zero() { return 0 }
+function emptyStr() { return "" }
+
+// --- value-returning: a && b / a || b yield the operand, not a boolean ---
+console.log("vr-and-tt", five() && 7)             // 5 truthy  -> 7
+console.log("vr-and-ft", zero() && 7)             // 0 falsy   -> 0
+console.log("vr-or-ft", zero() || 9)              // 0 falsy   -> 9
+console.log("vr-or-tt", five() || 9)              // 5 truthy  -> 5
+console.log("vr-and-str", emptyStr() && 7)        // "" falsy  -> ""
+console.log("vr-chain", five() && zero() || 9)    // (5 && 0)=0 -> 0 || 9 -> 9
+console.log("vr-nested", (five() && 7) || zero()) // (5 && 7)=7 truthy -> 7
+
+// --- short-circuit: the right operand is NOT evaluated (no side effect) when the left decides it ---
+let andCalls = 0
+function andRight() { andCalls = andCalls + 1; return true }
+let r1 = false && andRight()                      // false short-circuits -> andRight not called
+let r2 = true && andRight()                       // true -> andRight called once
+console.log("sc-and", r1, r2, andCalls)           // false true 1
+
+let orCalls = 0
+function orRight() { orCalls = orCalls + 1; return 7 }
+let s1 = true || orRight()                         // true short-circuits -> orRight not called
+let s2 = false || orRight()                        // false -> orRight called once
+console.log("sc-or", s1, s2, orCalls)              // true 7 1
+
+// --- short-circuit in a while condition: side-effect counts ---
+let fCalls = 0
+let gCalls = 0
+let i = 0
+function f() { fCalls = fCalls + 1; return i < 3 }
+function g() { gCalls = gCalls + 1; return true }
+while (f() && g()) { i = i + 1 }
+console.log("while-and", i, fCalls, gCalls)        // 3 4 3 (g not called when f is false)
+
+let qCalls = 0
+function q() { qCalls = qCalls + 1; return false }
+let n = 0
+while ((n < 2) || q()) { n = n + 1 }
+console.log("while-or", n, qCalls)                 // 2 1 (q only when n<2 is false)
+
+// --- for + && and do-while + || conditions ---
+let forCount = 0
+for (let k = 0; k < 5 && forCount < 3; k = k + 1) { forCount = forCount + 1 }
+console.log("for-and", forCount)                   // 3
+
+let d = 0
+let dq = 0
+function dqf() { dq = dq + 1; return false }
+do { d = d + 1 } while (d < 2 || dqf())
+console.log("do-or", d, dq)                        // 2 1
+
+// --- non-boolean truthiness in condition position ---
+function andTruthy(v) {
+  if (v && true) { return "truthy" }
+  return "falsy"
+}
+console.log("and-0", andTruthy(0))
+console.log("and-empty", andTruthy(""))
+console.log("and-null", andTruthy(null))
+console.log("and-1", andTruthy(1))
+console.log("and-obj", andTruthy({}))
+
+// --- nested (a && b) || c in condition position ---
+function nested(a, b, c) {
+  if ((a && b) || c) { return "yes" }
+  return "no"
+}
+console.log("n-TTF", nested(true, true, false))
+console.log("n-TFF", nested(true, false, false))
+console.log("n-TFT", nested(true, false, true))
+console.log("n-FxT", nested(false, true, true))
+console.log("n-FxF", nested(false, true, false))

--- a/tests/core/logical_operators.tish
+++ b/tests/core/logical_operators.tish
@@ -1,0 +1,77 @@
+// #240 / #167: && and || follow JS semantics — they SHORT-CIRCUIT (the dead operand's side effects
+// never run) and they RETURN THE OPERAND VALUE (not a coerced boolean). This pins the observable
+// behavior across interp == vm == native == node. Valid in both tish and node.
+
+function five() { return 5 }
+function zero() { return 0 }
+function emptyStr() { return "" }
+
+// --- value-returning: a && b / a || b yield the operand, not a boolean ---
+console.log("vr-and-tt", five() && 7)             // 5 truthy  -> 7
+console.log("vr-and-ft", zero() && 7)             // 0 falsy   -> 0
+console.log("vr-or-ft", zero() || 9)              // 0 falsy   -> 9
+console.log("vr-or-tt", five() || 9)              // 5 truthy  -> 5
+console.log("vr-and-str", emptyStr() && 7)        // "" falsy  -> ""
+console.log("vr-chain", five() && zero() || 9)    // (5 && 0)=0 -> 0 || 9 -> 9
+console.log("vr-nested", (five() && 7) || zero()) // (5 && 7)=7 truthy -> 7
+
+// --- short-circuit: the right operand is NOT evaluated (no side effect) when the left decides it ---
+let andCalls = 0
+function andRight() { andCalls = andCalls + 1; return true }
+let r1 = false && andRight()                      // false short-circuits -> andRight not called
+let r2 = true && andRight()                       // true -> andRight called once
+console.log("sc-and", r1, r2, andCalls)           // false true 1
+
+let orCalls = 0
+function orRight() { orCalls = orCalls + 1; return 7 }
+let s1 = true || orRight()                         // true short-circuits -> orRight not called
+let s2 = false || orRight()                        // false -> orRight called once
+console.log("sc-or", s1, s2, orCalls)              // true 7 1
+
+// --- short-circuit in a while condition: side-effect counts ---
+let fCalls = 0
+let gCalls = 0
+let i = 0
+function f() { fCalls = fCalls + 1; return i < 3 }
+function g() { gCalls = gCalls + 1; return true }
+while (f() && g()) { i = i + 1 }
+console.log("while-and", i, fCalls, gCalls)        // 3 4 3 (g not called when f is false)
+
+let qCalls = 0
+function q() { qCalls = qCalls + 1; return false }
+let n = 0
+while ((n < 2) || q()) { n = n + 1 }
+console.log("while-or", n, qCalls)                 // 2 1 (q only when n<2 is false)
+
+// --- for + && and do-while + || conditions ---
+let forCount = 0
+for (let k = 0; k < 5 && forCount < 3; k = k + 1) { forCount = forCount + 1 }
+console.log("for-and", forCount)                   // 3
+
+let d = 0
+let dq = 0
+function dqf() { dq = dq + 1; return false }
+do { d = d + 1 } while (d < 2 || dqf())
+console.log("do-or", d, dq)                        // 2 1
+
+// --- non-boolean truthiness in condition position ---
+function andTruthy(v) {
+  if (v && true) { return "truthy" }
+  return "falsy"
+}
+console.log("and-0", andTruthy(0))
+console.log("and-empty", andTruthy(""))
+console.log("and-null", andTruthy(null))
+console.log("and-1", andTruthy(1))
+console.log("and-obj", andTruthy({}))
+
+// --- nested (a && b) || c in condition position ---
+function nested(a, b, c) {
+  if ((a && b) || c) { return "yes" }
+  return "no"
+}
+console.log("n-TTF", nested(true, true, false))
+console.log("n-TFF", nested(true, false, false))
+console.log("n-TFT", nested(true, false, true))
+console.log("n-FxT", nested(false, true, true))
+console.log("n-FxF", nested(false, true, false))

--- a/tests/core/logical_operators.tish.expected
+++ b/tests/core/logical_operators.tish.expected
@@ -1,0 +1,23 @@
+vr-and-tt 7
+vr-and-ft 0
+vr-or-ft 9
+vr-or-tt 5
+vr-and-str 
+vr-chain 9
+vr-nested 7
+sc-and false true 1
+sc-or true 7 1
+while-and 3 4 3
+while-or 2 1
+for-and 3
+do-or 2 1
+and-0 falsy
+and-empty falsy
+and-null falsy
+and-1 truthy
+and-obj truthy
+n-TTF yes
+n-TFF no
+n-TFT yes
+n-FxT yes
+n-FxF no

--- a/tests/main.js
+++ b/tests/main.js
@@ -1564,6 +1564,86 @@ console.log("empty string:", "".length);
 }
 
 {
+// #240 / #167: && and || follow JS semantics — they SHORT-CIRCUIT (the dead operand's side effects
+// never run) and they RETURN THE OPERAND VALUE (not a coerced boolean). This pins the observable
+// behavior across interp == vm == native == node. Valid in both tish and node.
+
+function five() { return 5 }
+function zero() { return 0 }
+function emptyStr() { return "" }
+
+// --- value-returning: a && b / a || b yield the operand, not a boolean ---
+console.log("vr-and-tt", five() && 7)             // 5 truthy  -> 7
+console.log("vr-and-ft", zero() && 7)             // 0 falsy   -> 0
+console.log("vr-or-ft", zero() || 9)              // 0 falsy   -> 9
+console.log("vr-or-tt", five() || 9)              // 5 truthy  -> 5
+console.log("vr-and-str", emptyStr() && 7)        // "" falsy  -> ""
+console.log("vr-chain", five() && zero() || 9)    // (5 && 0)=0 -> 0 || 9 -> 9
+console.log("vr-nested", (five() && 7) || zero()) // (5 && 7)=7 truthy -> 7
+
+// --- short-circuit: the right operand is NOT evaluated (no side effect) when the left decides it ---
+let andCalls = 0
+function andRight() { andCalls = andCalls + 1; return true }
+let r1 = false && andRight()                      // false short-circuits -> andRight not called
+let r2 = true && andRight()                       // true -> andRight called once
+console.log("sc-and", r1, r2, andCalls)           // false true 1
+
+let orCalls = 0
+function orRight() { orCalls = orCalls + 1; return 7 }
+let s1 = true || orRight()                         // true short-circuits -> orRight not called
+let s2 = false || orRight()                        // false -> orRight called once
+console.log("sc-or", s1, s2, orCalls)              // true 7 1
+
+// --- short-circuit in a while condition: side-effect counts ---
+let fCalls = 0
+let gCalls = 0
+let i = 0
+function f() { fCalls = fCalls + 1; return i < 3 }
+function g() { gCalls = gCalls + 1; return true }
+while (f() && g()) { i = i + 1 }
+console.log("while-and", i, fCalls, gCalls)        // 3 4 3 (g not called when f is false)
+
+let qCalls = 0
+function q() { qCalls = qCalls + 1; return false }
+let n = 0
+while ((n < 2) || q()) { n = n + 1 }
+console.log("while-or", n, qCalls)                 // 2 1 (q only when n<2 is false)
+
+// --- for + && and do-while + || conditions ---
+let forCount = 0
+for (let k = 0; k < 5 && forCount < 3; k = k + 1) { forCount = forCount + 1 }
+console.log("for-and", forCount)                   // 3
+
+let d = 0
+let dq = 0
+function dqf() { dq = dq + 1; return false }
+do { d = d + 1 } while (d < 2 || dqf())
+console.log("do-or", d, dq)                        // 2 1
+
+// --- non-boolean truthiness in condition position ---
+function andTruthy(v) {
+  if (v && true) { return "truthy" }
+  return "falsy"
+}
+console.log("and-0", andTruthy(0))
+console.log("and-empty", andTruthy(""))
+console.log("and-null", andTruthy(null))
+console.log("and-1", andTruthy(1))
+console.log("and-obj", andTruthy({}))
+
+// --- nested (a && b) || c in condition position ---
+function nested(a, b, c) {
+  if ((a && b) || c) { return "yes" }
+  return "no"
+}
+console.log("n-TTF", nested(true, true, false))
+console.log("n-TFF", nested(true, false, false))
+console.log("n-TFT", nested(true, false, true))
+console.log("n-FxT", nested(false, true, true))
+console.log("n-FxF", nested(false, true, false))
+}
+
+{
 // `Map`/`Set` `.values()` / `.keys()` / `.entries()` return real iterators: usable via
 // `.next()` (→ { value, done }) and in `for…of` / spread, identical to node. Outputs are
 // reduced to scalars so nothing depends on iterator-display formatting.

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -1592,6 +1592,87 @@ console.log("empty string:", "".length)
 }
 __perf_run_core_length()
 
+fn __perf_run_core_logical_operators() {
+// #240 / #167: && and || follow JS semantics — they SHORT-CIRCUIT (the dead operand's side effects
+// never run) and they RETURN THE OPERAND VALUE (not a coerced boolean). This pins the observable
+// behavior across interp == vm == native == node. Valid in both tish and node.
+
+function five() { return 5 }
+function zero() { return 0 }
+function emptyStr() { return "" }
+
+// --- value-returning: a && b / a || b yield the operand, not a boolean ---
+console.log("vr-and-tt", five() && 7)             // 5 truthy  -> 7
+console.log("vr-and-ft", zero() && 7)             // 0 falsy   -> 0
+console.log("vr-or-ft", zero() || 9)              // 0 falsy   -> 9
+console.log("vr-or-tt", five() || 9)              // 5 truthy  -> 5
+console.log("vr-and-str", emptyStr() && 7)        // "" falsy  -> ""
+console.log("vr-chain", five() && zero() || 9)    // (5 && 0)=0 -> 0 || 9 -> 9
+console.log("vr-nested", (five() && 7) || zero()) // (5 && 7)=7 truthy -> 7
+
+// --- short-circuit: the right operand is NOT evaluated (no side effect) when the left decides it ---
+let andCalls = 0
+function andRight() { andCalls = andCalls + 1; return true }
+let r1 = false && andRight()                      // false short-circuits -> andRight not called
+let r2 = true && andRight()                       // true -> andRight called once
+console.log("sc-and", r1, r2, andCalls)           // false true 1
+
+let orCalls = 0
+function orRight() { orCalls = orCalls + 1; return 7 }
+let s1 = true || orRight()                         // true short-circuits -> orRight not called
+let s2 = false || orRight()                        // false -> orRight called once
+console.log("sc-or", s1, s2, orCalls)              // true 7 1
+
+// --- short-circuit in a while condition: side-effect counts ---
+let fCalls = 0
+let gCalls = 0
+let i = 0
+function f() { fCalls = fCalls + 1; return i < 3 }
+function g() { gCalls = gCalls + 1; return true }
+while (f() && g()) { i = i + 1 }
+console.log("while-and", i, fCalls, gCalls)        // 3 4 3 (g not called when f is false)
+
+let qCalls = 0
+function q() { qCalls = qCalls + 1; return false }
+let n = 0
+while ((n < 2) || q()) { n = n + 1 }
+console.log("while-or", n, qCalls)                 // 2 1 (q only when n<2 is false)
+
+// --- for + && and do-while + || conditions ---
+let forCount = 0
+for (let k = 0; k < 5 && forCount < 3; k = k + 1) { forCount = forCount + 1 }
+console.log("for-and", forCount)                   // 3
+
+let d = 0
+let dq = 0
+function dqf() { dq = dq + 1; return false }
+do { d = d + 1 } while (d < 2 || dqf())
+console.log("do-or", d, dq)                        // 2 1
+
+// --- non-boolean truthiness in condition position ---
+function andTruthy(v) {
+  if (v && true) { return "truthy" }
+  return "falsy"
+}
+console.log("and-0", andTruthy(0))
+console.log("and-empty", andTruthy(""))
+console.log("and-null", andTruthy(null))
+console.log("and-1", andTruthy(1))
+console.log("and-obj", andTruthy({}))
+
+// --- nested (a && b) || c in condition position ---
+function nested(a, b, c) {
+  if ((a && b) || c) { return "yes" }
+  return "no"
+}
+console.log("n-TTF", nested(true, true, false))
+console.log("n-TFF", nested(true, false, false))
+console.log("n-TFT", nested(true, false, true))
+console.log("n-FxT", nested(false, true, true))
+console.log("n-FxF", nested(false, true, false))
+}
+__perf_run_core_logical_operators()
+
 fn __perf_run_core_map_set_iterators() {
 // `Map`/`Set` `.values()` / `.keys()` / `.entries()` return real iterators: usable via
 // `.next()` (→ { value, done }) and in `for…of` / spread, identical to node. Outputs are


### PR DESCRIPTION
## What

Closes #240 — surfaced while writing the gating fixture for #167.

JS `a && b` / `a || b` **short-circuit** (the dead operand's side effects never run) and evaluate to the **operand value**, not a coerced boolean. tish violated this on multiple backends:

| | short-circuits | value-returning |
|---|:--:|:--:|
| interp | ✗ | ✗ (always Bool) |
| vm | ✓ | ✗ (`&&` truthy-left) |
| native | ✓ | ✗ (Bool) |

So `five() && 7` was `true` (not `7`), `const name = user && user.name` was `true`, and on the interpreter the right operand of a short-circuited `&&`/`||` ran its side effects. The parity suite had no fixture covering observable short-circuit or operand returns, so it went uncaught.

## Fix

- **interp** (`tish_eval`): the generic `Expr::Binary` arm evaluated both operands and `eval_binop` coerced `And`/`Or` to `Bool`. Special-case `And`/`Or` to evaluate the left, short-circuit on its truthiness, and return the operand value.
- **vm** (`tish_bytecode`): the `&&` lowering ended in `BinOp(And)`, coercing a truthy-left result to `Bool`. Mirror the already-correct `||` lowering (`Dup`/`JumpIfFalse` to keep the left, else `Pop` and yield the right). Condition position uses the same path.
- **native** (`tish_compile` codegen): the boxed `Value` path emitted `Value::Bool(l.is_truthy() && r.is_truthy())`. Emit `{ let __l = l; if __l.is_truthy() { r } else { __l } }` (and the dual for `||`) — short-circuit + operand value. Typed `bool && bool` keeps Rust's own `&&`/`||`, where the bool already *is* the operand.

## Test

New `tests/core/logical_operators` fixture — value-returning, short-circuit side-effect counts, condition-position (if/while/for/do-while), non-boolean truthiness, nesting. Verified green on **interp == vm == native == js == cranelift == llvm == wasi == node**.

- `cargo test --workspace`: 345 passed, 0 failed.
- Perf gauntlet soundness unchanged: **0 `TYPED≠BOXED`, 0 `≠NODE`** across all 21 (8/21 beat V8, same as baseline).