### PR TITLE
fix(lint,lsp): lint export-default subtree + consistent diagnostic source (#151, #155)

### DIFF
--- a/crates/tish_lint/src/lib.rs
+++ b/crates/tish_lint/src/lib.rs
@@ -134,11 +134,12 @@ fn lint_stmt(s: &Statement, out: &mut Vec<LintDiagnostic>) {
             lint_stmt(body, out);
             lint_expr(cond, out);
         }
-        Statement::Export { declaration, .. } => {
-            if let tishlang_ast::ExportDeclaration::Named(inner) = declaration.as_ref() {
-                lint_stmt(inner, out);
-            }
-        }
+        Statement::Export { declaration, .. } => match declaration.as_ref() {
+            tishlang_ast::ExportDeclaration::Named(inner) => lint_stmt(inner, out),
+            // Walk `export default <expr>` too — its subtree was previously never linted, so e.g.
+            // `export default { a: 1, a: 2 }` produced no tish-duplicate-key warning (#151).
+            tishlang_ast::ExportDeclaration::Default(expr) => lint_expr(expr, out),
+        },
         Statement::ExprStmt { expr, .. } => lint_expr(expr, out),
         Statement::VarDecl { init: Some(e), .. } => lint_expr(e, out),
         Statement::VarDeclDestructure { init, .. } => lint_expr(init, out),
@@ -364,6 +365,15 @@ mod tests {
     #[test]
     fn lints_inside_delete_target() {
         assert!(dup_keys("delete ({ a: 1, a: 2 }).a\n") >= 1, "delete target");
+    }
+
+    // #151: the `export default <expr>` subtree was never walked (only `export <named>` was).
+    #[test]
+    fn lints_inside_export_default() {
+        assert!(
+            dup_keys("export default { a: 1, a: 2 }\n") >= 1,
+            "dup key inside `export default` must be linted"
+        );
     }
 }
 

--- a/crates/tish_lsp/src/main.rs
+++ b/crates/tish_lsp/src/main.rs
@@ -210,6 +210,7 @@ fn compute_diagnostics(text: &str) -> Vec<Diagnostic> {
                     severity: Some(sev),
                     code: Some(NumberOrString::String(d.code.to_string())),
                     message: d.message,
+                    source: Some("tish".into()),
                     ..Default::default()
                 });
             }
@@ -219,6 +220,7 @@ fn compute_diagnostics(text: &str) -> Vec<Diagnostic> {
                     severity: Some(DiagnosticSeverity::ERROR),
                     code: Some(NumberOrString::String("tish-unresolved-name".into())),
                     message: format!("no binding in scope for `{}`", u.name),
+                    source: Some("tish".into()),
                     ..Default::default()
                 });
             }
@@ -265,6 +267,7 @@ fn compute_diagnostics(text: &str) -> Vec<Diagnostic> {
                 range: diag_range(l, c, text),
                 severity: Some(DiagnosticSeverity::ERROR),
                 message: e,
+                source: Some("tish".into()),
                 ..Default::default()
             });
         }


### PR DESCRIPTION
Two low-severity audit findings (tracked by #165):

- **#151** — `tish_lint` only recursed into `Named` exports, so rules inside `export default <expr>` were skipped (`export default { a: 1, a: 2 }` → no dup-key warning). Now walks the default-exported expression. Regression test added.
- **#155** — LSP lint / unresolved-name / parse-error diagnostics were emitted with `source: null`; unused/type set `source: "tish"`. Now all five producers stamp `source: "tish"` for consistent display/filtering.

Lint tests green; lsp builds.