### PR TITLE
fix(parser): function span ends at its body's closing brace (#158 follow-up)

### DIFF
--- a/crates/tish_parser/src/lib.rs
+++ b/crates/tish_parser/src/lib.rs
@@ -45,6 +45,24 @@ mod tests {
         }
     }
 
+    // #158: a block's span — and the enclosing function's span — must end at the closing `}`, not
+    // overrun onto the statement on the following line.
+    #[test]
+    fn block_and_fn_spans_stop_at_closing_brace() {
+        // `}` is on line 3 (1-based); `let after` begins on line 4.
+        let program = parse("fn f(a) {\n  let x = a\n}\nlet after = 1\n").expect("parse");
+        let Statement::FunDecl { span, body, .. } = &program.statements[0] else {
+            panic!("expected FunDecl");
+        };
+        assert_eq!(span.end.0, 3, "fn span must end on the `}}` line, not the next statement: {span:?}");
+        assert_eq!(
+            body.span().end.0,
+            3,
+            "body block span must end on the `}}` line: {:?}",
+            body.span()
+        );
+    }
+
     #[test]
     fn test_object_literal_shorthand_single() {
         let program = parse("const o = { port }").expect("parse object shorthand");

--- a/crates/tish_parser/src/parser.rs
+++ b/crates/tish_parser/src/parser.rs
@@ -979,17 +979,12 @@ impl<'a> Parser<'a> {
             Box::new(self.parse_block()?)
         };
 
-        // Span must cover the whole declaration through the body. `peek().start` alone can sit on
-        // the opening `{` (same as `span_start` at EOF) or otherwise truncate before inner spans.
-        let peek_start = self.peek().map(|t| t.span.start).unwrap_or(span_start);
-        let body_end = body.as_ref().span().end;
-        let end = if peek_start.0 > body_end.0
-            || (peek_start.0 == body_end.0 && peek_start.1 > body_end.1)
-        {
-            peek_start
-        } else {
-            body_end
-        };
+        // The declaration spans from `fn`/`async` through the END of its body. `parse_block` now
+        // ends the body block exactly at its closing `}` (#158), so the body's end IS the function's
+        // end. (This previously maxed with `peek().start` — the NEXT token after the function — to
+        // compensate for the old block-span truncation, which instead overran the function span past
+        // `}` and inflated its folding / document-symbol range onto the following line. #158)
+        let end = body.as_ref().span().end;
 
         Ok(Statement::FunDecl {
             async_,


### PR DESCRIPTION
Companion to the #158 block-span fix. `parse_fun_decl` used `max(peek().start, body.span().end)`; with the body block span now ending at `}`, the `max` with `peek().start` (the next token) only overran the function span onto the following line — inflating its folding / document-symbol range. Use the body's end directly: a function spans `fn`…`}` exactly.

Span-metadata only (no execution change). New parser test pins the function span *and* its body block span to the `}` line; parser/resolver/lsp/lint/fmt tests all pass.