### PR TITLE
perf(native): int32-domain bitwise/shift lowering (#174)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -6684,6 +6684,70 @@ impl Codegen {
         Ok(())
     }
 
+    /// Lower an expression that JS will coerce to **int32** inside a bitwise/shift computation,
+    /// staying in the integer domain instead of round-tripping every intermediate through `f64`.
+    ///
+    /// Returns `Ok(Some(code))` where `code` is an `i32`-typed Rust expression equal to
+    /// `ToInt32(e)`, or `Ok(None)` if a leaf can't be proven `F64` (then the caller keeps the
+    /// existing per-op lowering — purely additive, never a regression).
+    ///
+    /// This is behaviour-identical to the nested `to_int32`/`to_uint32` lowering: an intermediate
+    /// `(i32 as f64)` immediately re-narrowed by `to_int32` is exact (every `i32` is representable
+    /// in `f64`, and `to_int32` of a finite value recovers it), so erasing it changes nothing but
+    /// the round-trips. Crucially, only bitwise/shift nodes recurse — an `f64` `*`/`+`/`-` node is
+    /// a *leaf* here, so e.g. `(h * 16777619) >>> 0` keeps its `f64` multiply (the 2^53 rule: the
+    /// product exceeds 2^53 and must round in `f64` *before* `ToUint32`, exactly as V8 does).
+    fn emit_int32_operand(&mut self, e: &Expr) -> Result<Option<String>, CompileError> {
+        if let Expr::Binary {
+            left, op, right, ..
+        } = e
+        {
+            let bitwise = matches!(
+                op,
+                BinOp::BitAnd
+                    | BinOp::BitOr
+                    | BinOp::BitXor
+                    | BinOp::Shl
+                    | BinOp::Shr
+                    | BinOp::UShr
+            );
+            if bitwise {
+                let li = match self.emit_int32_operand(left)? {
+                    Some(c) => c,
+                    None => return Ok(None),
+                };
+                let ri = match self.emit_int32_operand(right)? {
+                    Some(c) => c,
+                    None => return Ok(None),
+                };
+                // Shift counts: `(ri as u32)` shares its low 5 bits with `to_uint32(rhs)`, and
+                // `wrapping_sh*` masks the count mod 32 — exactly JS's `count & 31`.
+                let code = match op {
+                    BinOp::BitAnd => format!("({} & {})", li, ri),
+                    BinOp::BitOr => format!("({} | {})", li, ri),
+                    BinOp::BitXor => format!("({} ^ {})", li, ri),
+                    BinOp::Shl => format!("({}).wrapping_shl(({}) as u32)", li, ri),
+                    BinOp::Shr => format!("({}).wrapping_shr(({}) as u32)", li, ri),
+                    // `>>>` is a logical shift on the uint32 view; reinterpret back to `i32` to
+                    // stay in the integer domain (the unsigned value is recovered at the f64 edge).
+                    BinOp::UShr => {
+                        format!("((({}) as u32).wrapping_shr(({}) as u32) as i32)", li, ri)
+                    }
+                    _ => unreachable!(),
+                };
+                return Ok(Some(code));
+            }
+        }
+        // Leaf: fold only when it is a plain `f64` (so `to_int32` applies directly). `to_int32`
+        // keeps its `is_finite` guard here — a leaf may legitimately be NaN/±Infinity (→ 0).
+        let (code, ty) = self.emit_typed_expr(e)?;
+        if ty == RustType::F64 {
+            Ok(Some(format!("tishlang_runtime::to_int32({})", code)))
+        } else {
+            Ok(None)
+        }
+    }
+
     fn emit_typed_expr(&mut self, expr: &Expr) -> Result<(String, RustType), CompileError> {
         match expr {
             // ── literals ─────────────────────────────────────────────────────────
@@ -6728,6 +6792,32 @@ impl Codegen {
                 let (r, rt) = self.emit_typed_expr(right)?;
 
                 if let Some(result_ty) = RustType::result_type_of_binop(*op, &lt, &rt) {
+                    // Bitwise/shift over numbers: lower the *whole* chain in the int32 domain so
+                    // intermediate `to_int32`/`to_uint32`↔`f64` round-trips collapse (the win `>>>`
+                    // exists for — crypto/hashing loops). Only fires when every leaf proves `f64`;
+                    // otherwise we fall through to the per-op lowering below. Behaviour-identical
+                    // (see `emit_int32_operand`), and the gauntlet's `typed == boxed == node` check
+                    // gates any divergence.
+                    if matches!(
+                        op,
+                        BinOp::BitAnd
+                            | BinOp::BitOr
+                            | BinOp::BitXor
+                            | BinOp::Shl
+                            | BinOp::Shr
+                            | BinOp::UShr
+                    ) && result_ty == RustType::F64
+                    {
+                        if let Some(int_code) = self.emit_int32_operand(expr)? {
+                            // `>>>` yields a uint32 Number; the others yield a signed int32 Number.
+                            let f64_code = if matches!(op, BinOp::UShr) {
+                                format!("(({}) as u32 as f64)", int_code)
+                            } else {
+                                format!("(({}) as f64)", int_code)
+                            };
+                            return Ok((f64_code, RustType::F64));
+                        }
+                    }
                     // Both sides are compatible native types → emit native op.
                     let code = match op {
                         BinOp::Add if result_ty == RustType::String => {

--- a/tests/core/parity_bitwise_int_domain.js
+++ b/tests/core/parity_bitwise_int_domain.js
@@ -1,0 +1,49 @@
+// Int-domain bitwise lowering (#174): the native typed backend lowers a chain of bitwise/shift
+// ops in the integer domain, erasing the intermediate `ToInt32`/`ToUint32`↔f64 round-trips. This
+// must stay bit-identical to the interpreter, VM, cranelift, wasi and node. The key invariants:
+//   - an f64 `*`/`+` inside a `>>>` is NOT a bitwise node, so it keeps its f64 arithmetic and only
+//     ToUint32s the rounded product (the 2^53 rule: `h * 16777619` overflows 2^53 and must round
+//     in f64 *before* ToUint32, exactly as V8 does);
+//   - NaN / ±Infinity coerce to 0; negatives sign-extend under `>>` and wrap under `>>>`;
+//   - shift counts mask mod 32.
+
+// FNV-1a: the canonical chained-bitwise hot loop. `(h * prime) >>> 0` is the 2^53 case.
+function fnv1a(n) {
+  let h = 2166136261
+  for (let i = 0; i < n; i = i + 1) {
+    h = h ^ (i & 255)
+    h = (h * 16777619) >>> 0
+    h = ((h << 13) | (h >>> 19)) >>> 0
+  }
+  return h >>> 0
+}
+
+// Deeply nested chain (exercises the recursion staying in int domain across mixed ops). Operates
+// on number-literal-seeded locals so it stays on the typed path the int-domain lowering targets.
+function mix(n) {
+  let a = 305419896
+  let b = -1412567295
+  let acc = 0
+  for (let i = 0; i < n; i = i + 1) {
+    a = (a + i) | 0
+    acc = (acc ^ ((((a ^ b) << 3) | ((a & b) >>> 1)) ^ (((a | b) >> 2) & (b << 5)))) >>> 0
+  }
+  return acc >>> 0
+}
+
+console.log("fnv", fnv1a(100000))
+console.log("mix", mix(100000))
+console.log("neg_xor", (-5) ^ 3)
+console.log("mask_big", (0xFFFFFFFF & 0x0F))
+console.log("ushr_signbit", (0x80000000 >>> 1))
+console.log("ushr_neg1", ((-1) >>> 0))
+console.log("shl_31", (1 << 31))
+console.log("shl_wrap", (1 << 33))
+console.log("shr_neg", ((-8) >> 2))
+console.log("or_zero", (0xDEADBEEF | 0))
+console.log("nan_or", ((0 / 0) | 0))
+console.log("inf_or", ((1 / 0) | 0))
+console.log("neginf_ushr", ((-1 / 0) >>> 0))
+console.log("trunc_pos", (3.9 | 0))
+console.log("trunc_neg", (-3.9 | 0))
+console.log("rotate", (((255 << 24) | (128 << 16)) >>> 0))

--- a/tests/core/parity_bitwise_int_domain.tish
+++ b/tests/core/parity_bitwise_int_domain.tish
@@ -1,0 +1,49 @@
+// Int-domain bitwise lowering (#174): the native typed backend lowers a chain of bitwise/shift
+// ops in the integer domain, erasing the intermediate `ToInt32`/`ToUint32`↔f64 round-trips. This
+// must stay bit-identical to the interpreter, VM, cranelift, wasi and node. The key invariants:
+//   - an f64 `*`/`+` inside a `>>>` is NOT a bitwise node, so it keeps its f64 arithmetic and only
+//     ToUint32s the rounded product (the 2^53 rule: `h * 16777619` overflows 2^53 and must round
+//     in f64 *before* ToUint32, exactly as V8 does);
+//   - NaN / ±Infinity coerce to 0; negatives sign-extend under `>>` and wrap under `>>>`;
+//   - shift counts mask mod 32.
+
+// FNV-1a: the canonical chained-bitwise hot loop. `(h * prime) >>> 0` is the 2^53 case.
+function fnv1a(n) {
+  let h = 2166136261
+  for (let i = 0; i < n; i = i + 1) {
+    h = h ^ (i & 255)
+    h = (h * 16777619) >>> 0
+    h = ((h << 13) | (h >>> 19)) >>> 0
+  }
+  return h >>> 0
+}
+
+// Deeply nested chain (exercises the recursion staying in int domain across mixed ops). Operates
+// on number-literal-seeded locals so it stays on the typed path the int-domain lowering targets.
+function mix(n) {
+  let a = 305419896
+  let b = -1412567295
+  let acc = 0
+  for (let i = 0; i < n; i = i + 1) {
+    a = (a + i) | 0
+    acc = (acc ^ ((((a ^ b) << 3) | ((a & b) >>> 1)) ^ (((a | b) >> 2) & (b << 5)))) >>> 0
+  }
+  return acc >>> 0
+}
+
+console.log("fnv", fnv1a(100000))
+console.log("mix", mix(100000))
+console.log("neg_xor", (-5) ^ 3)
+console.log("mask_big", (0xFFFFFFFF & 0x0F))
+console.log("ushr_signbit", (0x80000000 >>> 1))
+console.log("ushr_neg1", ((-1) >>> 0))
+console.log("shl_31", (1 << 31))
+console.log("shl_wrap", (1 << 33))
+console.log("shr_neg", ((-8) >> 2))
+console.log("or_zero", (0xDEADBEEF | 0))
+console.log("nan_or", ((0 / 0) | 0))
+console.log("inf_or", ((1 / 0) | 0))
+console.log("neginf_ushr", ((-1 / 0) >>> 0))
+console.log("trunc_pos", (3.9 | 0))
+console.log("trunc_neg", (-3.9 | 0))
+console.log("rotate", (((255 << 24) | (128 << 16)) >>> 0))

--- a/tests/core/parity_bitwise_int_domain.tish.expected
+++ b/tests/core/parity_bitwise_int_domain.tish.expected
@@ -1,0 +1,16 @@
+fnv 3295615320
+mix 3465128608
+neg_xor -8
+mask_big 15
+ushr_signbit 1073741824
+ushr_neg1 4294967295
+shl_31 -2147483648
+shl_wrap 2
+shr_neg -2
+or_zero -559038737
+nan_or 0
+inf_or 0
+neginf_ushr 0
+trunc_pos 3
+trunc_neg -3
+rotate 4286578688


### PR DESCRIPTION
## What

The typed native backend lowered each bitwise/shift op as `(to_int32(l) OP to_int32(r)) as f64`, so a chain like `((h << 13) | (h >>> 19)) >>> 0` round-tripped through `f64` between *every* operator — each inner op produced an `f64` the next op immediately re-narrowed with `to_int32`.

`emit_int32_operand` now lowers a whole bitwise/shift tree in the **integer domain**: `to_int32` is emitted only at the leaves (real `f64` locals/exprs), the chain stays in `i32`, and the result converts back to `f64` once at the top.

## Correctness

Behaviour-identical to the old nested lowering: erasing an intermediate `(i32 as f64)` that is immediately re-narrowed by `to_int32` is exact (every `i32` is representable in `f64`, and `to_int32` of a finite value recovers it). Only bitwise/shift nodes recurse, so an `f64` `*`/`+`/`-` inside a `>>>` stays a **leaf** and keeps its `f64` arithmetic — e.g. `(h * 16777619) >>> 0` still rounds the product in `f64` *before* `ToUint32` (the 2⁵³ rule, matching V8). The path only fires when every leaf proves `f64`; otherwise it falls back to the existing per-op lowering, so it is purely additive — never a regression.

## Measured (#174 — the bitwise/hashing workload `>>>` exists for)

Interleaved same-machine A/B (old codegen vs new, native typed, 10 runs each, no distribution overlap):

| benchmark | old | new | node | checksum |
|---|---|---|---|---|
| fnv_hash | ~685ms | ~425ms (**−38%**) | 167ms | identical (87326928) |
| nsieve | ~157ms | ~156ms | 103ms | identical (hot path isn't bitwise) |
| fannkuch | ~2150ms | ~2140ms | 217ms | identical (hot path isn't bitwise) |

This does **not** yet flip fnv_hash past V8 (still ~2.5×, down from ~4.1×) — closing the rest needs proven-finite int specialization (the range lattice) so the per-leaf `to_int32` guard can drop. It is the round-trip-erasure half of #174, landed and verified.

## Tests

New cross-backend probe `tests/core/parity_bitwise_int_domain.{tish,js,tish.expected}` covers negatives, `NaN`/±`Infinity` → 0, shift-count wrap, the multiply-stays-`f64` case, and deeply nested chains. interp / vm / native (typed + default) / cranelift / wasi / js / node all agree. `cargo test -p tishlang --test integration_test` green (20/0), `cargo test -p tishlang_compile` green (26/0).

Refs #174, #203.