### PR TITLE
fix(native): clone Value-typed identifier array-literal elements (#247)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -3900,7 +3900,13 @@ impl Codegen {
                     for elem in elements {
                         if let ArrayElement::Expr(expr) = elem {
                             let v = self.emit_expr(expr)?;
-                            if self.should_clone(expr) {
+                            // A `Value`-typed identifier (object, or a global like `NaN`/`Infinity`)
+                            // is emitted bare here, so moving it into the array breaks any later use
+                            // in the SAME expression — e.g. `[1, o].includes(o)` borrows `o` after the
+                            // array moved it. The scope-local last-use analysis can't see that reuse,
+                            // so clone every identifier element (cheap; these literals are cold, and
+                            // string/number idents already clone inside their `Value::*` conversion).
+                            if matches!(expr, Expr::Ident { .. }) || self.should_clone(expr) {
                                 els.push(format!("({}).clone()", v));
                             } else {
                                 els.push(v);

--- a/tests/core/parity_array_ident_elem.js
+++ b/tests/core/parity_array_ident_elem.js
@@ -1,0 +1,13 @@
+// Native codegen: a Value-typed identifier (object, or a global like NaN/Infinity) used BOTH as an
+// array-literal element AND again in the same expression must be cloned, not moved (#247 native
+// build failure: `[1, NaN].includes(NaN)`). Must stay bit-identical across all backends.
+let o = { a: 1 }
+let p = { a: 1 }
+console.log("nan", [1, NaN].includes(NaN))
+console.log("inf", [1, Infinity].includes(Infinity))
+console.log("obj_same", [1, o].includes(o))
+console.log("obj_diff", [1, o].includes(p))
+console.log("str", ["a", "b"].includes("b"))
+let arr = [10, 20, 30]
+console.log("nested", [arr, arr].length)
+console.log("reuse_idx", [o, o, o].indexOf(o))

--- a/tests/core/parity_array_ident_elem.tish
+++ b/tests/core/parity_array_ident_elem.tish
@@ -1,0 +1,13 @@
+// Native codegen: a Value-typed identifier (object, or a global like NaN/Infinity) used BOTH as an
+// array-literal element AND again in the same expression must be cloned, not moved (#247 native
+// build failure: `[1, NaN].includes(NaN)`). Must stay bit-identical across all backends.
+let o = { a: 1 }
+let p = { a: 1 }
+console.log("nan", [1, NaN].includes(NaN))
+console.log("inf", [1, Infinity].includes(Infinity))
+console.log("obj_same", [1, o].includes(o))
+console.log("obj_diff", [1, o].includes(p))
+console.log("str", ["a", "b"].includes("b"))
+let arr = [10, 20, 30]
+console.log("nested", [arr, arr].length)
+console.log("reuse_idx", [o, o, o].indexOf(o))

--- a/tests/core/parity_array_ident_elem.tish.expected
+++ b/tests/core/parity_array_ident_elem.tish.expected
@@ -1,0 +1,7 @@
+nan true
+inf true
+obj_same true
+obj_diff false
+str true
+nested 2
+reuse_idx 0

--- a/tests/main.js
+++ b/tests/main.js
@@ -2974,6 +2974,22 @@ console.log(obj?.c ?? "missing");
 }
 
 {
+// Native codegen: a Value-typed identifier (object, or a global like NaN/Infinity) used BOTH as an
+// array-literal element AND again in the same expression must be cloned, not moved (#247 native
+// build failure: `[1, NaN].includes(NaN)`). Must stay bit-identical across all backends.
+let o = { a: 1 }
+let p = { a: 1 }
+console.log("nan", [1, NaN].includes(NaN))
+console.log("inf", [1, Infinity].includes(Infinity))
+console.log("obj_same", [1, o].includes(o))
+console.log("obj_diff", [1, o].includes(p))
+console.log("str", ["a", "b"].includes("b"))
+let arr = [10, 20, 30]
+console.log("nested", [arr, arr].length)
+console.log("reuse_idx", [o, o, o].indexOf(o))
+}
+
+{
 // #247 feature gaps now implemented across interp/vm/native/cranelift/wasi/js: Array.findLast/
 // findLastIndex, Array.at, String.at (negative index from end; out of range -> null). Valid in
 // tish and node (node's `undefined` for OOB normalizes to tish's `null` in the parity harness).

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3017,6 +3017,23 @@ console.log(obj?.c ?? "missing")
 }
 __perf_run_core_optional_chaining()
 
+fn __perf_run_core_parity_array_ident_elem() {
+// Native codegen: a Value-typed identifier (object, or a global like NaN/Infinity) used BOTH as an
+// array-literal element AND again in the same expression must be cloned, not moved (#247 native
+// build failure: `[1, NaN].includes(NaN)`). Must stay bit-identical across all backends.
+let o = { a: 1 }
+let p = { a: 1 }
+console.log("nan", [1, NaN].includes(NaN))
+console.log("inf", [1, Infinity].includes(Infinity))
+console.log("obj_same", [1, o].includes(o))
+console.log("obj_diff", [1, o].includes(p))
+console.log("str", ["a", "b"].includes("b"))
+let arr = [10, 20, 30]
+console.log("nested", [arr, arr].length)
+console.log("reuse_idx", [o, o, o].indexOf(o))
+}
+__perf_run_core_parity_array_ident_elem()
+
 fn __perf_run_core_parity_array_methods() {
 // #247 feature gaps now implemented across interp/vm/native/cranelift/wasi/js: Array.findLast/
 // findLastIndex, Array.at, String.at (negative index from end; out of range -> null). Valid in


### PR DESCRIPTION
A `Value`-typed identifier used as an array-literal element is emitted bare → **moved** into the array's `vec![…]`. When the same identifier is reused later in the same expression, the generated Rust fails to compile (`error[E0382]: borrow of moved value`).

Canonical case (a #247 parity probe): `[1, NaN].includes(NaN)` — the array moves `NaN`, then the inlined `includes` borrows it. Also `[1, Infinity].includes(Infinity)` and `let o = {}; [1, o].includes(o)`. Number/string identifiers were unaffected (their `Value::Number`/`Value::String` conversion already clones); only already-`Value` identifiers (objects, `NaN`/`Infinity` globals) hit it.

The scope-local last-use analysis can't see the second use within one compound expression, so it lets the element move. **Fix:** in the boxed array-literal path, always clone identifier elements (cold path; only adds a clone where one was missing).

Unblocks the native build of the #247 probe (was its lone native compile failure). New probe `parity_array_ident_elem` covers object reference identity, `NaN`/`Infinity`, strings, and `indexOf` reuse — interp/vm/native/node agree. Integration suite 20/0, compile 26/0.