### PR TITLE
fix(vm): do-while continue jumps forward to the condition, not a no-op JumpBack

### DIFF
--- a/crates/tish_bytecode/src/compiler.rs
+++ b/crates/tish_bytecode/src/compiler.rs
@@ -1561,7 +1561,12 @@ impl<'a> Compiler<'a> {
                 self.loop_stack.push(LoopInfo {
                     break_patches: Vec::new(),
                     continue_patches: Vec::new(),
-                    continue_is_forward_jump: false,
+                    // `continue` jumps to the condition test, which is emitted AFTER the body — a
+                    // FORWARD jump. (A backward JumpBack would patch to dist = 0 via saturating_sub
+                    // of a forward target, becoming a no-op; execution then fell through and re-ran
+                    // the body's already-unwound ExitBlock on an empty block stack — the
+                    // "ExitBlock without matching EnterBlock" crash.)
+                    continue_is_forward_jump: true,
                 });
                 self.breakable_stack.push(Breakable::Loop {
                     unwind_depth: self.block_depth,
@@ -1577,7 +1582,8 @@ impl<'a> Compiler<'a> {
                 let info = self.loop_stack.pop().unwrap();
                 self.breakable_stack.pop();
                 for p in info.continue_patches {
-                    self.patch_jump_back(p, cond_start);
+                    // Forward jump to the condition (see continue_is_forward_jump above).
+                    self.patch_jump(p, cond_start);
                 }
                 for p in info.break_patches {
                     self.patch_jump(p, end);

--- a/crates/tish_bytecode/tests/break_continue_bytecode.rs
+++ b/crates/tish_bytecode/tests/break_continue_bytecode.rs
@@ -42,3 +42,22 @@ fn mutation_vm_ast_opt_with_peephole() {
     let chunk = compile(&prog).expect("compile");
     run(&chunk).expect("VM");
 }
+
+// Regression: `continue` inside a `do { } while (cond)` targets the condition test, which is emitted
+// AFTER the body — a FORWARD jump. It used to be lowered as a backward `JumpBack`, which `patch_jump_back`
+// resolved to distance 0 (saturating_sub of a forward target) — a no-op. Execution then fell through into
+// the body block's already-unwound `ExitBlock`, crashing the VM with "ExitBlock without matching
+// EnterBlock". The `continue` here unwinds the body block AND the `if` then-block, so it exercises the
+// multi-ExitBlock unwind path specifically.
+#[test]
+fn do_while_continue_does_not_crash_vm() {
+    let src = "let d = 0\n\
+               do {\n\
+                 d = d + 1\n\
+                 if (d === 2) { continue }\n\
+               } while (d < 5)\n";
+    let prog = tishlang_parser::parse(src).expect("parse");
+    // Both compile paths must run clean (the crash happened regardless of peephole optimization).
+    run(&compile_unoptimized(&prog).expect("compile (unopt)")).expect("VM run unoptimized");
+    run(&compile(&prog).expect("compile (opt)")).expect("VM run optimized");
+}

--- a/tests/core/do_while_continue.js
+++ b/tests/core/do_while_continue.js
@@ -1,0 +1,33 @@
+// Regression: `continue` inside a `do { } while (cond)` jumps FORWARD to the condition test (the
+// condition is emitted after the body). A backward jump resolved to a no-op and fell through into the
+// body's already-unwound ExitBlock, crashing the VM. Valid in both tish and node.
+
+// continue inside a nested block (unwinds body block + if-then block)
+let d = 0
+do {
+  d = d + 1
+  if (d === 2) { continue }
+} while (d < 5)
+console.log("basic", d)
+
+// continue with no inner block (braceless if)
+let a = 0
+let sum = 0
+do { a = a + 1; if (a === 2) continue; sum = sum + a } while (a < 5)
+console.log("no-block", a, sum)
+
+// continue and break together
+let b = 0
+let hits = 0
+do { b = b + 1; if (b === 3) continue; if (b === 5) break; hits = hits + 1 } while (b < 10)
+console.log("break", b, hits)
+
+// nested do-while, continue in the inner loop
+let outer = 0
+let innerTotal = 0
+do {
+  outer = outer + 1
+  let j = 0
+  do { j = j + 1; if (j === 2) { continue } innerTotal = innerTotal + 1 } while (j < 3)
+} while (outer < 2)
+console.log("nested", outer, innerTotal)

--- a/tests/core/do_while_continue.tish
+++ b/tests/core/do_while_continue.tish
@@ -1,0 +1,33 @@
+// Regression: `continue` inside a `do { } while (cond)` jumps FORWARD to the condition test (the
+// condition is emitted after the body). A backward jump resolved to a no-op and fell through into the
+// body's already-unwound ExitBlock, crashing the VM. Valid in both tish and node.
+
+// continue inside a nested block (unwinds body block + if-then block)
+let d = 0
+do {
+  d = d + 1
+  if (d === 2) { continue }
+} while (d < 5)
+console.log("basic", d)
+
+// continue with no inner block (braceless if)
+let a = 0
+let sum = 0
+do { a = a + 1; if (a === 2) continue; sum = sum + a } while (a < 5)
+console.log("no-block", a, sum)
+
+// continue and break together
+let b = 0
+let hits = 0
+do { b = b + 1; if (b === 3) continue; if (b === 5) break; hits = hits + 1 } while (b < 10)
+console.log("break", b, hits)
+
+// nested do-while, continue in the inner loop
+let outer = 0
+let innerTotal = 0
+do {
+  outer = outer + 1
+  let j = 0
+  do { j = j + 1; if (j === 2) { continue } innerTotal = innerTotal + 1 } while (j < 3)
+} while (outer < 2)
+console.log("nested", outer, innerTotal)

--- a/tests/core/do_while_continue.tish.expected
+++ b/tests/core/do_while_continue.tish.expected
@@ -1,0 +1,4 @@
+basic 5
+no-block 5 13
+break 5 3
+nested 2 4

--- a/tests/main.js
+++ b/tests/main.js
@@ -1333,6 +1333,42 @@ console.log("done");
 }
 
 {
+// Regression: `continue` inside a `do { } while (cond)` jumps FORWARD to the condition test (the
+// condition is emitted after the body). A backward jump resolved to a no-op and fell through into the
+// body's already-unwound ExitBlock, crashing the VM. Valid in both tish and node.
+
+// continue inside a nested block (unwinds body block + if-then block)
+let d = 0
+do {
+  d = d + 1
+  if (d === 2) { continue }
+} while (d < 5)
+console.log("basic", d)
+
+// continue with no inner block (braceless if)
+let a = 0
+let sum = 0
+do { a = a + 1; if (a === 2) continue; sum = sum + a } while (a < 5)
+console.log("no-block", a, sum)
+
+// continue and break together
+let b = 0
+let hits = 0
+do { b = b + 1; if (b === 3) continue; if (b === 5) break; hits = hits + 1 } while (b < 10)
+console.log("break", b, hits)
+
+// nested do-while, continue in the inner loop
+let outer = 0
+let innerTotal = 0
+do {
+  outer = outer + 1
+  let j = 0
+  do { j = j + 1; if (j === 2) { continue } innerTotal = innerTotal + 1 } while (j < 3)
+} while (outer < 2)
+console.log("nested", outer, innerTotal)
+}
+
+{
 // MVP test: exponentiation operator ** (JS equivalent of exponentiation.tish)
 console.log(2 ** 3);
 console.log(2 ** 10);

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -1353,6 +1353,43 @@ console.log("done")
 }
 __perf_run_core_do_while()
 
+fn __perf_run_core_do_while_continue() {
+// Regression: `continue` inside a `do { } while (cond)` jumps FORWARD to the condition test (the
+// condition is emitted after the body). A backward jump resolved to a no-op and fell through into the
+// body's already-unwound ExitBlock, crashing the VM. Valid in both tish and node.
+
+// continue inside a nested block (unwinds body block + if-then block)
+let d = 0
+do {
+  d = d + 1
+  if (d === 2) { continue }
+} while (d < 5)
+console.log("basic", d)
+
+// continue with no inner block (braceless if)
+let a = 0
+let sum = 0
+do { a = a + 1; if (a === 2) continue; sum = sum + a } while (a < 5)
+console.log("no-block", a, sum)
+
+// continue and break together
+let b = 0
+let hits = 0
+do { b = b + 1; if (b === 3) continue; if (b === 5) break; hits = hits + 1 } while (b < 10)
+console.log("break", b, hits)
+
+// nested do-while, continue in the inner loop
+let outer = 0
+let innerTotal = 0
+do {
+  outer = outer + 1
+  let j = 0
+  do { j = j + 1; if (j === 2) { continue } innerTotal = innerTotal + 1 } while (j < 3)
+} while (outer < 2)
+console.log("nested", outer, innerTotal)
+}
+__perf_run_core_do_while_continue()
+
 fn __perf_run_core_exponentiation() {
 // MVP test: exponentiation operator **
 console.log(2 ** 3)


### PR DESCRIPTION
## What

A `continue` inside `do { ... } while (cond)` crashed the **bytecode VM** with `Error: ExitBlock without matching EnterBlock`. The `--backend interp` interpreter and node both ran it correctly. Pre-existing (reproduces at e89b23ee).

```tish
let d = 0
do {
  d = d + 1
  if (d === 2) { continue }
} while (d < 5)
console.log("m1", d)   // vm: crash;  interp/node: m1 5
```

## Root cause

In `do { } while (cond)` the condition test is emitted **after** the body, so a `continue` (which targets the condition) is a **forward** jump. But the do-while lowering marked it `continue_is_forward_jump: false` (a backward `JumpBack`) and patched it with `patch_jump_back`, whose `after_insn.saturating_sub(target)` underflows to **0** for a forward target — making the `JumpBack` a no-op. Execution then fell through into the body block's already-unwound `ExitBlock` (the `continue` had emitted its own `ExitBlock`s to unwind the body block + the `if` then-block), popping an empty block stack → the crash.

(The `while` loop is fine — its `continue` target is genuinely backward. The C-style `for` loop already uses a forward continue.)

## Fix

Set `continue_is_forward_jump: true` for do-while and patch continue sites with the forward `patch_jump` to `cond_start` — matching the for-loop's forward-continue shape. Two-line change in the `Statement::DoWhile` arm.

## Test

- `do_while_continue_does_not_crash_vm` in `crates/tish_bytecode/tests/break_continue_bytecode.rs` — compiles + runs the repro on the VM via **both** compile paths (unoptimized + peephole), exercising the multi-`ExitBlock` unwind (body block + if-then block).
- New `tests/core/do_while_continue` parity fixture — continue in a nested block, braceless `if`, `continue` + `break`, and a nested do-while — green on **interp == vm == native == node**.
- `cargo test --workspace`: 346 passed, 0 failed.