### PR TITLE
fix(parser): block span ends at its closing brace, not the next token (#158)

### DIFF
--- a/crates/tish_parser/src/parser.rs
+++ b/crates/tish_parser/src/parser.rs
@@ -364,27 +364,21 @@ impl<'a> Parser<'a> {
             statements.push(self.parse_statement()?);
         }
 
+        // Block ends at its CLOSING `}`/`Dedent`. Capture that token's end BEFORE advancing past it:
+        // reading `self.peek()` *after* the advance pointed at the NEXT token, overrunning the block
+        // span onto the following statement — so a cursor on the line after `}` was still "inside"
+        // the block and completion offered the body's params/locals there (#158). Fall back to the
+        // last inner statement's end for an unterminated block at EOF, else the block start.
+        let mut closer_end: Option<(usize, usize)> = None;
         if matches!(
             self.peek_kind(),
             Some(TokenKind::RBrace | TokenKind::Dedent)
         ) {
+            closer_end = self.peek().map(|t| t.span.end);
             self.advance();
         }
-
-        let peek_end = self.peek().map(|x| x.span.end);
         let last_end = statements.last().map(|s| s.span().end);
-        let end = match (peek_end, last_end) {
-            (Some(p), Some(l)) => {
-                if p.0 > l.0 || (p.0 == l.0 && p.1 > l.1) {
-                    p
-                } else {
-                    l
-                }
-            }
-            (Some(p), None) => p,
-            (None, Some(l)) => l,
-            (None, None) => span_start,
-        };
+        let end = closer_end.or(last_end).unwrap_or(span_start);
 
         Ok(Statement::Block {
             statements,

--- a/crates/tish_resolve/src/lib.rs
+++ b/crates/tish_resolve/src/lib.rs
@@ -4381,6 +4381,20 @@ mod tests {
         assert!(names.iter().any(|n| n.as_ref() == "bar"));
     }
 
+    // #158: on the line AFTER a function's closing brace, completion must not leak the function's
+    // params or inner locals (the body Block span used to overrun onto that line). The top-level
+    // function name is still in scope.
+    #[test]
+    fn completion_does_not_leak_past_function_brace() {
+        let src = "fn f(paramA, paramB) {\n  let secret = 1\n}\nlet after = 0\n";
+        let program = parse(src).expect("parse");
+        let names = completion_value_names_at_cursor(&program, src, 3, 0); // start of `let after`
+        let has = |n: &str| names.iter().any(|x| x.as_ref() == n);
+        assert!(!has("paramA") && !has("paramB"), "params leaked past `}}`: {names:?}");
+        assert!(!has("secret"), "inner local leaked past `}}`: {names:?}");
+        assert!(has("f"), "top-level fn must stay in scope: {names:?}");
+    }
+
     #[test]
     fn unresolved_unknown_ident() {
         let src = "let x = nope\n";


### PR DESCRIPTION
Closes #158.

`parse_block` advanced past the closing `}`/`Dedent` and then read `self.peek().span.end` — by then the *next* token — so a block's span overran onto the following statement. Symptom: completion on the line right after a function's `}` offered the function's params/inner locals (the cursor looked "inside" the overrun body span), inserting names that don't resolve.

**Fix at the source:** capture the closing token's end *before* advancing and use it as the block end (fallback: last inner statement's end for an unterminated EOF block). A block now spans exactly `{`..`}` — also correct for folding ranges, document symbols, and hover, which were all getting a too-large range.

Metadata-only — execution unchanged (verified interp+vm output identical); the cross-backend integration suite (20/0) and parser/resolver/lint/lsp/fmt/vm/eval unit tests all pass. New resolver regression test: completion no longer leaks params/locals past `}`.