### PR TITLE
feat(wasm): --target wasm-gpu — WebGPU runtime + start(chunk, host) loader (#277)

### DIFF
--- a/crates/tish/src/cli_help.rs
+++ b/crates/tish/src/cli_help.rs
@@ -406,6 +406,9 @@ pub fn build_after_help() -> String {
           JavaScript bundle
   {t}wasm{r}
           WebAssembly (.tish project; .js source supported on some paths)
+  {t}wasm-gpu{r}
+          WebAssembly + the WebGPU reflection bridge — emits a start(chunk, host) loader that
+          bootstraps WebGPU (device/queue/context/canvas) into the `host` global your program reads
   {t}wasi{r}
           WASI WebAssembly
   {t}bytecode{r}

--- a/crates/tish/src/main.rs
+++ b/crates/tish/src/main.rs
@@ -658,14 +658,23 @@ fn build_file(
         return compile_to_js(&input_path, output_path, optimize, source_map);
     }
 
-    if target == "wasm" && is_js {
+    // `wasm-gpu` (#277): same pipeline as `wasm` but builds the `--features gpu` WebGPU runtime and
+    // emits a `start(chunk, host)` loader that bootstraps WebGPU into the `host` global.
+    let wasm_gpu = target == "wasm-gpu";
+
+    if (target == "wasm" || wasm_gpu) && is_js {
         let source = fs::read_to_string(&input_path).map_err(|e| format!("{}", e))?;
         let program = tishlang_js_to_tish::convert(&source).map_err(|e| format!("{}", e))?;
-        return tishlang_wasm::compile_program_to_wasm(&program, Path::new(output_path), optimize)
-            .map_err(|e| format!("{}", e));
+        return tishlang_wasm::compile_program_to_wasm(
+            &program,
+            Path::new(output_path),
+            optimize,
+            wasm_gpu,
+        )
+        .map_err(|e| format!("{}", e));
     }
 
-    if target == "wasm" {
+    if target == "wasm" || wasm_gpu {
         let project_root = input_path.parent().and_then(|p| {
             if p.file_name().and_then(|n| n.to_str()) == Some("src") {
                 p.parent()
@@ -678,6 +687,7 @@ fn build_file(
             project_root,
             Path::new(output_path),
             optimize,
+            wasm_gpu,
         )
         .map_err(|e| e.to_string());
     }
@@ -720,7 +730,7 @@ fn build_file(
 
     if target != "native" {
         return Err(format!(
-            "Unknown target: {}. Use 'native', 'js', 'wasm', 'wasi', or 'bytecode'.",
+            "Unknown target: {}. Use 'native', 'js', 'wasm', 'wasm-gpu', 'wasi', or 'bytecode'.",
             target
         ));
     }

--- a/crates/tish_wasm/src/lib.rs
+++ b/crates/tish_wasm/src/lib.rs
@@ -88,6 +88,7 @@ pub fn compile_program_to_wasm(
     program: &Program,
     output_path: &Path,
     optimize: bool,
+    gpu: bool,
 ) -> Result<(), WasmError> {
     let program = if optimize {
         tishlang_opt::optimize(program)
@@ -103,10 +104,87 @@ pub fn compile_program_to_wasm(
             message: e.to_string(),
         })?
     };
-    emit_wasm_from_chunk(&chunk, output_path)
+    emit_wasm_from_chunk(&chunk, output_path, gpu)
 }
 
-fn emit_wasm_from_chunk(chunk: &Chunk, output_path: &Path) -> Result<(), WasmError> {
+/// The HTML loader emitted next to the wasm + JS glue. `gpu = false` imports `run` and calls
+/// `run(chunk)` (plain VM). `gpu = true` (#277) imports `start`, bootstraps WebGPU into a `host`
+/// env object, and calls `start(chunk, host)`. The GPU loader is a working default — edit
+/// `buildHost()` to add app assets, pick a specific canvas, or change the surface configuration.
+fn loader_html(stem: &str, chunk_b64: &str, gpu: bool) -> String {
+    let js_name = format!("{}.js", stem);
+    if gpu {
+        format!(
+            r#"<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>{title}</title><style>html,body{{margin:0;height:100%}}#tish-canvas{{width:100vw;height:100vh;display:block}}</style></head>
+<body>
+<canvas id="tish-canvas"></canvas>
+<script type="module">
+const CHUNK_B64 = "{chunk}";
+const chunk = Uint8Array.from(atob(CHUNK_B64), c => c.charCodeAt(0));
+import init, {{ start }} from './{js}';
+
+// The `host` global your tish program reads. Customize freely.
+async function buildHost() {{
+  if (!navigator.gpu) throw new Error("WebGPU not available (use a WebGPU-capable browser / context).");
+  const adapter = await navigator.gpu.requestAdapter();
+  if (!adapter) throw new Error("No WebGPU adapter.");
+  const device = await adapter.requestDevice();
+  const canvas = document.getElementById("tish-canvas");
+  const dpr = self.devicePixelRatio || 1;
+  canvas.width = Math.floor(canvas.clientWidth * dpr);
+  canvas.height = Math.floor(canvas.clientHeight * dpr);
+  const context = canvas.getContext("webgpu");
+  const format = navigator.gpu.getPreferredCanvasFormat();
+  context.configure({{ device, format, alphaMode: "opaque" }});
+  return {{ gpu: navigator.gpu, adapter, device, queue: device.queue, context, format, canvas, assets: {{}} }};
+}}
+
+try {{
+  const host = await buildHost();
+  await init();
+  start(chunk, host);
+}} catch (e) {{
+  document.body.innerHTML = "<pre style='color:#c00;padding:1rem;font:14px monospace'>" + (e && e.message || e) + "</pre>";
+  throw e;
+}}
+</script>
+</body>
+</html>
+"#,
+            title = stem,
+            chunk = chunk_b64,
+            js = js_name
+        )
+    } else {
+        format!(
+            r#"<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>{}</title></head>
+<body>
+<script type="module">
+const CHUNK_B64 = "{}";
+const chunk = Uint8Array.from(atob(CHUNK_B64), c => c.charCodeAt(0));
+import init, {{ run }} from './{}';
+await init();
+run(chunk);
+</script>
+</body>
+</html>
+"#,
+            stem, chunk_b64, js_name
+        )
+    }
+}
+
+/// Build the wasm runtime + emit the JS/HTML loader for a serialized `chunk`.
+///
+/// `gpu = false` → `--features browser`, plain `run(chunk)` VM entry (the default `--target wasm`).
+/// `gpu = true`  → `--features gpu`, the reflection WebGPU bridge ([`tishlang_wasm_runtime`]'s
+/// `gpu.rs`) and a `start(chunk, host)` entry; the emitted HTML bootstraps WebGPU (adapter/device/
+/// canvas/context) into the `host` global the tish program reads. (#277, `--target wasm-gpu`.)
+fn emit_wasm_from_chunk(chunk: &Chunk, output_path: &Path, gpu: bool) -> Result<(), WasmError> {
     let chunk_bytes = serialize(chunk);
     let chunk_b64 = BASE64.encode(&chunk_bytes);
     let stem = output_path
@@ -139,7 +217,7 @@ fn emit_wasm_from_chunk(chunk: &Chunk, output_path: &Path) -> Result<(), WasmErr
             "wasm32-unknown-unknown",
             "--release",
             "--features",
-            "browser",
+            if gpu { "gpu" } else { "browser" },
         ])
         .status()
         .map_err(|e| WasmError {
@@ -182,24 +260,7 @@ fn emit_wasm_from_chunk(chunk: &Chunk, output_path: &Path) -> Result<(), WasmErr
             message: "wasm-bindgen failed".to_string(),
         });
     }
-    let js_name = format!("{}.js", stem);
-    let html = format!(
-        r#"<!DOCTYPE html>
-<html>
-<head><meta charset="utf-8"><title>{}</title></head>
-<body>
-<script type="module">
-const CHUNK_B64 = "{}";
-const chunk = Uint8Array.from(atob(CHUNK_B64), c => c.charCodeAt(0));
-import init, {{ run }} from './{}';
-await init();
-run(chunk);
-</script>
-</body>
-</html>
-"#,
-        stem, chunk_b64, js_name
-    );
+    let html = loader_html(stem, &chunk_b64, gpu);
     let html_path = out_dir_abs.join(format!("{}.html", stem));
     std::fs::write(&html_path, html).map_err(|e| WasmError {
         message: format!("Cannot write {}: {}", html_path.display(), e),
@@ -221,14 +282,17 @@ run(chunk);
 /// - `{output}.html` — loader (open in browser)
 ///
 /// Requires: `rustup target add wasm32-unknown-unknown`, `wasm-bindgen-cli`
+/// `gpu = true` targets the WebGPU runtime (`--features gpu`, `start(chunk, host)` entry); see
+/// [`emit_wasm_from_chunk`]. (#277, exposed as `--target wasm-gpu`.)
 pub fn compile_to_wasm(
     entry_path: &Path,
     project_root: Option<&Path>,
     output_path: &Path,
     optimize: bool,
+    gpu: bool,
 ) -> Result<(), WasmError> {
     let (chunk, _) = resolve_and_compile_to_chunk(entry_path, project_root, optimize)?;
-    emit_wasm_from_chunk(&chunk, output_path)
+    emit_wasm_from_chunk(&chunk, output_path, gpu)
 }
 
 /// Compile a Tish project to a raw serialized bytecode chunk.
@@ -425,4 +489,34 @@ fn main() {
         final_wasm.display()
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::loader_html;
+
+    #[test]
+    fn gpu_loader_uses_start_and_bootstraps_webgpu() {
+        // #277: the wasm-gpu loader must call the `start(chunk, host)` entry (not `run`) and build
+        // the WebGPU `host` env (adapter/device/context) the tish program reads.
+        let html = loader_html("viz", "QkFTRTY0", true);
+        assert!(html.contains("import init, { start }"), "imports start");
+        assert!(html.contains("start(chunk, host)"), "calls start with host");
+        assert!(html.contains("navigator.gpu.requestAdapter()"), "bootstraps adapter");
+        assert!(html.contains("getContext(\"webgpu\")"), "configures the canvas context");
+        assert!(html.contains("device, queue: device.queue, context, format, canvas"), "host shape");
+        assert!(html.contains("from './viz.js'"), "imports the right glue");
+        assert!(!html.contains("run(chunk)"), "must NOT use the plain run() entry");
+        assert!(html.contains("QkFTRTY0"), "embeds the chunk");
+    }
+
+    #[test]
+    fn plain_loader_uses_run() {
+        let html = loader_html("app", "QkFTRTY0", false);
+        assert!(html.contains("import init, { run }"), "imports run");
+        assert!(html.contains("run(chunk)"), "calls run");
+        assert!(!html.contains("start("), "no gpu start entry");
+        assert!(!html.contains("requestAdapter"), "no webgpu bootstrap");
+        assert!(html.contains("from './app.js'"), "imports the right glue");
+    }
 }


### PR DESCRIPTION
Closes #277.

## Problem
`tish build --target wasm` hardcoded `--features browser` + a `run(chunk)` loader, so the reflection-based WebGPU bridge already in `tishlang_wasm_runtime/src/gpu.rs` (`--features gpu`, `start(chunk, host)` entry) was **built-but-unreachable** from the CLI. A WebGPU project had to hand-roll `cargo build --features gpu` + a custom loader, coupling to gpu.rs internals.

## Fix — `--target wasm-gpu` (issue option 1, which also delivers option 2)
Same pipeline as `wasm`, but:
- builds `tishlang_wasm_runtime` with **`--features gpu`**, and
- emits an HTML loader that bootstraps WebGPU (`requestAdapter`→device, canvas→`context.configure` with the preferred format) into a `host` env `{ gpu, adapter, device, queue, context, format, canvas, assets }` and calls **`start(chunk, host)`**.

The loader is a working, **editable** default — its `buildHost()` is the documented host-env contract, so apps customize the canvas/assets without reverse-engineering `gpu.rs`. Plain `--target wasm` is byte-for-byte unchanged.

## Implementation
- Threads `gpu: bool` through `compile_to_wasm` / `compile_program_to_wasm` / `emit_wasm_from_chunk` (only callers were in `main.rs`).
- Extracts the loader into a pure `loader_html(stem, chunk_b64, gpu)` — **unit-tested** (gpu→`start`+WebGPU bootstrap+host shape, no `run`; plain→`run`, no bootstrap).
- `--help` build-targets + unknown-target error updated.

## Validation
- `cargo build --release --bin tish` clean; `cargo test -p tishlang_wasm` green (2 new loader tests).
- `cargo build -p tishlang_wasm_runtime --target wasm32-unknown-unknown --features gpu` builds clean.
- `tish build --target wasm-gpu` compiles the gpu runtime and reaches wasm-bindgen (the bindgen version-skew in my local env is pre-existing — identical for `--target wasm` — and unrelated to this change).