### PR TITLE
fix(lsp): no "No binding in scope" on valid member-property hover (#159)

### DIFF
--- a/crates/tish_lsp/src/main.rs
+++ b/crates/tish_lsp/src/main.rs
@@ -720,6 +720,18 @@ impl LanguageServer for Backend {
                     }
                 } else {
                     let word = word_at_position(&text, pos);
+                    // On a member property (`obj.a`) there is no separate lexical binding, so
+                    // "No binding in scope" is misleading and disagrees with go-to-definition's
+                    // silent no-op on the same token. Show a neutral note there instead. (#159)
+                    let on_member_prop = tishlang_resolve::member_access_chain_at_cursor(
+                        &program, &text, pos.line, pos.character,
+                    )
+                    .is_some();
+                    let no_binding_msg = if on_member_prop {
+                        "\n\n_Object property._"
+                    } else {
+                        "\n\n_No binding in scope for this name._"
+                    };
                     if word.is_empty() {
                         md.push_str("\n\n_No binding in scope for this name._");
                     } else if let Ok(fp) = uri.to_file_path() {
@@ -750,10 +762,10 @@ impl LanguageServer for Backend {
                                 "\n\n[Open Rust implementation]({href}#L{line_1})"
                             ));
                         } else {
-                            md.push_str("\n\n_No binding in scope for this name._");
+                            md.push_str(no_binding_msg);
                         }
                     } else {
-                        md.push_str("\n\n_No binding in scope for this name._");
+                        md.push_str(no_binding_msg);
                     }
                 }
             }


### PR DESCRIPTION
Closes #159.

Hovering `a` in `obj.a` claimed "No binding in scope for this name." — misleading (object properties have no separate lexical binding) and inconsistent with go-to-definition's silent no-op on the same token. When the cursor is on a member chain (`member_access_chain_at_cursor`) and no native-member resolution applies, show a neutral "Object property" note instead. lsp 40/0.