### PR TITLE
perf(native): skip box+unbox on typed decls + native mixed-numeric compare (2 gauntlet flips)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -5940,6 +5940,19 @@ impl Codegen {
             }
         }
 
+        // Fast path: when the native typed emitter already yields the target type, use its code
+        // directly — skipping the `Value::Number(<expr>)` box that `from_value_expr` would
+        // immediately unbox. This round-trip otherwise lands in hot loops: `let xt = x*x - y*y + x0`
+        // (xt inferred f64) emitted `match &Value::Number(<expr>) { Value::Number(n) => *n,
+        // _ => panic!() }` *every iteration*. `emit_typed_expr`'s contract guarantees `code` is a
+        // value of `typed_ty` directly, so when it equals the target the code is exactly what we
+        // want, unboxed. (Any other type falls through to the unchanged box-and-coerce path below.)
+        if let Ok((typed_code, typed_ty)) = self.emit_typed_expr(expr) {
+            if &typed_ty == target_type {
+                return Ok(typed_code);
+            }
+        }
+
         // Fall back to emit_expr + conversion
         let value_expr = self.emit_expr(expr)?;
         Ok(target_type.from_value_expr(&value_expr))

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -6891,6 +6891,37 @@ impl Codegen {
                     return Ok((code, result_ty));
                 }
 
+                // Mixed numeric relational: one side is a native `f64`, the other a boxed `Value`
+                // (e.g. nsieve's `while (k < n)` where `k` is f64 and the param `n` stayed boxed).
+                // JS does a numeric comparison here — the f64 side forces ToNumber on the other —
+                // so coerce the Value inline (`as_number().unwrap_or(NaN)`) and compare natively,
+                // instead of boxing the f64 side and paying `ops::{lt,le,gt,ge}` + `Value::Bool` +
+                // `is_truthy` every iteration. Behaviour-identical to that boxed path for every
+                // input: a non-number Value coerces to NaN, so all comparisons are `false`, exactly
+                // as `ops::*` returns `false` outside the (Number,Number)/(String,String) cases —
+                // and (String,String) can't reach here since one side is f64.
+                if matches!(op, BinOp::Lt | BinOp::Le | BinOp::Gt | BinOp::Ge)
+                    && (lt == RustType::F64 || rt == RustType::F64)
+                {
+                    let coerce = |code: &str, ty: &RustType| match ty {
+                        RustType::F64 => Some(code.to_string()),
+                        RustType::Value => {
+                            Some(format!("({}).as_number().unwrap_or(f64::NAN)", code))
+                        }
+                        _ => None,
+                    };
+                    if let (Some(lc), Some(rc)) = (coerce(&l, &lt), coerce(&r, &rt)) {
+                        let sym = match op {
+                            BinOp::Lt => "<",
+                            BinOp::Le => "<=",
+                            BinOp::Gt => ">",
+                            BinOp::Ge => ">=",
+                            _ => unreachable!(),
+                        };
+                        return Ok((format!("({} {} {})", lc, sym, rc), RustType::Bool));
+                    }
+                }
+
                 // Fall back: convert both sides to Value and use the runtime.
                 let lv = if lt.is_native() {
                     lt.to_value_expr(&l)

--- a/tests/core/parity_mixed_numeric_compare.js
+++ b/tests/core/parity_mixed_numeric_compare.js
@@ -1,0 +1,31 @@
+// Mixed numeric relational (native typed path): when one operand lowers to a native f64 and the
+// other is a boxed Value (e.g. an unannotated param only ever compared, like nsieve's `n`), the
+// comparison is lowered to a native `f64 < value.as_number().unwrap_or(NaN)` instead of boxing the
+// f64 side through `ops::lt`. Must stay bit-identical to interp/vm/cranelift/wasi/node. Numeric
+// args throughout (the real hot-loop case), so node agrees too.
+function countLt(n) { let c = 0; for (let i = 0; i < n; i++) { if (i < n) { c = c + 1 } } return c }
+function bounds(lo, hi) { let s = 0; let x = lo; while (x <= hi) { s = s + x; x = x + 1 } return s }
+function cmpAll(a) {
+  let r = 0; let x = 3.5
+  if (x < a) { r = r + 1 }
+  if (x > a) { r = r + 2 }
+  if (x <= a) { r = r + 4 }
+  if (x >= a) { r = r + 8 }
+  return r
+}
+// nsieve's exact shape: f64 counter vs boxed param in a strided inner loop.
+function sieveCount(n) {
+  let isP = []
+  for (let i = 0; i < n; i++) { isP.push(true) }
+  let count = 0
+  for (let i = 2; i < n; i++) {
+    if (isP[i]) { count = count + 1; let k = i + i; while (k < n) { isP[k] = false; k = k + i } }
+  }
+  return count
+}
+console.log("countLt", countLt(1000))
+console.log("bounds", bounds(5, 100))
+console.log("cmp_gt", cmpAll(2))
+console.log("cmp_eqish", cmpAll(3.5))
+console.log("cmp_lt", cmpAll(9))
+console.log("sieve", sieveCount(10000))

--- a/tests/core/parity_mixed_numeric_compare.tish
+++ b/tests/core/parity_mixed_numeric_compare.tish
@@ -1,0 +1,31 @@
+// Mixed numeric relational (native typed path): when one operand lowers to a native f64 and the
+// other is a boxed Value (e.g. an unannotated param only ever compared, like nsieve's `n`), the
+// comparison is lowered to a native `f64 < value.as_number().unwrap_or(NaN)` instead of boxing the
+// f64 side through `ops::lt`. Must stay bit-identical to interp/vm/cranelift/wasi/node. Numeric
+// args throughout (the real hot-loop case), so node agrees too.
+function countLt(n) { let c = 0; for (let i = 0; i < n; i++) { if (i < n) { c = c + 1 } } return c }
+function bounds(lo, hi) { let s = 0; let x = lo; while (x <= hi) { s = s + x; x = x + 1 } return s }
+function cmpAll(a) {
+  let r = 0; let x = 3.5
+  if (x < a) { r = r + 1 }
+  if (x > a) { r = r + 2 }
+  if (x <= a) { r = r + 4 }
+  if (x >= a) { r = r + 8 }
+  return r
+}
+// nsieve's exact shape: f64 counter vs boxed param in a strided inner loop.
+function sieveCount(n) {
+  let isP = []
+  for (let i = 0; i < n; i++) { isP.push(true) }
+  let count = 0
+  for (let i = 2; i < n; i++) {
+    if (isP[i]) { count = count + 1; let k = i + i; while (k < n) { isP[k] = false; k = k + i } }
+  }
+  return count
+}
+console.log("countLt", countLt(1000))
+console.log("bounds", bounds(5, 100))
+console.log("cmp_gt", cmpAll(2))
+console.log("cmp_eqish", cmpAll(3.5))
+console.log("cmp_lt", cmpAll(9))
+console.log("sieve", sieveCount(10000))

--- a/tests/core/parity_mixed_numeric_compare.tish.expected
+++ b/tests/core/parity_mixed_numeric_compare.tish.expected
@@ -1,0 +1,6 @@
+countLt 1000
+bounds 5040
+cmp_gt 10
+cmp_eqish 12
+cmp_lt 5
+sieve 1229

--- a/tests/main.js
+++ b/tests/main.js
@@ -3125,6 +3125,40 @@ console.log("bitand", 0xff & 0x0f)
 }
 
 {
+// Mixed numeric relational (native typed path): when one operand lowers to a native f64 and the
+// other is a boxed Value (e.g. an unannotated param only ever compared, like nsieve's `n`), the
+// comparison is lowered to a native `f64 < value.as_number().unwrap_or(NaN)` instead of boxing the
+// f64 side through `ops::lt`. Must stay bit-identical to interp/vm/cranelift/wasi/node. Numeric
+// args throughout (the real hot-loop case), so node agrees too.
+function countLt(n) { let c = 0; for (let i = 0; i < n; i++) { if (i < n) { c = c + 1 } } return c }
+function bounds(lo, hi) { let s = 0; let x = lo; while (x <= hi) { s = s + x; x = x + 1 } return s }
+function cmpAll(a) {
+  let r = 0; let x = 3.5
+  if (x < a) { r = r + 1 }
+  if (x > a) { r = r + 2 }
+  if (x <= a) { r = r + 4 }
+  if (x >= a) { r = r + 8 }
+  return r
+}
+// nsieve's exact shape: f64 counter vs boxed param in a strided inner loop.
+function sieveCount(n) {
+  let isP = []
+  for (let i = 0; i < n; i++) { isP.push(true) }
+  let count = 0
+  for (let i = 2; i < n; i++) {
+    if (isP[i]) { count = count + 1; let k = i + i; while (k < n) { isP[k] = false; k = k + i } }
+  }
+  return count
+}
+console.log("countLt", countLt(1000))
+console.log("bounds", bounds(5, 100))
+console.log("cmp_gt", cmpAll(2))
+console.log("cmp_eqish", cmpAll(3.5))
+console.log("cmp_lt", cmpAll(9))
+console.log("sieve", sieveCount(10000))
+}
+
+{
 // Cross-backend parity: member access / method calls on numeric literals. `(255).toString(16)` must
 // compile to valid JS — emitting `255.toString(16)` is a JS syntax error (the lexer reads `255.` as
 // a float). The parens must be preserved for integer literals (and folded integer constants). Every

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3172,6 +3172,41 @@ console.log("bitand", 0xff & 0x0f)
 }
 __perf_run_core_parity_coercion()
 
+fn __perf_run_core_parity_mixed_numeric_compare() {
+// Mixed numeric relational (native typed path): when one operand lowers to a native f64 and the
+// other is a boxed Value (e.g. an unannotated param only ever compared, like nsieve's `n`), the
+// comparison is lowered to a native `f64 < value.as_number().unwrap_or(NaN)` instead of boxing the
+// f64 side through `ops::lt`. Must stay bit-identical to interp/vm/cranelift/wasi/node. Numeric
+// args throughout (the real hot-loop case), so node agrees too.
+function countLt(n) { let c = 0; for (let i = 0; i < n; i++) { if (i < n) { c = c + 1 } } return c }
+function bounds(lo, hi) { let s = 0; let x = lo; while (x <= hi) { s = s + x; x = x + 1 } return s }
+function cmpAll(a) {
+  let r = 0; let x = 3.5
+  if (x < a) { r = r + 1 }
+  if (x > a) { r = r + 2 }
+  if (x <= a) { r = r + 4 }
+  if (x >= a) { r = r + 8 }
+  return r
+}
+// nsieve's exact shape: f64 counter vs boxed param in a strided inner loop.
+function sieveCount(n) {
+  let isP = []
+  for (let i = 0; i < n; i++) { isP.push(true) }
+  let count = 0
+  for (let i = 2; i < n; i++) {
+    if (isP[i]) { count = count + 1; let k = i + i; while (k < n) { isP[k] = false; k = k + i } }
+  }
+  return count
+}
+console.log("countLt", countLt(1000))
+console.log("bounds", bounds(5, 100))
+console.log("cmp_gt", cmpAll(2))
+console.log("cmp_eqish", cmpAll(3.5))
+console.log("cmp_lt", cmpAll(9))
+console.log("sieve", sieveCount(10000))
+}
+__perf_run_core_parity_mixed_numeric_compare()
+
 fn __perf_run_core_parity_number_methods() {
 // Cross-backend parity: member access / method calls on numeric literals. `(255).toString(16)` must
 // compile to valid JS — emitting `255.toString(16)` is a JS syntax error (the lexer reads `255.` as


### PR DESCRIPTION
Two native-typed codegen improvements. Gauntlet **8/21 → 10/21**; all 21 checksums unchanged (no `TYPED≠BOXED`/`≠NODE`); cross-backend integration suite green (20/0).

## 1. Skip box+unbox for typed local decls whose init is already native

`emit_native_expr` (typed `let x: T = init`) fell straight to `from_value_expr(emit_expr(init))`. When `init` already lowers to the target native type, that boxes it to `Value::Number(<expr>)` then immediately unboxes with `match … { Value::Number(n) => *n, _ => panic!() }` — a dead round-trip, **per iteration** in hot loops. E.g. mandelbrot's `let xt = x*x - y*y + x0` emitted `let mut xt: f64 = match &Value::Number(((x*x)-(y*y))+x0) { … }`; now `let mut xt: f64 = (((x*x)-(y*y))+x0);`.

Fix: try `emit_typed_expr` first; if it already yields the target type, use its unboxed code. Behaviour-identical (the boxed path was wrapping/unwrapping the same value); any other type falls through unchanged.

## 2. Native compare for mixed f64-vs-boxed-Value relationals

When one side of `< <= > >=` is a native f64 and the other a boxed `Value` (e.g. an unannotated param only ever compared — nsieve's `n`), the emitter boxed the f64 side and called `ops::lt(&Value::Number(k), &n).is_truthy()` every iteration. JS does a numeric comparison here, so emit it natively: `(k < (n).as_number().unwrap_or(f64::NAN))`. Behaviour-identical to `ops::{lt,le,gt,ge}` for every input (a non-number Value → NaN → false, exactly as `ops::*` returns false outside Number/Number; String/String can't reach here since one side is f64).

## Measured (interleaved same-machine A/B; node = fixed control)

- **nsieve**: ~103ms → ~48ms native typed (node ~71ms) → **PASS** (was 1.54×). Robust.
- **mandelbrot**: box+unbox removal closed the gap to ~parity with V8; flips on this gauntlet run (84 vs 116ms) but is borderline ~1.0× run-to-run.

## Tests

New probe `parity_mixed_numeric_compare` (nsieve shape + all four relational ops; interp/vm/native/node agree). Bundled perf sources regenerated (89 tests). `tishlang_compile` unit tests green.

Refs #203, #175.