### PR TITLE
fix(js): lower === null / !== null to == null so nullish checks agree across backends

### DIFF
--- a/crates/tish_compile_js/src/codegen.rs
+++ b/crates/tish_compile_js/src/codegen.rs
@@ -487,6 +487,19 @@ impl Codegen {
         }
     }
 
+    /// Is `expr` the `null` literal? Used to lower `x === null` / `x !== null` to JS `== null` /
+    /// `!= null` so the check catches `undefined` too (tish treats a missing/undefined value as
+    /// null on every other backend) — see the StrictEq/StrictNe arms below.
+    fn is_null_literal(expr: &Expr) -> bool {
+        matches!(
+            expr,
+            Expr::Literal {
+                value: Literal::Null,
+                ..
+            }
+        )
+    }
+
     fn emit_expr(&mut self, expr: &Expr) -> Result<String, CompileError> {
         Ok(match expr {
             Expr::Literal { value, .. } => match value {
@@ -510,8 +523,26 @@ impl Codegen {
                     BinOp::Pow => "**",
                     BinOp::Eq => "==",
                     BinOp::Ne => "!=",
-                    BinOp::StrictEq => "===",
-                    BinOp::StrictNe => "!==",
+                    // tish has no `undefined`: a missing/absent value reads back as `null`, so
+                    // `x === null` means "is nullish" — exactly how interp/vm/native behave (a
+                    // missing property is null there). In the JS runtime a missing property is
+                    // `undefined`, so lower `=== null` / `!== null` to loose `== null` / `!= null`,
+                    // which match BOTH null and undefined — keeping `=== null` mean the same thing on
+                    // every target. Strict equality between non-null operands is unaffected.
+                    BinOp::StrictEq => {
+                        if Self::is_null_literal(left) || Self::is_null_literal(right) {
+                            "=="
+                        } else {
+                            "==="
+                        }
+                    }
+                    BinOp::StrictNe => {
+                        if Self::is_null_literal(left) || Self::is_null_literal(right) {
+                            "!="
+                        } else {
+                            "!=="
+                        }
+                    }
                     BinOp::Lt => "<",
                     BinOp::Le => "<=",
                     BinOp::Gt => ">",

--- a/crates/tish_compile_js/src/tests_jsx.rs
+++ b/crates/tish_compile_js/src/tests_jsx.rs
@@ -411,4 +411,27 @@ fn factory() {
             );
         }
     }
+
+    // tish `=== null` / `!== null` lower to JS `== null` / `!= null` so the nullish check catches the
+    // JS-runtime `undefined` (missing props / holes) too — matching interp/vm/native, which read a
+    // missing property back as null. Strict equality between non-null operands stays strict.
+    #[test]
+    fn strict_eq_null_lowers_to_loose_null() {
+        let program = parse("let x = 1\nconsole.log(x === null)\nconsole.log(x !== null)\n").unwrap();
+        let js = crate::compile(&program, false).unwrap();
+        assert!(!js.contains("=== null"), "`=== null` must lower to `== null`:\n{js}");
+        assert!(!js.contains("!== null"), "`!== null` must lower to `!= null`:\n{js}");
+        assert!(
+            js.contains("== null") && js.contains("!= null"),
+            "expected loose null checks:\n{js}"
+        );
+    }
+
+    #[test]
+    fn strict_eq_between_non_null_operands_stays_strict() {
+        let program = parse("let a = 1\nlet b = 2\nconsole.log(a === b)\nconsole.log(a !== b)\n").unwrap();
+        let js = crate::compile(&program, false).unwrap();
+        assert!(js.contains("==="), "non-null `===` must stay strict:\n{js}");
+        assert!(js.contains("!=="), "non-null `!==` must stay strict:\n{js}");
+    }
 }

--- a/tests/core/strict_eq_null.js
+++ b/tests/core/strict_eq_null.js
@@ -1,0 +1,30 @@
+// `== null` is tish's "is it nullish / absent" check. tish has no `undefined`: a missing property
+// reads back as null, so `obj.missing == null` is true on interp/vm/native. The JS backend lowers
+// `== null` / `!= null` to `== null` / `!= null` so it ALSO catches the JS-runtime `undefined`
+// (missing props / array holes), keeping `== null` identical on every target. Strict equality
+// between non-null operands is unchanged.
+
+let o = { a: 1, b: null }
+console.log("present-val", o.a == null)    // 1 is not null -> false
+console.log("present-null", o.b == null)   // null -> true
+console.log("absent", o.z == null)         // missing prop -> null -> true
+console.log("absent-ne", o.z != null)      // false
+
+let nested = { f: { x: 1 } }
+console.log("nested-absent", nested.f.y == null)   // true
+console.log("nested-present", nested.f.x == null)  // false
+
+// `in` is the precise key-existence check (true even when the value is null)
+console.log("in-present", "a" in o)          // true
+console.log("in-null-val", "b" in o)         // true (key exists, value null)
+console.log("in-absent", "z" in o)           // false
+
+// strict equality between non-null operands is unaffected by the null-lowering
+console.log("num-eq", (1 + 1) === 2)         // true
+console.log("num-ne", 3 !== 4)               // true
+console.log("str-eq", "ab" === "ab")         // true
+console.log("bool-ne", true !== false)       // true
+
+let n = null
+console.log("var-null", n == null)          // true
+console.log("var-null-ne", n != null)       // false

--- a/tests/core/strict_eq_null.tish
+++ b/tests/core/strict_eq_null.tish
@@ -1,0 +1,30 @@
+// `=== null` is tish's "is it nullish / absent" check. tish has no `undefined`: a missing property
+// reads back as null, so `obj.missing === null` is true on interp/vm/native. The JS backend lowers
+// `=== null` / `!== null` to `== null` / `!= null` so it ALSO catches the JS-runtime `undefined`
+// (missing props / array holes), keeping `=== null` identical on every target. Strict equality
+// between non-null operands is unchanged.
+
+let o = { a: 1, b: null }
+console.log("present-val", o.a === null)    // 1 is not null -> false
+console.log("present-null", o.b === null)   // null -> true
+console.log("absent", o.z === null)         // missing prop -> null -> true
+console.log("absent-ne", o.z !== null)      // false
+
+let nested = { f: { x: 1 } }
+console.log("nested-absent", nested.f.y === null)   // true
+console.log("nested-present", nested.f.x === null)  // false
+
+// `in` is the precise key-existence check (true even when the value is null)
+console.log("in-present", "a" in o)          // true
+console.log("in-null-val", "b" in o)         // true (key exists, value null)
+console.log("in-absent", "z" in o)           // false
+
+// strict equality between non-null operands is unaffected by the null-lowering
+console.log("num-eq", (1 + 1) === 2)         // true
+console.log("num-ne", 3 !== 4)               // true
+console.log("str-eq", "ab" === "ab")         // true
+console.log("bool-ne", true !== false)       // true
+
+let n = null
+console.log("var-null", n === null)          // true
+console.log("var-null-ne", n !== null)       // false

--- a/tests/core/strict_eq_null.tish.expected
+++ b/tests/core/strict_eq_null.tish.expected
@@ -1,0 +1,15 @@
+present-val false
+present-null true
+absent true
+absent-ne false
+nested-absent true
+nested-present false
+in-present true
+in-null-val true
+in-absent false
+num-eq true
+num-ne true
+str-eq true
+bool-ne true
+var-null true
+var-null-ne false

--- a/tests/main.js
+++ b/tests/main.js
@@ -3108,6 +3108,39 @@ console.log("done");
 }
 
 {
+// `== null` is tish's "is it nullish / absent" check. tish has no `undefined`: a missing property
+// reads back as null, so `obj.missing == null` is true on interp/vm/native. The JS backend lowers
+// `== null` / `!= null` to `== null` / `!= null` so it ALSO catches the JS-runtime `undefined`
+// (missing props / array holes), keeping `== null` identical on every target. Strict equality
+// between non-null operands is unchanged.
+
+let o = { a: 1, b: null }
+console.log("present-val", o.a == null)    // 1 is not null -> false
+console.log("present-null", o.b == null)   // null -> true
+console.log("absent", o.z == null)         // missing prop -> null -> true
+console.log("absent-ne", o.z != null)      // false
+
+let nested = { f: { x: 1 } }
+console.log("nested-absent", nested.f.y == null)   // true
+console.log("nested-present", nested.f.x == null)  // false
+
+// `in` is the precise key-existence check (true even when the value is null)
+console.log("in-present", "a" in o)          // true
+console.log("in-null-val", "b" in o)         // true (key exists, value null)
+console.log("in-absent", "z" in o)           // false
+
+// strict equality between non-null operands is unaffected by the null-lowering
+console.log("num-eq", (1 + 1) === 2)         // true
+console.log("num-ne", 3 !== 4)               // true
+console.log("str-eq", "ab" === "ab")         // true
+console.log("bool-ne", true !== false)       // true
+
+let n = null
+console.log("var-null", n == null)          // true
+console.log("var-null-ne", n != null)       // false
+}
+
+{
 // MVP test: strict equality - no coercion (JS equivalent of strict_equality.tish)
 console.log(1 === 1);
 console.log(1 === 2);

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3158,6 +3158,40 @@ console.log("done")
 }
 __perf_run_core_space_indent()
 
+fn __perf_run_core_strict_eq_null() {
+// `=== null` is tish's "is it nullish / absent" check. tish has no `undefined`: a missing property
+// reads back as null, so `obj.missing === null` is true on interp/vm/native. The JS backend lowers
+// `=== null` / `!== null` to `== null` / `!= null` so it ALSO catches the JS-runtime `undefined`
+// (missing props / array holes), keeping `=== null` identical on every target. Strict equality
+// between non-null operands is unchanged.
+
+let o = { a: 1, b: null }
+console.log("present-val", o.a === null)    // 1 is not null -> false
+console.log("present-null", o.b === null)   // null -> true
+console.log("absent", o.z === null)         // missing prop -> null -> true
+console.log("absent-ne", o.z !== null)      // false
+
+let nested = { f: { x: 1 } }
+console.log("nested-absent", nested.f.y === null)   // true
+console.log("nested-present", nested.f.x === null)  // false
+
+// `in` is the precise key-existence check (true even when the value is null)
+console.log("in-present", "a" in o)          // true
+console.log("in-null-val", "b" in o)         // true (key exists, value null)
+console.log("in-absent", "z" in o)           // false
+
+// strict equality between non-null operands is unaffected by the null-lowering
+console.log("num-eq", (1 + 1) === 2)         // true
+console.log("num-ne", 3 !== 4)               // true
+console.log("str-eq", "ab" === "ab")         // true
+console.log("bool-ne", true !== false)       // true
+
+let n = null
+console.log("var-null", n === null)          // true
+console.log("var-null-ne", n !== null)       // false
+}
+__perf_run_core_strict_eq_null()
+
 fn __perf_run_core_strict_equality() {
 // MVP test: strict equality - no coercion
 console.log(1 === 1)


### PR DESCRIPTION
## What

tish has no `undefined` — a missing object property reads back as `null`, so `obj.missing === null` is `true` on interp/vm/native. But the JS backend emitted `=== null`, and in the JS runtime a missing property is `undefined`, so `undefined === null` is `false`. The **same program gave different answers** under `tish run` vs `tish build --target js`:

| check (prop absent) | interp/vm/native | js target (before) |
|---|:--:|:--:|
| `o.z === null` | `true` | **`false`** ✗ |
| `cfg.features.y === null` | `true` | **`false`** ✗ |

(Surfaced while investigating how to check property existence — `window.feature == undefined` style. Relates to the loose-`==` discussion in #244, but is an independent correctness bug.)

## Fix

In the JS backend, lower `x === null` → `x == null` and `x !== null` → `x != null` (only when an operand is the `null` literal). `== null` matches both `null` and `undefined`, so `=== null` now means **"is nullish / absent" identically on every target**:
- native/interp/vm: only `null` exists → unchanged.
- js: `== null` also catches the JS-runtime `undefined` → now matches tish semantics.

Provably safe: for any non-nullish operand `===`/`== ` agree; they differ only for JS `undefined`, where tish *wants* the match. Strict equality between non-null operands is untouched, and `false`/`0`/`""`/`NaN` correctly do **not** match `=== null`.

For "does the key exist?" (true even when the value is `null`), `'prop' in obj` is the precise check — verified correct on every backend.

## Test

- `tests/core/strict_eq_null` parity fixture — absent / present-null / present-value props, nested, `in`, non-null strict equality, real `null` — green on **interp == vm == native == cranelift == js == node**.
- `tish_compile_js` unit tests pin the lowering (`=== null` → `== null`) and that non-null `===` stays strict.
- `cargo test --workspace`: 347 passed, 0 failed.

> Note: this is the precondition that would later let loose `==` be removed from the language without losing nullish checks — but that broader removal is deferred per discussion.