### PR TITLE
fix(native): compose nested bitwise/shift/unary in the boxed Value path

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1343,23 +1343,27 @@ impl Codegen {
 
     /// Generate code for a bitwise binary operation (`& | ^`). `to_int32` is JS ToInt32
     /// (modulo 2³², NaN/±Infinity → 0) — out-of-range operands wrap, not saturate.
+    /// Boxed/`Value`-path bitwise op (`& | ^`). Uses the `*_value(&Value)` coercion helpers rather
+    /// than a `let Value::Number(a) = &(..) else { panic!() }` block: the block bound `a`/`b`, so a
+    /// nested bitwise operand (whose block *also* binds `a`/`b`) shadowed the outer binding and the
+    /// generated code failed to compile (`error[E0308]`, `&&f64` vs `Value`). The helpers bind no
+    /// name, so the ops compose at any nesting depth, and they coerce non-numbers to `NaN` (→ `0`)
+    /// exactly like the interpreter/VM instead of panicking.
     fn emit_bitwise_binop(l: &str, r: &str, op: &str) -> String {
         format!(
-            "Value::Number({{ let Value::Number(a) = &({}) else {{ panic!() }}; \
-             let Value::Number(b) = &({}) else {{ panic!() }}; (tishlang_runtime::to_int32(*a) {} tishlang_runtime::to_int32(*b)) as f64 }})",
-            l, r, op
+            "Value::Number((tishlang_runtime::to_int32_value(&({})) {} tishlang_runtime::to_int32_value(&({}))) as f64)",
+            l, op, r
         )
     }
 
-    /// Generate code for a shift (`<< >> >>>`). `a_to` is the left-operand coercion
-    /// (`to_int32` signed, `to_uint32` for the logical `>>>`); `method` is the `wrapping_sh*`
-    /// call. Counts go through `to_uint32` then mask to 5 bits — exact JS semantics, panic-free.
+    /// Boxed/`Value`-path shift (`<< >> >>>`). `a_to` is the left-operand coercion helper
+    /// (`to_int32_value` signed, `to_uint32_value` for the logical `>>>`); `method` is the
+    /// `wrapping_sh*` call. Counts go through `to_uint32_value` then mask to 5 bits — exact JS
+    /// semantics, panic-free, and composable (no name binding — see `emit_bitwise_binop`).
     fn emit_shift_binop(l: &str, r: &str, a_to: &str, method: &str) -> String {
         format!(
-            "Value::Number({{ let Value::Number(a) = &({}) else {{ panic!() }}; \
-             let Value::Number(b) = &({}) else {{ panic!() }}; \
-             tishlang_runtime::{}(*a).{}(tishlang_runtime::to_uint32(*b)) as f64 }})",
-            l, r, a_to, method
+            "Value::Number(tishlang_runtime::{}(&({})).{}(tishlang_runtime::to_uint32_value(&({}))) as f64)",
+            a_to, l, method, r
         )
     }
 
@@ -3218,16 +3222,17 @@ impl Codegen {
                 let o = self.emit_expr(operand)?;
                 match op {
                     UnaryOp::Not => format!("Value::Bool(!{}.is_truthy())", o),
-                    UnaryOp::Neg => format!(
-                        "Value::Number({{ let Value::Number(n) = &({}) else {{ panic!(\"Expected number\") }}; -n }})",
-                        o
-                    ),
-                    UnaryOp::Pos => format!(
-                        "Value::Number({{ let Value::Number(n) = &({}) else {{ panic!(\"Expected number\") }}; *n }})",
-                        o
-                    ),
+                    // `*_value(&Value)` coercion (no name binding) so unary ops compose over nested
+                    // bitwise/unary operands without the `let Value::Number(n) = &(..)` shadowing
+                    // miscompile, and coerce non-numbers to `NaN` like the interpreter/VM.
+                    UnaryOp::Neg => {
+                        format!("Value::Number(-tishlang_runtime::to_number_value(&({})))", o)
+                    }
+                    UnaryOp::Pos => {
+                        format!("Value::Number(tishlang_runtime::to_number_value(&({})))", o)
+                    }
                     UnaryOp::BitNot => format!(
-                        "Value::Number({{ let Value::Number(n) = &({}) else {{ panic!(\"Expected number\") }}; (!tishlang_runtime::to_int32(*n)) as f64 }})",
+                        "Value::Number((!tishlang_runtime::to_int32_value(&({}))) as f64)",
                         o
                     ),
                     UnaryOp::Void => format!("{{ {}; Value::Null }}", o),
@@ -7429,8 +7434,7 @@ impl Codegen {
                 l, r
             ),
             BinOp::Pow => format!(
-                "Value::Number({{ let Value::Number(a) = &({}) else {{ panic!() }}; \
-                 let Value::Number(b) = &({}) else {{ panic!() }}; a.powf(*b) }})",
+                "Value::Number(tishlang_runtime::to_number_value(&({})).powf(tishlang_runtime::to_number_value(&({}))))",
                 l, r
             ),
             BinOp::StrictEq => format!("Value::Bool({}.strict_eq(&{}))", l, r),
@@ -7448,9 +7452,9 @@ impl Codegen {
             BinOp::BitAnd => Self::emit_bitwise_binop(l, r, "&"),
             BinOp::BitOr => Self::emit_bitwise_binop(l, r, "|"),
             BinOp::BitXor => Self::emit_bitwise_binop(l, r, "^"),
-            BinOp::Shl => Self::emit_shift_binop(l, r, "to_int32", "wrapping_shl"),
-            BinOp::Shr => Self::emit_shift_binop(l, r, "to_int32", "wrapping_shr"),
-            BinOp::UShr => Self::emit_shift_binop(l, r, "to_uint32", "wrapping_shr"),
+            BinOp::Shl => Self::emit_shift_binop(l, r, "to_int32_value", "wrapping_shl"),
+            BinOp::Shr => Self::emit_shift_binop(l, r, "to_int32_value", "wrapping_shr"),
+            BinOp::UShr => Self::emit_shift_binop(l, r, "to_uint32_value", "wrapping_shr"),
             BinOp::In => format!("tish_in_operator(&{}, &{})", l, r),
             BinOp::Eq | BinOp::Ne => {
                 return Err(CompileError::new(

--- a/crates/tish_core/src/value.rs
+++ b/crates/tish_core/src/value.rs
@@ -834,6 +834,31 @@ pub fn to_uint32(x: f64) -> u32 {
     }
 }
 
+/// `ToNumber` for the native boxed runtime: a `Value::Number` passes through, every other variant
+/// coerces to `NaN`. This is the same `as_number().unwrap_or(NaN)` convention used by the
+/// interpreter (`binop_number` / `to_int32`), the VM (`eval_binop`), and `ops::add`/`sub`/`mul`/`div`
+/// — so the native backend stays bit-for-bit in lock-step with them at runtime (a string/bool/null
+/// operand is `NaN`, hence `0` for bitwise). The compiler constant-folds literal cases like
+/// `"5" | 0 === 5` separately, so this only governs runtime (non-constant) operands.
+#[inline]
+pub fn to_number_value(v: &Value) -> f64 {
+    v.as_number().unwrap_or(f64::NAN)
+}
+
+/// `ToInt32` of an arbitrary [`Value`] (coerce via [`to_number_value`], then [`to_int32`]). Designed
+/// to compose in generated code: unlike a `let Value::Number(a) = &(..) else { panic!() }` block,
+/// it binds no name, so nested bitwise/shift operands can never shadow each other.
+#[inline]
+pub fn to_int32_value(v: &Value) -> i32 {
+    to_int32(to_number_value(v))
+}
+
+/// `ToUint32` companion to [`to_int32_value`].
+#[inline]
+pub fn to_uint32_value(v: &Value) -> u32 {
+    to_uint32(to_number_value(v))
+}
+
 /// Invoke a callable [`Value`]: [`Value::Function`], or an object exposing `__call` (e.g. `Symbol`).
 pub fn value_call(callee: &Value, args: &[Value]) -> Value {
     match callee {

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -16,7 +16,9 @@ pub use tishlang_core::ArcStr;
 /// Used by native codegen for `f()` / `obj()` dispatch (`Value::Function` or `__call` on objects).
 pub use tishlang_core::value_call;
 /// JS ToInt32/ToUint32 for the emitted bitwise/shift code (modulo 2³², NaN/±Infinity → 0).
-pub use tishlang_core::{to_int32, to_uint32};
+pub use tishlang_core::{
+    to_int32, to_int32_value, to_number_value, to_uint32, to_uint32_value,
+};
 // Re-export the shared-mutable wrapper so the Rust code emitted by
 // `tishlang_compile::codegen` can write `VmRef::new(...)` without needing
 // a direct dependency on `tishlang_core` from the generated crate.

--- a/tests/core/parity_bitwise_int_domain.js
+++ b/tests/core/parity_bitwise_int_domain.js
@@ -31,8 +31,23 @@ function mix(n) {
   return acc >>> 0
 }
 
+// Untyped-param nested bitwise/unary/pow: these go through the BOXED/Value native path
+// (`emit_bitwise_binop`/`emit_shift_binop`/unary/Pow), which previously generated
+// `let Value::Number(a) = &(..)` blocks that shadowed across nesting and failed to compile
+// (`error[E0308]`). Called with numeric args so every backend (incl. node) agrees.
+function nested_boxed(a, b) { return ((a ^ b) << 3) | ((a & b) >>> 1) }
+function nested_unary(a) { return ~(~a | 0) ^ -(-a) }
+function nested_pow(a, b) { return (a ** b) | (a << 1) }
+function deep_boxed(a, b) {
+  return (((a ^ b) << 2) | ((a & b) >>> 1)) ^ (((a | b) >> 1) & ((a ^ 7) << 1))
+}
+
 console.log("fnv", fnv1a(100000))
 console.log("mix", mix(100000))
+console.log("nested_boxed", nested_boxed(305419896, -1412567295))
+console.log("nested_unary", nested_unary(12345))
+console.log("nested_pow", nested_pow(3, 5))
+console.log("deep_boxed", deep_boxed(305419896, 271733878))
 console.log("neg_xor", (-5) ^ 3)
 console.log("mask_big", (0xFFFFFFFF & 0x0F))
 console.log("ushr_signbit", (0x80000000 >>> 1))

--- a/tests/core/parity_bitwise_int_domain.tish
+++ b/tests/core/parity_bitwise_int_domain.tish
@@ -31,8 +31,23 @@ function mix(n) {
   return acc >>> 0
 }
 
+// Untyped-param nested bitwise/unary/pow: these go through the BOXED/Value native path
+// (`emit_bitwise_binop`/`emit_shift_binop`/unary/Pow), which previously generated
+// `let Value::Number(a) = &(..)` blocks that shadowed across nesting and failed to compile
+// (`error[E0308]`). Called with numeric args so every backend (incl. node) agrees.
+function nested_boxed(a, b) { return ((a ^ b) << 3) | ((a & b) >>> 1) }
+function nested_unary(a) { return ~(~a | 0) ^ -(-a) }
+function nested_pow(a, b) { return (a ** b) | (a << 1) }
+function deep_boxed(a, b) {
+  return (((a ^ b) << 2) | ((a & b) >>> 1)) ^ (((a | b) >> 1) & ((a ^ 7) << 1))
+}
+
 console.log("fnv", fnv1a(100000))
 console.log("mix", mix(100000))
+console.log("nested_boxed", nested_boxed(305419896, -1412567295))
+console.log("nested_unary", nested_unary(12345))
+console.log("nested_pow", nested_pow(3, 5))
+console.log("deep_boxed", deep_boxed(305419896, 271733878))
 console.log("neg_xor", (-5) ^ 3)
 console.log("mask_big", (0xFFFFFFFF & 0x0F))
 console.log("ushr_signbit", (0x80000000 >>> 1))

--- a/tests/core/parity_bitwise_int_domain.tish.expected
+++ b/tests/core/parity_bitwise_int_domain.tish.expected
@@ -1,5 +1,9 @@
 fnv 3295615320
 mix 3465128608
+nested_boxed -808457272
+nested_unary 0
+nested_pow 247
+deep_boxed 135266822
 neg_xor -8
 mask_big 15
 ushr_signbit 1073741824


### PR DESCRIPTION
## Bug

The untyped/**boxed** native emitters for `& | ^`, `<< >> >>>`, `**`, and unary `- + ~` generated:

```rust
Value::Number({ let Value::Number(a) = &(<L>) else { panic!() };
                let Value::Number(b) = &(<R>) else { panic!() }; ... })
```

When an operand was itself such a block (nested bitwise/shift/pow on untyped `Value` leaves — e.g. function params without numeric inference), the reused binding names `a`/`b`/`n` shadowed across nesting, so a deeper `&(a)` resolved to an outer `&f64` instead of the `Value` and the generated Rust failed to compile (`error[E0308]`: `&&f64` vs `Value`).

Minimal repro (default/boxed native mode, all `TISH_*` typing flags unset):

```js
function f(a, b) { return ((a ^ b) << 3) | ((a & b) >>> 1) }
```

A single level compiled; two same-named levels did not. Pre-existing (reproduces on `main`); only the boxed path — the typed path is correct.

## Fix

Stop binding names. Add composable `&Value -> f64/i32/u32` coercion helpers (`to_number_value`/`to_int32_value`/`to_uint32_value`) in `tishlang_core`, re-export from `tishlang_runtime`, and rewrite all **six** emitters (the audit found Pow and unary Neg/Pos/BitNot share the identical idiom and latent bug) to use them. With no bound names, the ops compose at any nesting depth.

## Semantics — no new divergence

The helpers use the established `as_number().unwrap_or(NaN)` convention — identical to the interpreter (`binop_number`/`to_int32`), the VM (`eval_binop`), and `ops::add`/`sub`/`mul`/`div`. So:
- **Numeric operands** (every existing test): byte-identical behavior.
- **Non-number operands**: now coerce to `NaN` (→ `0` for bitwise) exactly like interp/vm at runtime, instead of panicking.

Verified `native == interp == vm` for `x|0` / `x>>>0` / `~x` / `-x` with string/bool/null/array `x`. (They share a runtime-ToNumber gap vs node — `"5"|0` is `0` at runtime in all three tish backends, `5` only via constant folding — which is a **separate pre-existing issue**, not introduced here. The fix deliberately aligns native *with* interp/vm rather than inventing a third behavior. Full-ToNumber runtime coercion can be a follow-up across all backends.)

## Tests

Expanded `tests/core/parity_bitwise_int_domain` with untyped-param nested bitwise/unary/pow cases (numeric args, so node agrees too). Cross-backend integration suite green (20/0), `tishlang_core`+`tishlang_compile` unit tests green, typed path unchanged (fnv_hash 420ms, checksum identical).