### PR TITLE
fix(vm): String.split via always-available builtin so tish_vm builds standalone

### DIFF
--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -3168,13 +3168,23 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                 "split" => make_native_fn(move |args: &[Value]| {
                     let sep = args.first().unwrap_or(&Value::Null);
                     let limit = args.get(1).unwrap_or(&Value::Null);
-                    // string_split_limit honors the optional limit and routes a RegExp separator
-                    // internally, so the VM matches the interpreter and rust/cranelift backends.
-                    tishlang_runtime::string_split_limit(
-                        &Value::String(s_clone.clone()),
-                        sep,
-                        limit,
-                    )
+                    let max = match limit {
+                        Value::Number(n) if *n >= 0.0 => Some(*n as usize),
+                        _ => None,
+                    };
+                    // A RegExp separator needs the runtime's regex path — but a `Value::RegExp` can
+                    // only exist with the `regex` feature, which is also what pulls in the optional
+                    // `tishlang_runtime`. String separators use the always-available builtin, so
+                    // `tish_vm` still compiles (and tests) without the optional runtime crate.
+                    #[cfg(feature = "regex")]
+                    if matches!(sep, Value::RegExp(_)) {
+                        return tishlang_runtime::string_split_limit(
+                            &Value::String(s_clone.clone()),
+                            sep,
+                            limit,
+                        );
+                    }
+                    str_builtins::split_limit(&Value::String(s_clone.clone()), sep, max)
                 }),
                 "trim" => make_native_fn(move |_args: &[Value]| {
                     str_builtins::trim(&Value::String(s_clone.clone()))


### PR DESCRIPTION
`tish_vm` referenced the **optional** `tishlang_runtime` crate unconditionally in the `String.split` dispatch (vm.rs), so `cargo build/test -p tishlang_vm` with default features failed (E0433). The full workspace build masked it via feature unification (the bin enables `regex`/`http`/… which pull the runtime in). Surfaced after #246's split consolidation landed.

**Fix:** string separators now call `tishlang_builtins::string::split_limit` — the exact function the runtime wrapper delegated to (behavior-identical). RegExp separators (only possible with the `regex` feature, which itself pulls in the runtime) keep the `cfg(regex)`-gated runtime path.

**Validated:** `cargo test -p tishlang_vm` now compiles + passes (was E0433); `cargo test --workspace` compiles; split output unchanged across interp/vm/native.

(Separately noted: `"xyz".split("")` returns `["","x","y","z",""]` vs node's `["x","y","z"]` — a *pre-existing* empty-separator divergence in the shared impl, not touched here.)