### PR TITLE
fix: -0 ToString is "0" across all backends; inspect keeps "-0" (#247)

### DIFF
--- a/crates/tish_core/src/value.rs
+++ b/crates/tish_core/src/value.rs
@@ -935,8 +935,10 @@ impl std::fmt::Debug for Value {
 /// We take the shortest round-tripping digits from Rust's `{:e}` (a Ryū/Grisu-class shortest
 /// formatter, matching V8's digit choice) and lay them out per the ECMAScript rule: plain
 /// decimal when the point position `n` is in `(-6, 21]`, otherwise `d[.ddd]e±E` with `E = n-1`
-/// (sign always shown, no leading zeros in the exponent). `-0` renders as `"-0"` (matching
-/// `console.log` and tish's existing behavior).
+/// (sign always shown, no leading zeros in the exponent). This is the ECMAScript `Number::toString`
+/// used by `.toString()`, `String(n)`, `+` concatenation, and template literals, so `-0` renders as
+/// `"0"` (the sign is dropped — `(-0).toString() === "0"`). The *inspect* form (`console.log` of a
+/// bare number / array element) keeps `"-0"`; that distinction lives in [`Value::to_display_string`].
 pub fn js_number_to_string(value: f64) -> String {
     if value.is_nan() {
         return "NaN".to_string();
@@ -948,7 +950,8 @@ pub fn js_number_to_string(value: f64) -> String {
         return "-Infinity".to_string();
     }
     if value == 0.0 {
-        return if value.is_sign_negative() { "-0" } else { "0" }.to_string();
+        // ECMAScript `Number::toString`: both `+0` and `-0` stringify to `"0"`.
+        return "0".to_string();
     }
 
     let negative = value < 0.0;
@@ -1001,6 +1004,9 @@ impl Value {
     /// Convert value to display string (for console output).
     pub fn to_display_string(&self) -> String {
         match self {
+            // Inspect form keeps the sign of negative zero (`console.log(-0)` → `-0`), unlike the
+            // ECMAScript ToString used by `to_js_string`. See `js_number_to_string`. (#247)
+            Value::Number(n) if *n == 0.0 && n.is_sign_negative() => "-0".to_string(),
             Value::Number(n) => js_number_to_string(*n),
             Value::String(s) => s.to_string(),
             Value::Bool(b) => b.to_string(),
@@ -1071,6 +1077,9 @@ impl Value {
                 .collect::<Vec<_>>()
                 .join(","),
             Value::Object(_) => "[object Object]".to_string(),
+            // ECMAScript ToString of a number (drops `-0`'s sign), distinct from the inspect form
+            // that `to_display_string` would give for `-0`. (#247)
+            Value::Number(n) => js_number_to_string(*n),
             // Primitives (and the remaining cases) coincide with the display form.
             _ => self.to_display_string(),
         }
@@ -1341,9 +1350,11 @@ mod number_to_string_tests {
     #[test]
     fn matches_javascript_number_tostring() {
         // (value, expected) — every `expected` is what Node's `String(value)` produces.
+        // `String(-0) === "0"`: ToString drops the sign of negative zero (the inspect form keeps
+        // it, but that path is `Value::to_display_string`, not this function). (#247)
         let cases: &[(f64, &str)] = &[
             (0.0, "0"),
-            (-0.0, "-0"),
+            (-0.0, "0"),
             (123.0, "123"),
             (123.456, "123.456"),
             (0.5, "0.5"),

--- a/crates/tish_eval/src/value.rs
+++ b/crates/tish_eval/src/value.rs
@@ -197,6 +197,10 @@ impl std::fmt::Debug for Value {
 impl std::fmt::Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            // Inspect form (`console.log`): keeps the sign of negative zero, unlike the ECMAScript
+            // ToString used by `to_js_string`. Matches Node's console output (`console.log(-0)` →
+            // `-0`). `to_js_string` has an explicit `Number` arm so ToString still drops it. (#247)
+            Value::Number(n) if *n == 0.0 && n.is_sign_negative() => write!(f, "-0"),
             // Match JS `Number.prototype.toString` (exponential past digit 21 / before −6),
             // shared with the VM/native path via `tishlang_core`.
             Value::Number(n) => write!(f, "{}", tishlang_core::js_number_to_string(*n)),
@@ -279,6 +283,10 @@ impl Value {
                 .collect::<Vec<_>>()
                 .join(","),
             Value::Object(_) => "[object Object]".to_string(),
+            // ECMAScript ToString of a number drops `-0`'s sign (`String(-0) === "0"`), distinct
+            // from the inspect `Display` above which keeps it. Explicit arm so the `_` fallback to
+            // `to_string()` (inspect) is not used for numbers. (#247)
+            Value::Number(n) => tishlang_core::js_number_to_string(*n),
             _ => self.to_string(),
         }
     }

--- a/crates/tish_opt/src/lib.rs
+++ b/crates/tish_opt/src/lib.rs
@@ -578,7 +578,9 @@ fn js_number_to_string(value: f64) -> String {
         return "-Infinity".to_string();
     }
     if value == 0.0 {
-        return if value.is_sign_negative() { "-0" } else { "0" }.to_string();
+        // ECMAScript `Number::toString`: both `+0` and `-0` → `"0"` (a constant-folded
+        // `"" + (-0)` must match the runtime ToString, not the inspect form). (#247)
+        return "0".to_string();
     }
     let negative = value < 0.0;
     let sci = format!("{:e}", value.abs());

--- a/tests/core/parity_builtins.js
+++ b/tests/core/parity_builtins.js
@@ -1,6 +1,6 @@
 // #247 cross-backend built-in divergences (Math round/min/max/hypot, parseInt radix, includes(NaN),
-// toFixed) — fixed to match the JS target. interp/vm/native/cranelift/node must all agree. Valid in
-// tish and node. (-0 toString and instanceof/at/findLast tracked separately.)
+// toFixed, -0 ToString) — fixed to match the JS target. interp/vm/native/cranelift/node must all
+// agree. Valid in tish and node. (instanceof/at/findLast tracked separately.)
 console.log("round-neg", Math.round(-2.5))
 console.log("round-pos", Math.round(2.5))
 console.log("round-half", Math.round(0.5))
@@ -20,3 +20,9 @@ console.log("parseint-neg", parseInt("-0x10", 16))
 console.log("tofixed", (2.5).toFixed(0))
 console.log("tofixed-neg", (-2.5).toFixed(0))
 console.log("tofixed-pi", (3.14159).toFixed(2))
+// -0 ToString drops the sign (`String(-0) === "0"`); the console *inspect* form keeps it.
+console.log("negzero-tostring", (-0).toString())
+console.log("negzero-string", String(-0))
+console.log("negzero-concat", "" + (-0))
+console.log("negzero-template", `${-0}`)
+console.log("negzero-inspect", -0)

--- a/tests/core/parity_builtins.tish
+++ b/tests/core/parity_builtins.tish
@@ -1,6 +1,6 @@
 // #247 cross-backend built-in divergences (Math round/min/max/hypot, parseInt radix, includes(NaN),
-// toFixed) — fixed to match the JS target. interp/vm/native/cranelift/node must all agree. Valid in
-// tish and node. (-0 toString and instanceof/at/findLast tracked separately.)
+// toFixed, -0 ToString) — fixed to match the JS target. interp/vm/native/cranelift/node must all
+// agree. Valid in tish and node. (instanceof/at/findLast tracked separately.)
 console.log("round-neg", Math.round(-2.5))
 console.log("round-pos", Math.round(2.5))
 console.log("round-half", Math.round(0.5))
@@ -20,3 +20,9 @@ console.log("parseint-neg", parseInt("-0x10", 16))
 console.log("tofixed", (2.5).toFixed(0))
 console.log("tofixed-neg", (-2.5).toFixed(0))
 console.log("tofixed-pi", (3.14159).toFixed(2))
+// -0 ToString drops the sign (`String(-0) === "0"`); the console *inspect* form keeps it.
+console.log("negzero-tostring", (-0).toString())
+console.log("negzero-string", String(-0))
+console.log("negzero-concat", "" + (-0))
+console.log("negzero-template", `${-0}`)
+console.log("negzero-inspect", -0)

--- a/tests/core/parity_builtins.tish.expected
+++ b/tests/core/parity_builtins.tish.expected
@@ -17,3 +17,8 @@ parseint-neg -16
 tofixed 3
 tofixed-neg -3
 tofixed-pi 3.14
+negzero-tostring 0
+negzero-string 0
+negzero-concat 0
+negzero-template 0
+negzero-inspect -0

--- a/tests/main.js
+++ b/tests/main.js
@@ -3076,8 +3076,8 @@ console.log("rotate", (((255 << 24) | (128 << 16)) >>> 0))
 
 {
 // #247 cross-backend built-in divergences (Math round/min/max/hypot, parseInt radix, includes(NaN),
-// toFixed) — fixed to match the JS target. interp/vm/native/cranelift/node must all agree. Valid in
-// tish and node. (-0 toString and instanceof/at/findLast tracked separately.)
+// toFixed, -0 ToString) — fixed to match the JS target. interp/vm/native/cranelift/node must all
+// agree. Valid in tish and node. (instanceof/at/findLast tracked separately.)
 console.log("round-neg", Math.round(-2.5))
 console.log("round-pos", Math.round(2.5))
 console.log("round-half", Math.round(0.5))
@@ -3097,6 +3097,12 @@ console.log("parseint-neg", parseInt("-0x10", 16))
 console.log("tofixed", (2.5).toFixed(0))
 console.log("tofixed-neg", (-2.5).toFixed(0))
 console.log("tofixed-pi", (3.14159).toFixed(2))
+// -0 ToString drops the sign (`String(-0) === "0"`); the console *inspect* form keeps it.
+console.log("negzero-tostring", (-0).toString())
+console.log("negzero-string", String(-0))
+console.log("negzero-concat", "" + (-0))
+console.log("negzero-template", `${-0}`)
+console.log("negzero-inspect", -0)
 }
 
 {

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3123,8 +3123,8 @@ __perf_run_core_parity_bitwise_int_domain()
 
 fn __perf_run_core_parity_builtins() {
 // #247 cross-backend built-in divergences (Math round/min/max/hypot, parseInt radix, includes(NaN),
-// toFixed) — fixed to match the JS target. interp/vm/native/cranelift/node must all agree. Valid in
-// tish and node. (-0 toString and instanceof/at/findLast tracked separately.)
+// toFixed, -0 ToString) — fixed to match the JS target. interp/vm/native/cranelift/node must all
+// agree. Valid in tish and node. (instanceof/at/findLast tracked separately.)
 console.log("round-neg", Math.round(-2.5))
 console.log("round-pos", Math.round(2.5))
 console.log("round-half", Math.round(0.5))
@@ -3144,6 +3144,12 @@ console.log("parseint-neg", parseInt("-0x10", 16))
 console.log("tofixed", (2.5).toFixed(0))
 console.log("tofixed-neg", (-2.5).toFixed(0))
 console.log("tofixed-pi", (3.14159).toFixed(2))
+// -0 ToString drops the sign (`String(-0) === "0"`); the console *inspect* form keeps it.
+console.log("negzero-tostring", (-0).toString())
+console.log("negzero-string", String(-0))
+console.log("negzero-concat", "" + (-0))
+console.log("negzero-template", `${-0}`)
+console.log("negzero-inspect", -0)
 }
 __perf_run_core_parity_builtins()
 


### PR DESCRIPTION
## What

The last open row of #247: `(-0).toString()`, `String(-0)`, `"" + (-0)`, and `` `${-0}` `` returned **`-0`** on interp/vm/native/cranelift, diverging from the JS target (Node) where ECMAScript `Number::toString` drops negative zero's sign (`String(-0) === "0"`). The console **inspect** form correctly keeps `-0` (`console.log(-0)` → `-0`).

The two were sharing one number formatter. This splits them:

- **`tish_core::js_number_to_string`** → `"0"` for ±0 (the spec ToString). The sign is preserved only in `Value::to_display_string` (inspect). `to_js_string` gets an explicit `Number` arm so ToString never falls through to the inspect form.
- **`tish_eval::Value`** mirrors the split: `Display` = inspect (`-0`), `to_js_string` = ToString (`0`).
- **`tish_opt`** keeps its duplicated `js_number_to_string` byte-for-byte in sync, so a constant-folded `"" + (-0)` matches the runtime (`0`).

## Result (all match Node)

| | interp | vm | native | js |
|---|---|---|---|---|
| `(-0).toString()` / `String(-0)` / `"" + (-0)` / `` `${-0}` `` | `0` | `0` | `0` | `0` |
| `console.log(-0)` (inspect) | `-0` | `-0` | `-0` | `-0` |

## Tests

- New `negzero-*` rows in `tests/core/parity_builtins.tish` (+ `.expected`, `.js`, regenerated CI bundle) lock it in — this was the last open #247 row.
- `test_mvp_programs_{interp_vm_stdout_parity,js,native,cranelift}` green; `tish_core`/`tish_opt`/`tish_eval` unit tests green.

The other 6 #247 rows (Math round/min/max/hypot, parseInt radix, includes(NaN), toFixed) were already fixed + probed.