### PR TITLE
feat(cli): pass args to `tish run` as process.argv (#88)

### DIFF
--- a/crates/tish/src/cli_help.rs
+++ b/crates/tish/src/cli_help.rs
@@ -479,6 +479,15 @@ pub(crate) struct RunArgs {
     /// Disable AST and bytecode optimizations (for debugging).
     #[arg(long, help_heading = "Options")]
     pub no_optimize: bool,
+    /// Arguments passed through to the script as `process.argv` (after the file). Like
+    /// `node main.js a b`, options for `tish` itself must come BEFORE the file. #88
+    #[arg(
+        trailing_var_arg = true,
+        allow_hyphen_values = true,
+        value_name = "ARGS",
+        help_heading = "Arguments"
+    )]
+    pub script_args: Vec<String>,
 }
 
 #[derive(Parser)]

--- a/crates/tish/src/main.rs
+++ b/crates/tish/src/main.rs
@@ -107,12 +107,18 @@ fn main() {
     let matches = cli_help::build_command().get_matches_from(&argv);
     let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
     let result = match cli.command {
-        Some(Commands::Run(a)) => run_file(
-            &a.file,
-            &a.backend,
-            &a.features,
-            a.no_optimize || no_opt_env,
-        ),
+        Some(Commands::Run(a)) => {
+            // Expose a node-shaped `process.argv` to the script: `[tish-exe, <file>, args...]`,
+            // so `tish run main.tish a b` gives the script `["…/tish", "main.tish", "a", "b"]`
+            // (not the `run` subcommand). Interp/VM read this via `tishlang_core::process_argv`. #88
+            let exe = std::env::args().next().unwrap_or_else(|| "tish".to_string());
+            let mut argv = Vec::with_capacity(a.script_args.len() + 2);
+            argv.push(exe);
+            argv.push(a.file.clone());
+            argv.extend(a.script_args.iter().cloned());
+            tishlang_core::set_process_argv(argv);
+            run_file(&a.file, &a.backend, &a.features, a.no_optimize || no_opt_env)
+        }
         Some(Commands::Repl(a)) => run_repl(&a.backend, a.no_optimize || no_opt_env, &a.features),
         Some(Commands::Build(a)) => {
             // `--check warn|error` drives the gradual type checker via the same channel as the
@@ -810,6 +816,48 @@ mod cli_tests {
         let cli = Cli::try_parse_from(argv).unwrap();
         match cli.command {
             Some(Commands::Run(a)) => assert_eq!(a.file, "hello.tish"),
+            _ => panic!("expected Run"),
+        }
+    }
+
+    #[test]
+    fn run_collects_trailing_script_args() {
+        // `tish run main.tish a --flag` → file=main.tish, script_args=[a, --flag] (#88).
+        let cli = Cli::try_parse_from(vec![
+            "tish".to_string(),
+            "run".to_string(),
+            "main.tish".to_string(),
+            "a".to_string(),
+            "--flag".to_string(),
+        ])
+        .unwrap();
+        match cli.command {
+            Some(Commands::Run(a)) => {
+                assert_eq!(a.file, "main.tish");
+                assert_eq!(a.script_args, vec!["a".to_string(), "--flag".to_string()]);
+            }
+            _ => panic!("expected Run"),
+        }
+    }
+
+    #[test]
+    fn run_options_before_file_still_parse() {
+        // tish options come BEFORE the file; everything after the file is the script's. (#88)
+        let cli = Cli::try_parse_from(vec![
+            "tish".to_string(),
+            "run".to_string(),
+            "--backend".to_string(),
+            "interp".to_string(),
+            "main.tish".to_string(),
+            "x".to_string(),
+        ])
+        .unwrap();
+        match cli.command {
+            Some(Commands::Run(a)) => {
+                assert_eq!(a.backend, "interp");
+                assert_eq!(a.file, "main.tish");
+                assert_eq!(a.script_args, vec!["x".to_string()]);
+            }
             _ => panic!("expected Run"),
         }
     }

--- a/crates/tish_core/src/lib.rs
+++ b/crates/tish_core/src/lib.rs
@@ -18,3 +18,25 @@ pub use uri::{percent_decode, percent_encode};
 pub use arcstr::ArcStr;
 pub use value::*;
 pub use vmref::{VmReadGuard, VmRef, VmWriteGuard};
+
+/// `process.argv` for the interpreter / VM. Defaults to the host process's own `std::env::args()`,
+/// but `tish run <file> [args...]` overrides it (via [`set_process_argv`]) with a node-shaped argv
+/// `[tish-exe, <file>, args...]` so a script sees its own args — not the `run` subcommand. Compiled
+/// native binaries don't touch this; they read `std::env::args()` directly (which is already their
+/// own argv). #88
+static PROCESS_ARGV: std::sync::OnceLock<Vec<String>> = std::sync::OnceLock::new();
+
+/// Override `process.argv` for the interpreter/VM (set once by `tish run` before executing). A
+/// later call is ignored (the first override wins), matching the single-program-per-process model.
+pub fn set_process_argv(argv: Vec<String>) {
+    let _ = PROCESS_ARGV.set(argv);
+}
+
+/// The argv a script should see as `process.argv`: the [`set_process_argv`] override if present,
+/// else the host process's `std::env::args()`.
+pub fn process_argv() -> Vec<String> {
+    match PROCESS_ARGV.get() {
+        Some(v) => v.clone(),
+        None => std::env::args().collect(),
+    }
+}

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -185,6 +185,26 @@ impl Evaluator {
                 true,
             );
 
+            // Bare `process` global (node-compatible), mirroring the VM. `process.argv` reads the
+            // configurable argv so `tish run <file> [args...]` reaches the script. #88
+            #[cfg(feature = "process")]
+            {
+                let mut process_obj = PropMap::default();
+                process_obj.insert("exit".into(), Value::Native(natives::process_exit));
+                process_obj.insert("cwd".into(), Value::Native(natives::process_cwd));
+                process_obj.insert("exec".into(), Value::Native(natives::process_exec));
+                let argv: Vec<Value> = tishlang_core::process_argv()
+                    .into_iter()
+                    .map(|s| Value::String(s.into()))
+                    .collect();
+                process_obj.insert("argv".into(), Value::Array(Rc::new(RefCell::new(argv))));
+                let env_obj: PropMap = std::env::vars()
+                    .map(|(k, v)| (Arc::from(k.as_str()), Value::String(v.into())))
+                    .collect();
+                process_obj.insert("env".into(), Value::object(env_obj));
+                s.set("process".into(), Value::object(process_obj), true);
+            }
+
             let mut object = PropMap::with_capacity(5);
             object.insert("keys".into(), Value::Native(Self::object_keys));
             object.insert("values".into(), Value::Native(Self::object_values));
@@ -1037,8 +1057,10 @@ impl Evaluator {
                     exports.insert("exit".into(), Value::Native(natives::process_exit));
                     exports.insert("cwd".into(), Value::Native(natives::process_cwd));
                     exports.insert("exec".into(), Value::Native(natives::process_exec));
-                    let argv: Vec<Value> =
-                        std::env::args().map(|s| Value::String(s.into())).collect();
+                    let argv: Vec<Value> = tishlang_core::process_argv()
+                        .into_iter()
+                        .map(|s| Value::String(s.into()))
+                        .collect();
                     exports.insert(
                         "argv".into(),
                         Value::Array(Rc::new(RefCell::new(argv.clone()))),

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -264,7 +264,7 @@ fn get_builtin_export(enabled: &HashSet<String>, spec: &str, export_name: &str) 
                 tishlang_runtime::process_exec(args)
             })),
             "argv" => Some(Value::Array(VmRef::new(
-                std::env::args().map(|s| Value::String(s.into())).collect(),
+                tishlang_core::process_argv().into_iter().map(|s| Value::String(s.into())).collect(),
             ))),
             "env" => Some(value_object_from_map(
                 std::env::vars()
@@ -288,7 +288,7 @@ fn get_builtin_export(enabled: &HashSet<String>, spec: &str, export_name: &str) 
                 m.insert(
                     "argv".into(),
                     Value::Array(VmRef::new(
-                        std::env::args().map(|s| Value::String(s.into())).collect(),
+                        tishlang_core::process_argv().into_iter().map(|s| Value::String(s.into())).collect(),
                     )),
                 );
                 m.insert(
@@ -788,7 +788,7 @@ fn init_globals(enabled: &HashSet<String>) -> ObjectMap {
         process_obj.insert(
             "argv".into(),
             Value::Array(VmRef::new(
-                std::env::args().map(|s| Value::String(s.into())).collect(),
+                tishlang_core::process_argv().into_iter().map(|s| Value::String(s.into())).collect(),
             )),
         );
         process_obj.insert(


### PR DESCRIPTION
Closes #88.

`tish run main.tish a b` now forwards `a b` to the script.

- `RunArgs` gains a trailing `script_args` field (node-style: `tish` options come **before** the file, script args after).
- `main` builds a node-shaped argv `[tish-exe, <file>, args...]` and installs it via a new `tishlang_core::set_process_argv` override that interp/VM read through `process_argv()`. Compiled native binaries are untouched — they already read their own `std::env::args()`.
- Also exposes a bare `process` global in the **interpreter** (argv/env/exit/cwd/exec), mirroring the VM. Previously `process` was only reachable via the `tish:process` module, so `process.argv` errored under `--backend interp`. Both run backends now agree.

Verified (vm + interp): `tish run f.tish a b` → `process.argv == [".../tish","f.tish","a","b"]`, `.slice(2) == ["a","b"]`; `--backend interp` before the file still parses. New CLI parsing tests; eval/vm/core unit tests + cross-backend integration suite (20/0) green.