### PR TITLE
feat(builtins): Array.findLast/findLastIndex + Array.at/String.at on all backends (#247)

### DIFF
--- a/crates/tish_builtins/src/array.rs
+++ b/crates/tish_builtins/src/array.rs
@@ -466,6 +466,83 @@ pub fn find_index(arr: &Value, callback: &Value) -> Value {
     Value::Number(-1.0)
 }
 
+/// `Array.prototype.findLast` — like [`find`] but iterates from the end; the callback still receives
+/// the original index. Returns `null` (JS `undefined`) when nothing matches. #247
+pub fn find_last(arr: &Value, callback: &Value) -> Value {
+    if let Some((data, cb)) = packed_snapshot(arr, callback) {
+        for i in (0..data.len()).rev() {
+            if cb
+                .call(&[Value::Number(data[i]), Value::Number(i as f64)])
+                .is_truthy()
+            {
+                return Value::Number(data[i]);
+            }
+        }
+        return Value::Null;
+    }
+    let arr = as_boxed_array(arr);
+    let arr = &*arr;
+    if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
+        let arr_borrow = arr.borrow();
+        for i in (0..arr_borrow.len()).rev() {
+            let v = &arr_borrow[i];
+            if cb.call(&[v.clone(), Value::Number(i as f64)]).is_truthy() {
+                return v.clone();
+            }
+        }
+    }
+    Value::Null
+}
+
+/// `Array.prototype.findLastIndex` — like [`find_index`] but from the end; `-1` if no match. #247
+pub fn find_last_index(arr: &Value, callback: &Value) -> Value {
+    if let Some((data, cb)) = packed_snapshot(arr, callback) {
+        for i in (0..data.len()).rev() {
+            if cb
+                .call(&[Value::Number(data[i]), Value::Number(i as f64)])
+                .is_truthy()
+            {
+                return Value::Number(i as f64);
+            }
+        }
+        return Value::Number(-1.0);
+    }
+    let arr = as_boxed_array(arr);
+    let arr = &*arr;
+    if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
+        let arr_borrow = arr.borrow();
+        for i in (0..arr_borrow.len()).rev() {
+            if cb
+                .call(&[arr_borrow[i].clone(), Value::Number(i as f64)])
+                .is_truthy()
+            {
+                return Value::Number(i as f64);
+            }
+        }
+    }
+    Value::Number(-1.0)
+}
+
+/// `Array.prototype.at(index)` — negative `index` counts from the end; out of range → `null`
+/// (JS `undefined`). A non-numeric index is `ToInteger`'d to 0, like JS. #247
+pub fn at(arr: &Value, index: &Value) -> Value {
+    let i = match index {
+        Value::Number(n) => *n as i64,
+        _ => 0,
+    };
+    let arr = as_boxed_array(arr);
+    let arr = &*arr;
+    if let Value::Array(arr) = arr {
+        let arr_borrow = arr.borrow();
+        let len = arr_borrow.len() as i64;
+        let idx = if i < 0 { len + i } else { i };
+        if idx >= 0 && idx < len {
+            return arr_borrow[idx as usize].clone();
+        }
+    }
+    Value::Null
+}
+
 pub fn some(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
         for (i, &n) in data.iter().enumerate() {

--- a/crates/tish_builtins/src/string.rs
+++ b/crates/tish_builtins/src/string.rs
@@ -364,6 +364,24 @@ pub fn char_at(s: &Value, idx: &Value) -> Value {
     }
 }
 
+/// `String.prototype.at(index)` — like `charAt` but negative `index` counts from the end and an
+/// out-of-range index yields `null` (JS `undefined`), not `""`. #247
+pub fn at(s: &Value, index: &Value) -> Value {
+    if let Value::String(s) = s {
+        let i = match index {
+            Value::Number(n) => *n as i64,
+            _ => 0,
+        };
+        let chars: Vec<char> = s.chars().collect();
+        let len = chars.len() as i64;
+        let idx = if i < 0 { len + i } else { i };
+        if idx >= 0 && idx < len {
+            return Value::String(chars[idx as usize].to_string().into());
+        }
+    }
+    Value::Null
+}
+
 pub fn char_code_at(s: &Value, idx: &Value) -> Value {
     if let Value::String(s) = s {
         let idx = match idx {

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -3504,6 +3504,15 @@ impl Codegen {
                                 obj_expr, idx
                             ));
                         }
+                        "at" => {
+                            // `at` is on both String and Array; this match is by method name, so
+                            // dispatch on the runtime value type (#247).
+                            let idx = arg_exprs.first().cloned().unwrap_or_else(|| "Value::Number(0.0)".to_string());
+                            return Ok(format!(
+                                "tishlang_runtime::value_at(&{}, &{})",
+                                obj_expr, idx
+                            ));
+                        }
                         "charCodeAt" => {
                             let idx = arg_exprs.first().cloned().unwrap_or_else(|| "Value::Number(0.0)".to_string());
                             return Ok(format!(
@@ -3602,6 +3611,20 @@ impl Codegen {
                             let callback = arg_exprs.first().cloned().unwrap_or_else(|| "Value::Null".to_string());
                             return Ok(format!(
                                 "tishlang_runtime::array_find_index(&{}, &{})",
+                                obj_expr, callback
+                            ));
+                        }
+                        "findLast" => {
+                            let callback = arg_exprs.first().cloned().unwrap_or_else(|| "Value::Null".to_string());
+                            return Ok(format!(
+                                "tishlang_runtime::array_find_last(&{}, &{})",
+                                obj_expr, callback
+                            ));
+                        }
+                        "findLastIndex" => {
+                            let callback = arg_exprs.first().cloned().unwrap_or_else(|| "Value::Null".to_string());
+                            return Ok(format!(
+                                "tishlang_runtime::array_find_last_index(&{}, &{})",
                                 obj_expr, callback
                             ));
                         }

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -1529,6 +1529,54 @@ impl Evaluator {
                                 }
                                 return Ok(Value::Number(-1.0));
                             }
+                            "findLast" => {
+                                // Like find, from the end (#247). Callback gets (value, original index).
+                                let callback = arg_vals.first().cloned().unwrap_or(Value::Null);
+                                let arr_borrow = arr.borrow();
+                                let scoped = self.create_callback_scope(&callback);
+                                for i in (0..arr_borrow.len()).rev() {
+                                    let v = arr_borrow[i].clone();
+                                    let args = [v.clone(), Value::Number(i as f64)];
+                                    let found = match &scoped {
+                                        Some((scope, params, body)) => self.call_with_scope(scope, params, body, &args)?,
+                                        None => self.call_func(&callback, &args)?,
+                                    };
+                                    if found.is_truthy() {
+                                        return Ok(v);
+                                    }
+                                }
+                                return Ok(Value::Null);
+                            }
+                            "findLastIndex" => {
+                                let callback = arg_vals.first().cloned().unwrap_or(Value::Null);
+                                let arr_borrow = arr.borrow();
+                                let scoped = self.create_callback_scope(&callback);
+                                for i in (0..arr_borrow.len()).rev() {
+                                    let args = [arr_borrow[i].clone(), Value::Number(i as f64)];
+                                    let found = match &scoped {
+                                        Some((scope, params, body)) => self.call_with_scope(scope, params, body, &args)?,
+                                        None => self.call_func(&callback, &args)?,
+                                    };
+                                    if found.is_truthy() {
+                                        return Ok(Value::Number(i as f64));
+                                    }
+                                }
+                                return Ok(Value::Number(-1.0));
+                            }
+                            "at" => {
+                                // Negative index counts from the end; out of range → null (#247).
+                                let i = match arg_vals.first() {
+                                    Some(Value::Number(n)) => *n as i64,
+                                    _ => 0,
+                                };
+                                let arr_borrow = arr.borrow();
+                                let len = arr_borrow.len() as i64;
+                                let idx = if i < 0 { len + i } else { i };
+                                if idx >= 0 && idx < len {
+                                    return Ok(arr_borrow[idx as usize].clone());
+                                }
+                                return Ok(Value::Null);
+                            }
                             "forEach" => {
                                 let callback = arg_vals.first().cloned().unwrap_or(Value::Null);
                                 let arr_borrow = arr.borrow();
@@ -1820,6 +1868,20 @@ impl Evaluator {
                                 return Ok(chars.get(idx)
                                     .map(|c| Value::String(c.to_string().into()))
                                     .unwrap_or(Value::String("".into())));
+                            }
+                            "at" => {
+                                // Negative index from end; out of range → null (#247).
+                                let i = match arg_vals.first() {
+                                    Some(Value::Number(n)) => *n as i64,
+                                    _ => 0,
+                                };
+                                let chars: Vec<char> = s.chars().collect();
+                                let len = chars.len() as i64;
+                                let idx = if i < 0 { len + i } else { i };
+                                if idx >= 0 && idx < len {
+                                    return Ok(Value::String(chars[idx as usize].to_string().into()));
+                                }
+                                return Ok(Value::Null);
                             }
                             "charCodeAt" => {
                                 let idx = match arg_vals.first() {

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -57,8 +57,9 @@ pub use tishlang_builtins::collections::{
 
 // Re-export array methods from tishlang_builtins
 pub use tishlang_builtins::array::{
-    concat as array_concat_impl, every as array_every, filter as array_filter, find as array_find,
-    find_index as array_find_index, flat as array_flat_impl, flat_map as array_flat_map,
+    at as array_at, concat as array_concat_impl, every as array_every, filter as array_filter,
+    find as array_find, find_index as array_find_index, find_last as array_find_last,
+    find_last_index as array_find_last_index, flat as array_flat_impl, flat_map as array_flat_map,
     for_each as array_for_each, includes as array_includes_impl, index_of as array_index_of_impl,
     join as array_join_impl, map as array_map, pop as array_pop, push as array_push_impl,
     fill as array_fill, reduce as array_reduce, reverse as array_reverse, shift as array_shift,
@@ -71,7 +72,7 @@ pub use tishlang_builtins::array::{
 
 // Re-export string methods from tishlang_builtins
 pub use tishlang_builtins::string::{
-    char_at as string_char_at_impl, char_code_at as string_char_code_at_impl,
+    at as string_at_impl, char_at as string_char_at_impl, char_code_at as string_char_code_at_impl,
     ends_with as string_ends_with_impl, escape_html as string_escape_html_impl,
     includes as string_includes_impl, index_of as string_index_of_impl,
     last_index_of as string_last_index_of_impl, pad_end as string_pad_end_impl,
@@ -167,6 +168,17 @@ pub fn string_replace_all(s: &Value, search: &Value, replacement: &Value) -> Val
 }
 pub fn string_char_at(s: &Value, idx: &Value) -> Value {
     string_char_at_impl(s, idx)
+}
+pub fn string_at(s: &Value, idx: &Value) -> Value {
+    string_at_impl(s, idx)
+}
+/// `.at(i)` dispatched on the runtime value — `at` exists on both String and Array, and the native
+/// method match is by name (not receiver type), so route here at runtime. #247
+pub fn value_at(recv: &Value, idx: &Value) -> Value {
+    match recv {
+        Value::String(_) => string_at_impl(recv, idx),
+        _ => array_at(recv, idx),
+    }
 }
 pub fn string_char_code_at(s: &Value, idx: &Value) -> Value {
     string_char_code_at_impl(s, idx)

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -2962,6 +2962,9 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                         "forEach"   => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::for_each(&bv, &cb) }),
                         "find"      => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::find(&bv, &cb) }),
                         "findIndex" => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::find_index(&bv, &cb) }),
+                        "findLast"      => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::find_last(&bv, &cb) }),
+                        "findLastIndex" => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::find_last_index(&bv, &cb) }),
+                        "at"        => make_native_fn(move |args| { let i = args.first().cloned().unwrap_or(Value::Null); arr_builtins::at(&bv, &i) }),
                         "some"      => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::some(&bv, &cb) }),
                         "every"     => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::every(&bv, &cb) }),
                         "join"      => make_native_fn(move |args| { let sep = args.first().cloned().unwrap_or(Value::Null); arr_builtins::join(&bv, &sep) }),
@@ -3065,6 +3068,18 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                 "findIndex" => make_native_fn(move |args: &[Value]| {
                     let cb = args.first().cloned().unwrap_or(Value::Null);
                     arr_builtins::find_index(&Value::Array(a_clone.clone()), &cb)
+                }),
+                "findLast" => make_native_fn(move |args: &[Value]| {
+                    let cb = args.first().cloned().unwrap_or(Value::Null);
+                    arr_builtins::find_last(&Value::Array(a_clone.clone()), &cb)
+                }),
+                "findLastIndex" => make_native_fn(move |args: &[Value]| {
+                    let cb = args.first().cloned().unwrap_or(Value::Null);
+                    arr_builtins::find_last_index(&Value::Array(a_clone.clone()), &cb)
+                }),
+                "at" => make_native_fn(move |args: &[Value]| {
+                    let i = args.first().cloned().unwrap_or(Value::Null);
+                    arr_builtins::at(&Value::Array(a_clone.clone()), &i)
                 }),
                 "some" => make_native_fn(move |args: &[Value]| {
                     let cb = args.first().cloned().unwrap_or(Value::Null);
@@ -3216,6 +3231,10 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                 "charAt" => make_native_fn(move |args: &[Value]| {
                     let idx = args.first().unwrap_or(&Value::Null);
                     str_builtins::char_at(&Value::String(s_clone.clone()), idx)
+                }),
+                "at" => make_native_fn(move |args: &[Value]| {
+                    let idx = args.first().unwrap_or(&Value::Null);
+                    str_builtins::at(&Value::String(s_clone.clone()), idx)
                 }),
                 "charCodeAt" => make_native_fn(move |args: &[Value]| {
                     let idx = args.first().unwrap_or(&Value::Null);

--- a/tests/core/parity_array_methods.js
+++ b/tests/core/parity_array_methods.js
@@ -1,0 +1,15 @@
+// #247 feature gaps now implemented across interp/vm/native/cranelift/wasi/js: Array.findLast/
+// findLastIndex, Array.at, String.at (negative index from end; out of range -> null). Valid in
+// tish and node (node's `undefined` for OOB normalizes to tish's `null` in the parity harness).
+let a = [5, 12, 8, 20, 3]
+console.log("findLast-even", a.findLast(x => x % 2 === 0))
+console.log("findLastIndex-even", a.findLastIndex(x => x % 2 === 0))
+console.log("findLast-none", a.findLast(x => x > 99))
+console.log("at0", a.at(0))
+console.log("at-neg1", a.at(-1))
+console.log("at-neg2", a.at(-2))
+console.log("at-oob", a.at(99))
+let s = "world"
+console.log("sat2", s.at(2))
+console.log("sat-neg1", s.at(-1))
+console.log("sat-oob", s.at(99))

--- a/tests/core/parity_array_methods.tish
+++ b/tests/core/parity_array_methods.tish
@@ -1,0 +1,15 @@
+// #247 feature gaps now implemented across interp/vm/native/cranelift/wasi/js: Array.findLast/
+// findLastIndex, Array.at, String.at (negative index from end; out of range -> null). Valid in
+// tish and node (node's `undefined` for OOB normalizes to tish's `null` in the parity harness).
+let a = [5, 12, 8, 20, 3]
+console.log("findLast-even", a.findLast(x => x % 2 === 0))
+console.log("findLastIndex-even", a.findLastIndex(x => x % 2 === 0))
+console.log("findLast-none", a.findLast(x => x > 99))
+console.log("at0", a.at(0))
+console.log("at-neg1", a.at(-1))
+console.log("at-neg2", a.at(-2))
+console.log("at-oob", a.at(99))
+let s = "world"
+console.log("sat2", s.at(2))
+console.log("sat-neg1", s.at(-1))
+console.log("sat-oob", s.at(99))

--- a/tests/core/parity_array_methods.tish.expected
+++ b/tests/core/parity_array_methods.tish.expected
@@ -1,0 +1,10 @@
+findLast-even 20
+findLastIndex-even 3
+findLast-none null
+at0 5
+at-neg1 3
+at-neg2 20
+at-oob null
+sat2 r
+sat-neg1 d
+sat-oob null

--- a/tests/main.js
+++ b/tests/main.js
@@ -2931,6 +2931,24 @@ console.log(obj?.c ?? "missing");
 }
 
 {
+// #247 feature gaps now implemented across interp/vm/native/cranelift/wasi/js: Array.findLast/
+// findLastIndex, Array.at, String.at (negative index from end; out of range -> null). Valid in
+// tish and node (node's `undefined` for OOB normalizes to tish's `null` in the parity harness).
+let a = [5, 12, 8, 20, 3]
+console.log("findLast-even", a.findLast(x => x % 2 === 0))
+console.log("findLastIndex-even", a.findLastIndex(x => x % 2 === 0))
+console.log("findLast-none", a.findLast(x => x > 99))
+console.log("at0", a.at(0))
+console.log("at-neg1", a.at(-1))
+console.log("at-neg2", a.at(-2))
+console.log("at-oob", a.at(99))
+let s = "world"
+console.log("sat2", s.at(2))
+console.log("sat-neg1", s.at(-1))
+console.log("sat-oob", s.at(99))
+}
+
+{
 // #247 cross-backend built-in divergences (Math round/min/max/hypot, parseInt radix, includes(NaN),
 // toFixed) — fixed to match the JS target. interp/vm/native/cranelift/node must all agree. Valid in
 // tish and node. (-0 toString and instanceof/at/findLast tracked separately.)

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -2973,6 +2973,25 @@ console.log(obj?.c ?? "missing")
 }
 __perf_run_core_optional_chaining()
 
+fn __perf_run_core_parity_array_methods() {
+// #247 feature gaps now implemented across interp/vm/native/cranelift/wasi/js: Array.findLast/
+// findLastIndex, Array.at, String.at (negative index from end; out of range -> null). Valid in
+// tish and node (node's `undefined` for OOB normalizes to tish's `null` in the parity harness).
+let a = [5, 12, 8, 20, 3]
+console.log("findLast-even", a.findLast(x => x % 2 === 0))
+console.log("findLastIndex-even", a.findLastIndex(x => x % 2 === 0))
+console.log("findLast-none", a.findLast(x => x > 99))
+console.log("at0", a.at(0))
+console.log("at-neg1", a.at(-1))
+console.log("at-neg2", a.at(-2))
+console.log("at-oob", a.at(99))
+let s = "world"
+console.log("sat2", s.at(2))
+console.log("sat-neg1", s.at(-1))
+console.log("sat-oob", s.at(99))
+}
+__perf_run_core_parity_array_methods()
+
 fn __perf_run_core_parity_builtins() {
 // #247 cross-backend built-in divergences (Math round/min/max/hypot, parseInt radix, includes(NaN),
 // toFixed) — fixed to match the JS target. interp/vm/native/cranelift/node must all agree. Valid in


### PR DESCRIPTION
Implements the #247 feature gaps — built-ins that were unimplemented on **every** backend (consistent, but missing, so any program using them errored). Now implemented and identical across interp / vm / native-rust / cranelift / wasi / js / node:

- **`Array.prototype.findLast` / `findLastIndex`** — like `find`/`findIndex`, iterating from the end (callback receives the original index).
- **`Array.prototype.at` / `String.prototype.at`** — negative index counts from the end; out of range → `null` (JS `undefined`, which the parity harness normalizes).

## Consistency-first

The JS semantics live in shared `tish_builtins` (`array::{find_last, find_last_index, at}`, `string::at`); the interpreter (which has its own `Value` type) mirrors them; the native runtime re-exports them. `.at` is on **both** String and Array and the native method dispatch is by name (not receiver type), so codegen routes it through a runtime `value_at` that checks the actual value — caught by validation when `String.at` first mis-routed to `array_at`.

## Validation

- `tests/core/parity_array_methods.tish` — identical output across interp/vm/native/cranelift.
- Full integration suite (all 6 backend variants, js node-normalized) green.
- Affected-crate unit tests green.

Remaining #247 items (separate): `(-0).toString()` (console-vs-ToString formatter split), `instanceof` (parser-level operator), missing-method error wording.