### PR TITLE
feat(vite): in-graph HMR for .tish modules via @tishlang/vite-plugin-tish (#284)

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -11,7 +11,8 @@
 # durable option). This requires a ONE-TIME setup on npmjs.com for EACH package
 # below; until that is done a publish fails with E404/E422. For every package
 # (@tishlang/tish, @tishlang/cargo-bindgen, @tishlang/tish-format, @tishlang/tish-lint,
-# @tishlang/pg, @tishlang/create-tish-app, and unscoped create-tish-app) open
+# @tishlang/tish-lsp, @tishlang/pg, @tishlang/create-tish-app, @tishlang/vite-plugin-tish,
+# and unscoped create-tish-app) open
 # npmjs.com > the package > Settings > "Trusted Publisher" > GitHub Actions and set:
 #   Organization or user: tishlang
 #   Repository:           tish
@@ -69,6 +70,10 @@ jobs:
             npm: "@tishlang/create-tish-app"
             type: source
             dir: create-tish-app
+          - label: "@tishlang/vite-plugin-tish"
+            npm: "@tishlang/vite-plugin-tish"
+            type: source
+            dir: vite-plugin-tish
           # Unscoped alias of create-tish-app — published as its own package, non-fatal.
           - label: "create-tish-app (unscoped)"
             npm: "create-tish-app"
@@ -178,6 +183,7 @@ jobs:
           NPM_LINT_URL="https://www.npmjs.com/package/@tishlang/tish-lint/v/${VERSION}"
           CTA_SCOPED="https://www.npmjs.com/package/@tishlang/create-tish-app/v/${VERSION}"
           CTA_UNSCOPED="https://www.npmjs.com/package/create-tish-app/v/${VERSION}"
+          VITE_PLUGIN_URL="https://www.npmjs.com/package/@tishlang/vite-plugin-tish/v/${VERSION}"
           CRATES_URL="https://crates.io/crates/tishlang/${VERSION}"
           RELEASE_ID="${{ github.event.release.id }}"
           REPO="${{ github.repository }}"
@@ -192,7 +198,7 @@ jobs:
           NEW_BODY="${CURRENT_BODY}
 
           ---
-          Published to npm: ${NPM_URL} | cargo-bindgen: ${NPM_BINDGEN_URL} | tish-format: ${NPM_FORMAT_URL} | tish-lint: ${NPM_LINT_URL} | create-tish-app: ${CTA_SCOPED} · ${CTA_UNSCOPED} | crates.io: ${CRATES_URL}"
+          Published to npm: ${NPM_URL} | cargo-bindgen: ${NPM_BINDGEN_URL} | tish-format: ${NPM_FORMAT_URL} | tish-lint: ${NPM_LINT_URL} | create-tish-app: ${CTA_SCOPED} · ${CTA_UNSCOPED} | vite-plugin-tish: ${VITE_PLUGIN_URL} | crates.io: ${CRATES_URL}"
           curl -s -X PATCH \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/vite-plugin-tish.yml
+++ b/.github/workflows/vite-plugin-tish.yml
@@ -1,0 +1,61 @@
+name: vite-plugin-tish
+
+# Tests the official Vite plugin (@tishlang/vite-plugin-tish, #284). The plugin shells out to the
+# `tish` CLI's `compile-module` subcommand, so we build the CLI first and point the tests at it via
+# TISH_PATH. Triggers when the plugin or the compile paths it depends on change.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "npm/vite-plugin-tish/**"
+      - "npm/package.json"
+      - "npm/package-lock.json"
+      - "crates/tish_compile_js/**"
+      - "crates/tish/**"
+      - ".github/workflows/vite-plugin-tish.yml"
+  pull_request:
+    paths:
+      - "npm/vite-plugin-tish/**"
+      - "npm/package.json"
+      - "npm/package-lock.json"
+      - "crates/tish_compile_js/**"
+      - "crates/tish/**"
+      - ".github/workflows/vite-plugin-tish.yml"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      - name: Build tish CLI
+        run: cargo build -p tishlang --bin tish
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # `--ignore-scripts` skips the other npm workspaces' postinstall binary downloads (tish,
+      # cargo-bindgen, create-tish-app); the plugin tests use the cargo-built CLI via TISH_PATH.
+      - name: Install npm dependencies
+        working-directory: npm
+        run: npm ci --ignore-scripts
+
+      - name: Run vite-plugin-tish tests
+        working-directory: npm
+        env:
+          TISH_PATH: ${{ github.workspace }}/target/debug/tish
+        run: npm test --workspace @tishlang/vite-plugin-tish

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,6 +3205,7 @@ dependencies = [
  "mimalloc",
  "rayon",
  "rustyline",
+ "serde_json",
  "tempfile",
  "tishlang_ast",
  "tishlang_bytecode",

--- a/crates/tish/Cargo.toml
+++ b/crates/tish/Cargo.toml
@@ -59,6 +59,7 @@ tishlang_runtime = { path = "../tish_runtime", version = ">=0.1" }
 tishlang_core = { path = "../tish_core", version = ">=0.1" }
 tishlang_js_to_tish = { path = "../js_to_tish", version = ">=0.1" }
 clap = { version = "4.6.0", features = ["derive", "color"] }
+serde_json = "1"
 tishlang_pg = { path = "../tish_pg", version = ">=0.1", optional = true }
 mimalloc = { version = "0.1", optional = true }
 

--- a/crates/tish/src/cli_help.rs
+++ b/crates/tish/src/cli_help.rs
@@ -571,6 +571,34 @@ pub(crate) struct BuildArgs {
     pub file: String,
 }
 
+#[derive(Parser)]
+pub(crate) struct CompileModuleArgs {
+    /// `--target js` only (the single-module ESM path is JS-specific).
+    #[arg(long, default_value = "js", value_name = "TARGET", help_heading = "Options")]
+    pub target: String,
+    /// `--format esm` only (one ES module per file).
+    #[arg(long, default_value = "esm", value_name = "FORMAT", help_heading = "Options")]
+    pub format: String,
+    /// Keep relative `.tish` specifiers and bare packages verbatim so Vite's resolveId/load re-enters the plugin per module (in-graph HMR). Omit for disk-style `.tish`->`.js` rewriting.
+    #[arg(long, help_heading = "Options")]
+    pub vite_dev: bool,
+    /// Emit a v3 source map back to the `.tish` source as a `{ "js", "map" }` JSON envelope on stdout (on by default; implies no optimization).
+    #[arg(long, help_heading = "Options")]
+    pub source_map: bool,
+    /// Disable the source map; print raw ES module JS to stdout instead of the JSON envelope.
+    #[arg(long = "no-source-map", help_heading = "Options")]
+    pub no_source_map: bool,
+    /// Project root for resolving bare specifiers / `node_modules` (defaults to the file's parent).
+    #[arg(long, value_name = "DIR", help_heading = "Options")]
+    pub project_root: Option<String>,
+    /// Disable AST optimizations (forced on when a source map is emitted).
+    #[arg(long, help_heading = "Options")]
+    pub no_optimize: bool,
+    /// Entry `.tish` file to compile (only this file is read; dependencies are left to the bundler).
+    #[arg(required = true, value_name = "FILE", help_heading = "Arguments")]
+    pub file: String,
+}
+
 #[derive(Subcommand)]
 pub(crate) enum Commands {
     /// Run a Tish file (interpret)
@@ -579,6 +607,9 @@ pub(crate) enum Commands {
     Repl(ReplArgs),
     /// Build native binary, wasm, wasi, or JavaScript output
     Build(BuildArgs),
+    /// Compile a single `.tish` module to one ES module (for Vite dev / HMR); prints to stdout
+    #[command(name = "compile-module")]
+    CompileModule(CompileModuleArgs),
     /// Parse and dump AST
     #[command(name = "dump-ast")]
     DumpAst {

--- a/crates/tish/src/main.rs
+++ b/crates/tish/src/main.rs
@@ -22,7 +22,7 @@ use tishlang_core::VmRef;
 use clap::FromArgMatches;
 use rustyline::{Behavior, ColorMode, CompletionType, Config, Editor};
 
-use cli_help::{Cli, Commands};
+use cli_help::{Cli, Commands, CompileModuleArgs};
 
 /// Normalize `--feature` / `--feature http,timers,fs` / `--feature full` for VM runs and native builds.
 fn normalize_capability_flags(features: &[String]) -> HashSet<String> {
@@ -73,7 +73,7 @@ fn native_build_features_from_cli(cli_features: &[String]) -> Vec<String> {
 fn argv_with_implicit_run(mut argv: Vec<String>) -> Vec<String> {
     if argv.len() >= 2 {
         let first = argv[1].as_str();
-        const SUBCOMMANDS: &[&str] = &["run", "repl", "build", "dump-ast"];
+        const SUBCOMMANDS: &[&str] = &["run", "repl", "build", "compile-module", "dump-ast"];
         let looks_like_file = !first.starts_with('-') && !SUBCOMMANDS.contains(&first);
         if looks_like_file {
             argv.insert(1, "run".to_string());
@@ -139,6 +139,7 @@ fn main() {
                 &a.format,
             )
         }
+        Some(Commands::CompileModule(a)) => compile_module(&a),
         Some(Commands::DumpAst {
             file,
             ignore_indent,
@@ -699,6 +700,71 @@ fn compile_to_js_esm(
         .map(|m| m.relative_path.clone())
     {
         println!("Entry: {}", out_dir.join(entry_rel).display());
+    }
+    Ok(())
+}
+
+/// `tish compile-module FILE` (#284): compile a single `.tish` file to one ES module and print it
+/// to stdout. This is the fast, in-graph path the Vite plugin shells out to in `load()` — only the
+/// one file is read (no dependency graph resolution), so Vite owns the module graph and can HMR a
+/// leaf module without a full reload.
+///
+/// With a source map (default), stdout is a JSON envelope `{"js":…,"map":…}` so the plugin gets
+/// both artifacts from one spawn; with `--no-source-map`, stdout is raw ES module JS.
+fn compile_module(args: &CompileModuleArgs) -> Result<(), String> {
+    if args.target != "js" {
+        return Err(format!(
+            "tish compile-module only supports --target js (got '{}').",
+            args.target
+        ));
+    }
+    if args.format != "esm" {
+        return Err(format!(
+            "tish compile-module only supports --format esm (got '{}').",
+            args.format
+        ));
+    }
+    let input_path = Path::new(&args.file)
+        .canonicalize()
+        .map_err(|e| format!("Cannot resolve {}: {}", args.file, e))?;
+    if input_path.extension().map(|e| e != "tish").unwrap_or(true) {
+        return Err(format!(
+            "tish compile-module expects a .tish file (got '{}').",
+            args.file
+        ));
+    }
+    let want_map = !args.no_source_map;
+    // A source map needs unmerged statement order, so it forces no optimization (same rule as
+    // `build --target js --source-map`).
+    let optimize = !args.no_optimize && !want_map;
+    let import_rewrite = if args.vite_dev {
+        tishlang_compile_js::ImportRewrite::ViteDev
+    } else {
+        tishlang_compile_js::ImportRewrite::Disk
+    };
+    let project_root = args
+        .project_root
+        .as_ref()
+        .map(PathBuf::from)
+        .or_else(|| input_path.parent().map(Path::to_path_buf));
+    let bundle = tishlang_compile_js::compile_module_esm(
+        &input_path,
+        project_root.as_deref(),
+        optimize,
+        import_rewrite,
+        want_map,
+    )
+    .map_err(|e| format!("{}", e))?;
+
+    if let Some(map_json) = bundle.source_map_json {
+        let map: serde_json::Value = serde_json::from_str(&map_json)
+            .map_err(|e| format!("Internal: source map is not valid JSON: {}", e))?;
+        let envelope = serde_json::json!({ "js": bundle.js, "map": map });
+        let line = serde_json::to_string(&envelope)
+            .map_err(|e| format!("Cannot serialize compile-module output: {}", e))?;
+        println!("{}", line);
+    } else {
+        print!("{}", bundle.js);
     }
     Ok(())
 }

--- a/crates/tish/tests/integration_test.rs
+++ b/crates/tish/tests/integration_test.rs
@@ -738,6 +738,114 @@ fn test_js_esm_export_collision() {
     }
 }
 
+/// #284: `tish compile-module --vite-dev --source-map` compiles a single `.tish` file (no graph
+/// resolution) to one ES module, keeps relative `.tish` specifiers, and emits a `{ js, map }` JSON
+/// envelope whose map references the `.tish` source. This is the in-graph path the Vite plugin uses.
+#[test]
+fn test_compile_module_vite_dev_with_source_map() {
+    let bin = tish_bin();
+    if !bin.exists() {
+        return;
+    }
+    let main = workspace_root()
+        .join("tests")
+        .join("modules")
+        .join("esm")
+        .join("vite_hmr")
+        .join("main.tish");
+    if !main.exists() {
+        return;
+    }
+    let out = Command::new(&bin)
+        .args(["compile-module"])
+        .arg(&main)
+        .args([
+            "--target",
+            "js",
+            "--format",
+            "esm",
+            "--vite-dev",
+            "--source-map",
+        ])
+        .current_dir(workspace_root())
+        .output()
+        .expect("run compile-module");
+    assert!(
+        out.status.success(),
+        "compile-module failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("stdout is not JSON: {e}\n{stdout}"));
+    let js = parsed["js"].as_str().expect("envelope has string `js`");
+    assert!(
+        js.contains("import { makeCounter } from \"./counter.tish\";"),
+        "Vite-dev keeps the .tish specifier:\n{js}"
+    );
+    assert!(
+        !js.contains("./counter.js"),
+        "Vite-dev must not rewrite .tish to .js:\n{js}"
+    );
+    let map = &parsed["map"];
+    assert!(map.is_object(), "envelope has object `map`: {map}");
+    assert_eq!(map["version"], serde_json::json!(3), "v3 source map");
+    let sources = map["sources"].as_array().expect("map has sources");
+    assert!(
+        sources
+            .iter()
+            .any(|s| s.as_str().map(|s| s.contains("main.tish")).unwrap_or(false)),
+        "map sources reference the .tish file: {sources:?}"
+    );
+}
+
+/// #284: without `--source-map`, `compile-module` prints raw ES module JS to stdout (no envelope),
+/// so the output can be consumed directly.
+#[test]
+fn test_compile_module_no_source_map_prints_raw_js() {
+    let bin = tish_bin();
+    if !bin.exists() {
+        return;
+    }
+    let counter = workspace_root()
+        .join("tests")
+        .join("modules")
+        .join("esm")
+        .join("vite_hmr")
+        .join("counter.tish");
+    if !counter.exists() {
+        return;
+    }
+    let out = Command::new(&bin)
+        .args(["compile-module"])
+        .arg(&counter)
+        .args([
+            "--target",
+            "js",
+            "--format",
+            "esm",
+            "--vite-dev",
+            "--no-source-map",
+        ])
+        .current_dir(workspace_root())
+        .output()
+        .expect("run compile-module");
+    assert!(
+        out.status.success(),
+        "compile-module failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("export function makeCounter"),
+        "raw JS output includes the export:\n{stdout}"
+    );
+    assert!(
+        !stdout.trim_start().starts_with('{'),
+        "no-source-map output is raw JS, not a JSON envelope:\n{stdout}"
+    );
+}
+
 /// Ignored: tishlang_eval::run() does not run the event loop.
 #[test]
 #[cfg(feature = "http")]

--- a/crates/tish_compile_js/src/codegen.rs
+++ b/crates/tish_compile_js/src/codegen.rs
@@ -1334,7 +1334,15 @@ pub fn compile_module_esm(
             Some((stmt_sources.as_slice(), root_canon.as_path())),
             Some(&mut builder),
         )?;
-        let sm = builder.into_sourcemap();
+        let mut sm = builder.into_sourcemap();
+        // Embed the original `.tish` so consumers (Vite, browser devtools) never resolve
+        // `sources` from disk. The map's `sources` are project-root-relative, but Vite resolves
+        // them against the module's own directory; without inline content it logs
+        // "Sourcemap ... points to missing source files" and devtools can't show the original.
+        let source_count = sm.get_source_count();
+        for id in 0..source_count {
+            sm.set_source_contents(id, Some(&source));
+        }
         let mut v = Vec::new();
         sm.to_writer(&mut v).map_err(|e| CompileError {
             message: e.to_string(),

--- a/crates/tish_compile_js/src/codegen.rs
+++ b/crates/tish_compile_js/src/codegen.rs
@@ -20,11 +20,23 @@ enum EmitMode {
     Esm,
 }
 
+/// How ESM import specifiers are rewritten. `Disk` (production `--format esm`) rewrites `.tish`
+/// specifiers to their sibling `.js` output paths and resolves bare specifiers to relative paths
+/// into the emitted module tree. `ViteDev` keeps relative `.tish` specifiers and bare specifiers
+/// as-is so Vite's `resolveId`/`load` re-enters the plugin per module (in-graph HMR, issue #284).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportRewrite {
+    Disk,
+    ViteDev,
+}
+
 struct Codegen {
     output: String,
     indent: usize,
     in_async: bool,
     emit_mode: EmitMode,
+    /// ESM only: how import specifiers are rewritten (disk `.js` paths vs Vite-dev `.tish`).
+    import_rewrite: ImportRewrite,
     /// ESM only: the absolute path of the module being emitted (the importer), used to rewrite
     /// relative/bare import specifiers to sibling `.js` output paths.
     module_path: PathBuf,
@@ -48,17 +60,19 @@ impl Codegen {
             indent: 0,
             in_async: false,
             emit_mode: EmitMode::Bundle,
+            import_rewrite: ImportRewrite::Disk,
             module_path: PathBuf::new(),
             project_root: PathBuf::new(),
         }
     }
 
-    fn new_esm(module_path: PathBuf, project_root: PathBuf) -> Self {
+    fn new_esm(module_path: PathBuf, project_root: PathBuf, import_rewrite: ImportRewrite) -> Self {
         Self {
             output: String::new(),
             indent: 0,
             in_async: false,
             emit_mode: EmitMode::Esm,
+            import_rewrite,
             module_path,
             project_root,
         }
@@ -907,7 +921,12 @@ impl Codegen {
         specifiers: &[ImportSpecifier],
         from: &str,
     ) -> Result<(), CompileError> {
-        let spec = rewrite_import_to_js(from, &self.module_path, &self.project_root)?;
+        let spec = rewrite_import_to_js(
+            from,
+            &self.module_path,
+            &self.project_root,
+            self.import_rewrite,
+        )?;
         let mut named: Vec<String> = Vec::new();
         let mut default_local: Option<String> = None;
         let mut namespace_local: Option<String> = None;
@@ -987,6 +1006,7 @@ fn rewrite_import_to_js(
     spec: &str,
     importer_abs: &Path,
     project_root: &Path,
+    rewrite: ImportRewrite,
 ) -> Result<String, CompileError> {
     if tishlang_compile::is_native_import(spec) {
         return Err(CompileError {
@@ -995,6 +1015,11 @@ fn rewrite_import_to_js(
                 spec
             ),
         });
+    }
+    // Vite dev keeps specifiers verbatim: relative `.tish` paths and bare packages are left for the
+    // plugin's `resolveId`/`load` (relative) or Node/Vite resolution (bare) to handle per-module.
+    if rewrite == ImportRewrite::ViteDev {
+        return Ok(spec.to_string());
     }
     if spec.starts_with("./") || spec.starts_with("../") {
         return Ok(spec_ext_to_js(spec));
@@ -1249,7 +1274,8 @@ pub fn compile_project_esm(
         } else {
             module.program.clone()
         };
-        let mut gen = Codegen::new_esm(mod_canon.clone(), res_root_canon.clone());
+        let mut gen =
+            Codegen::new_esm(mod_canon.clone(), res_root_canon.clone(), ImportRewrite::Disk);
         gen.emit_program(&program, None, None)?;
         out.push(EmittedJsModule {
             relative_path: rel_js,
@@ -1257,6 +1283,76 @@ pub fn compile_project_esm(
         });
     }
     Ok(out)
+}
+
+/// Compile a **single** `.tish` module to one ES module (issue #284, Vite dev / HMR). Unlike
+/// [`compile_project_esm`], the dependency graph is **not** resolved — only `module_path` is read
+/// and parsed — so a Vite plugin can compile one file per `load()` and let Vite own the module
+/// graph. With `ImportRewrite::ViteDev` relative `.tish` specifiers and bare packages are preserved
+/// so Vite re-enters the plugin per dependency. When `source_map` is set, a v3 map back to the
+/// `.tish` source is returned (requires `optimize == false`, matching the bundle source-map rule).
+pub fn compile_module_esm(
+    module_path: &Path,
+    project_root: Option<&Path>,
+    optimize: bool,
+    import_rewrite: ImportRewrite,
+    source_map: bool,
+) -> Result<JsBundle, CompileError> {
+    if source_map && optimize {
+        return Err(CompileError {
+            message: "source map requires no optimization (mappings follow unmerged statement order)."
+                .into(),
+        });
+    }
+    let source = std::fs::read_to_string(module_path).map_err(|e| CompileError {
+        message: format!("Cannot read {}: {}", module_path.display(), e),
+    })?;
+    let parsed = tishlang_parser::parse(&source).map_err(|e| CompileError {
+        message: format!("Parse error in {}: {}", module_path.display(), e),
+    })?;
+    let program = if optimize {
+        tishlang_opt::optimize(&parsed)
+    } else {
+        parsed
+    };
+    let module_canon = module_path
+        .canonicalize()
+        .unwrap_or_else(|_| module_path.to_path_buf());
+    let root = project_root
+        .map(Path::to_path_buf)
+        .or_else(|| module_path.parent().map(Path::to_path_buf))
+        .unwrap_or_else(|| PathBuf::from("."));
+    let root_canon = root.canonicalize().unwrap_or(root);
+
+    let mut gen = Codegen::new_esm(module_canon.clone(), root_canon.clone(), import_rewrite);
+    if source_map {
+        let stmt_sources = vec![module_canon.clone(); program.statements.len()];
+        let mut builder = SourceMapBuilder::new(Some("module.js"));
+        builder.set_source_root(Some(""));
+        gen.emit_program(
+            &program,
+            Some((stmt_sources.as_slice(), root_canon.as_path())),
+            Some(&mut builder),
+        )?;
+        let sm = builder.into_sourcemap();
+        let mut v = Vec::new();
+        sm.to_writer(&mut v).map_err(|e| CompileError {
+            message: e.to_string(),
+        })?;
+        let map_json = String::from_utf8(v).map_err(|e| CompileError {
+            message: e.to_string(),
+        })?;
+        Ok(JsBundle {
+            js: gen.output,
+            source_map_json: Some(map_json),
+        })
+    } else {
+        gen.emit_program(&program, None, None)?;
+        Ok(JsBundle {
+            js: gen.output,
+            source_map_json: None,
+        })
+    }
 }
 
 /// Deepest directory that is an ancestor of every given file path, compared component-wise. Used as

--- a/crates/tish_compile_js/src/lib.rs
+++ b/crates/tish_compile_js/src/lib.rs
@@ -8,8 +8,9 @@ mod error;
 mod tests_jsx;
 
 pub use codegen::{
-    compile_project_esm, compile_project_with_jsx, compile_project_with_jsx_and_source_map,
-    compile_with_jsx, EmittedJsModule, JsBundle,
+    compile_module_esm, compile_project_esm, compile_project_with_jsx,
+    compile_project_with_jsx_and_source_map, compile_with_jsx, EmittedJsModule, ImportRewrite,
+    JsBundle,
 };
 pub use error::CompileError;
 

--- a/crates/tish_compile_js/src/tests_jsx.rs
+++ b/crates/tish_compile_js/src/tests_jsx.rs
@@ -773,6 +773,28 @@ fn factory() {
     }
 
     #[test]
+    fn compile_module_esm_source_map_embeds_sources_content() {
+        // The map must carry sourcesContent so Vite/devtools never resolve `sources` from disk
+        // (otherwise Vite warns "Sourcemap ... points to missing source files").
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+        let p = dir.join("main.tish");
+        let src = "export fn greet(n) { return \"hi \" + n }\n";
+        std::fs::write(&p, src).unwrap();
+        let bundle =
+            compile_module_esm(&p, Some(dir), false, ImportRewrite::ViteDev, true).unwrap();
+        let map = bundle.source_map_json.expect("source map requested");
+        assert!(
+            map.contains("\"sourcesContent\""),
+            "map must include a sourcesContent field:\n{map}"
+        );
+        assert!(
+            map.contains("export fn greet"),
+            "sourcesContent must embed the original .tish source:\n{map}"
+        );
+    }
+
+    #[test]
     fn compile_module_esm_source_map_requires_no_optimize() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let dir = tmp.path();

--- a/crates/tish_compile_js/src/tests_jsx.rs
+++ b/crates/tish_compile_js/src/tests_jsx.rs
@@ -4,7 +4,10 @@ mod tests {
 
     use tishlang_parser::parse;
 
-    use crate::{compile_project_esm, compile_project_with_jsx, compile_with_jsx, EmittedJsModule};
+    use crate::{
+        compile_module_esm, compile_project_esm, compile_project_with_jsx, compile_with_jsx,
+        EmittedJsModule, ImportRewrite,
+    };
 
     #[test]
     fn lattish_jsx_emits_h_with_children_array() {
@@ -636,6 +639,150 @@ fn factory() {
         assert!(
             err.message.contains("Native module import") && err.message.contains("esm"),
             "expected a native-import rejection for ESM, got: {}",
+            err.message
+        );
+    }
+
+    // ── #284: single-module compile for Vite dev (in-graph HMR) ───────────────────────────────
+
+    /// Write `modules` into a fresh temp dir and compile just `entry` (no graph resolution),
+    /// in Vite-dev import-rewrite mode without a source map.
+    fn build_module_vite(entry: &str, modules: &[(&str, &str)]) -> String {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+        for (rel, src) in modules {
+            let p = dir.join(rel);
+            if let Some(parent) = p.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            let mut f = std::fs::File::create(&p).unwrap();
+            f.write_all(src.as_bytes()).unwrap();
+            f.sync_all().unwrap();
+        }
+        compile_module_esm(
+            &dir.join(entry),
+            Some(dir),
+            false,
+            ImportRewrite::ViteDev,
+            false,
+        )
+        .expect("compile_module_esm failed")
+        .js
+    }
+
+    #[test]
+    fn compile_module_esm_vite_preserves_relative_tish_imports() {
+        let js = build_module_vite(
+            "main.tish",
+            &[(
+                "main.tish",
+                "import { id } from \"./dep.tish\"\nconsole.log(id(1))\n",
+            )],
+        );
+        assert!(
+            js.contains("import { id } from \"./dep.tish\";"),
+            "Vite dev keeps the .tish specifier so resolveId re-enters the plugin:\n{js}"
+        );
+        assert!(
+            !js.contains("./dep.js"),
+            "Vite dev must NOT rewrite .tish to .js:\n{js}"
+        );
+    }
+
+    #[test]
+    fn compile_module_esm_vite_leaves_bare_specifiers_unchanged() {
+        let js = build_module_vite(
+            "main.tish",
+            &[(
+                "main.tish",
+                "import { h } from \"lattish\"\nconsole.log(h)\n",
+            )],
+        );
+        assert!(
+            js.contains("import { h } from \"lattish\";"),
+            "bare specifier passes through for normal Node/Vite resolution:\n{js}"
+        );
+    }
+
+    #[test]
+    fn compile_module_esm_vite_emits_exports() {
+        let js = build_module_vite(
+            "main.tish",
+            &[(
+                "main.tish",
+                "export const VERSION = \"1.0\"\nexport fn greet(n) { return \"hi \" + n }\nexport default greet\n",
+            )],
+        );
+        assert!(js.contains("export const VERSION = \"1.0\";"), "named const export:\n{js}");
+        assert!(js.contains("export function greet "), "named fn export:\n{js}");
+        assert!(js.contains("export default greet;"), "default export:\n{js}");
+    }
+
+    #[test]
+    fn compile_module_esm_does_not_resolve_graph() {
+        // Compiling a single module must not read or require its dependencies to exist on disk:
+        // only the entry file is created, yet the import to a missing `./dep.tish` compiles fine.
+        let js = build_module_vite(
+            "main.tish",
+            &[(
+                "main.tish",
+                "import { id } from \"./dep.tish\"\nconsole.log(id(1))\n",
+            )],
+        );
+        assert!(
+            js.contains("import { id } from \"./dep.tish\";"),
+            "single-module compile emits the import without loading the dependency:\n{js}"
+        );
+    }
+
+    #[test]
+    fn compile_module_esm_rejects_native_imports() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+        let p = dir.join("main.tish");
+        std::fs::write(&p, "import { readFile } from \"fs\"\nconsole.log(1)\n").unwrap();
+        let err = compile_module_esm(&p, Some(dir), false, ImportRewrite::ViteDev, false)
+            .unwrap_err();
+        assert!(
+            err.message.contains("Native module import"),
+            "expected a native-import rejection, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn compile_module_esm_source_map_maps_statement_to_tish_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+        let p = dir.join("main.tish");
+        std::fs::write(&p, "export fn greet(n) { return \"hi \" + n }\nconsole.log(greet(\"x\"))\n")
+            .unwrap();
+        let bundle =
+            compile_module_esm(&p, Some(dir), false, ImportRewrite::ViteDev, true).unwrap();
+        let map = bundle
+            .source_map_json
+            .expect("source map requested → must be present");
+        assert!(
+            map.contains("\"version\":3") || map.contains("\"version\": 3"),
+            "v3 source map:\n{map}"
+        );
+        assert!(
+            map.contains("main.tish"),
+            "map sources reference the .tish file:\n{map}"
+        );
+    }
+
+    #[test]
+    fn compile_module_esm_source_map_requires_no_optimize() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+        let p = dir.join("main.tish");
+        std::fs::write(&p, "console.log(1)\n").unwrap();
+        let err = compile_module_esm(&p, Some(dir), true, ImportRewrite::ViteDev, true)
+            .unwrap_err();
+        assert!(
+            err.message.to_lowercase().contains("optimiz"),
+            "source map + optimize must be rejected, got: {}",
             err.message
         );
     }

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -113,6 +113,7 @@ Build: `cargo build --features full`. CLI artifact output: `tish build … --fea
 | `tish build --native-backend cranelift` | Native binary that loads **embedded serialized bytecode** and runs **`tishlang_vm`** (`tish_cranelift_runtime`). Cranelift is used only to build a tiny object file holding the blob; **bytecode is not lowered to CLIF**. Throughput is **VM-class** (similar order to `tish run --backend vm`), not “rustc/LLVM on numeric loops.” |
 | `tish build --native-backend llvm` | Same **embedded bytecode + VM** link pattern as Cranelift (see `tishlang_llvm` + `tishlang_cranelift_runtime`). |
 | `tish build --target js` | Emitted JavaScript; the host (V8, etc.) may **JIT** tight loops. **`--format bundle`** (default) merges every module into one file; **`--format esm`** emits one `.js` per `.tish` module with real `import`/`export` (so `-o` is a directory) for Vite/Rollup tree-shaking — see [js-target.md](js-target.md). |
+| `tish compile-module FILE --target js --format esm --vite-dev` | Compiles a **single** `.tish` file (no graph resolution) to one ES module on stdout, keeping relative `.tish` specifiers so a bundler owns the graph. Used by the [`@tishlang/vite-plugin-tish`](../npm/vite-plugin-tish/README.md) plugin for in-graph dev / HMR; `--source-map` (default) emits a `{ "js", "map" }` JSON envelope with a map back to the `.tish` source. |
 
 **Interop:** `tish:*` and npm-style native imports require **`--native-backend rust`**. The Cranelift/LLVM native-binary paths are **pure Tish** only (no external native modules).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Internal and contributor-facing docs. User-facing docs live in the **[tishlang.c
 | File | Purpose |
 |------|---------|
 | `js-emit-philosophy.md` | **Normative:** Tish is not JS; JS emit scope; “obvious failures” vs feature creep; `type` keyword exceptions |
-| `js-target.md` | `tish build --target js` output formats: `--format bundle` (single merged file) vs `--format esm` (one file per module with real `import`/`export` for Vite/Rollup tree-shaking; fixes cross-module export collisions, #282) |
+| `js-target.md` | `tish build --target js` output formats: `--format bundle` (single merged file) vs `--format esm` (one file per module with real `import`/`export` for Vite/Rollup tree-shaking; fixes cross-module export collisions, #282); plus Vite dev / HMR via `tish compile-module` + `@tishlang/vite-plugin-tish` with dev source maps (#284) |
 | `ecma-alignment.md` | ECMA-262 / test262 mapping (source of truth; tish-docs summarizes) |
 | `LANGUAGE.md` | Canonical language reference (syntax, semantics, builtins; LLM/tool friendly) |
 | `plan-gap-analysis.md` | Implementation audit, MVP checklist, next steps |

--- a/docs/js-target.md
+++ b/docs/js-target.md
@@ -68,10 +68,40 @@ tish build src/main.tish -o dist/tish --target js --format esm
 # Vite bundles + tree-shakes the graph
 ```
 
+## Vite dev (HMR)
+
+For development, the official [`@tishlang/vite-plugin-tish`](../npm/vite-plugin-tish/README.md) plugin compiles each `.tish` file **into Vite's module graph one module at a time**, so editing a module hot-swaps in place (HMR) instead of reloading the whole page. This replaces the older shim that ran a whole-program `tish build` and sent `{ type: 'full-reload' }` on every change.
+
+```bash
+npm install -D @tishlang/vite-plugin-tish
+```
+
+```js
+// vite.config.js
+import { defineConfig } from "vite"
+import tish from "@tishlang/vite-plugin-tish"
+
+export default defineConfig({ plugins: [tish()] })
+```
+
+Under the hood the plugin shells out to a single-module compile:
+
+```bash
+tish compile-module src/counter.tish --target js --format esm --vite-dev --source-map
+```
+
+- `compile-module` reads and compiles **only that one file** (no dependency-graph resolution) — Vite owns the graph and resolves each `.tish` import back through the plugin.
+- `--vite-dev` keeps relative `.tish` specifiers (`./counter.tish`) and bare packages verbatim so Vite's `resolveId`/`load` re-enters the plugin per dependency.
+- `--source-map` (on by default for `compile-module`) emits a `{ "js": …, "map": … }` JSON envelope so Vite's error overlay and the browser debugger resolve back to the original `.tish` line/column. Pass `--no-source-map` to get raw JS on stdout instead.
+
+Dev source maps require no optimization (mappings follow unmerged statement order), so `compile-module --source-map` implies `--no-optimize`, the same rule as `build --target js --source-map`.
+
+For `--target bytecode` apps (the wasm VM owns all engine state) per-module HMR does not apply — set `mode: "full-reload"` on the plugin as the documented fallback.
+
 ### Limitations (current)
 
 - `-o` is treated as a **directory** in ESM mode.
 - **Native imports** (`tish:*`, `cargo:*`, `ffi:*`, and the built-in `fs`/`http`/`process`/`ws`) are rejected — they require `--target native`.
 - When the graph spans modules outside the entry's package, the output tree is rooted at their nearest common ancestor, so the entry is emitted in a subtree (the `Entry: …` line reports its path) and the tree may include `node_modules/` / sibling-package directories.
-- `--source-map` is **bundle-only** for now; ESM per-file source maps are a follow-up.
+- `--source-map` is **bundle-only** for disk `build` output; per-file source maps for production `--format esm` are a follow-up. (Dev source maps **are** available per module via `compile-module --source-map` / the Vite plugin.)
 - `.jsx` / `.js` single-file inputs are bundle-only.

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -7,8 +7,22 @@
       "name": "tish-npm-packages",
       "workspaces": [
         "tish",
-        "create-tish-app"
+        "cargo-bindgen",
+        "create-tish-app",
+        "vite-plugin-tish"
       ]
+    },
+    "cargo-bindgen": {
+      "name": "@tishlang/cargo-bindgen",
+      "version": "0.0.0",
+      "hasInstallScript": true,
+      "license": "PIF",
+      "bin": {
+        "tish-bindgen": "bin/tish-bindgen"
+      },
+      "engines": {
+        "node": ">=22"
+      }
     },
     "create-tish-app": {
       "name": "@tishlang/create-tish-app",
@@ -21,6 +35,809 @@
         "node": ">=14"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tishlang/cargo-bindgen": {
+      "resolved": "cargo-bindgen",
+      "link": true
+    },
     "node_modules/@tishlang/create-tish-app": {
       "resolved": "create-tish-app",
       "link": true
@@ -28,6 +845,781 @@
     "node_modules/@tishlang/tish": {
       "resolved": "tish",
       "link": true
+    },
+    "node_modules/@tishlang/vite-plugin-tish": {
+      "resolved": "vite-plugin-tish",
+      "link": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "tish": {
       "name": "@tishlang/tish",
@@ -39,6 +1631,21 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "vite-plugin-tish": {
+      "name": "@tishlang/vite-plugin-tish",
+      "version": "0.1.0",
+      "license": "PIF",
+      "devDependencies": {
+        "vite": "^7",
+        "vitest": "^3"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "vite": ">=5"
       }
     }
   }

--- a/npm/package.json
+++ b/npm/package.json
@@ -5,7 +5,8 @@
   "workspaces": [
     "tish",
     "cargo-bindgen",
-    "create-tish-app"
+    "create-tish-app",
+    "vite-plugin-tish"
   ],
   "scripts": {
     "build:binaries": "./scripts/build-binaries.sh"

--- a/npm/vite-plugin-tish/README.md
+++ b/npm/vite-plugin-tish/README.md
@@ -1,0 +1,75 @@
+# @tishlang/vite-plugin-tish
+
+Official [Vite](https://vitejs.dev) plugin for [Tish](https://tishlang.com). It compiles each
+`.tish` file directly into Vite's module graph, so editing a module hot-swaps in place (HMR) instead
+of triggering a full page reload, and dev builds carry source maps back to the original `.tish`.
+
+This replaces the common out-of-band shim that ran `tish build` over the whole program and sent
+`{ type: 'full-reload' }` on every change.
+
+## Requirements
+
+- Vite 5 or newer.
+- The `tish` CLI on your `PATH` (from `@tishlang/tish`), or pass `tishPath`.
+- Tish module output (`tish build --target js --format esm`) — the same per-module ESM emit the
+  plugin relies on. See [the JS target docs](https://tishlang.com/docs/reference/js-target).
+
+## Install
+
+```bash
+npm install -D @tishlang/vite-plugin-tish
+```
+
+## Usage
+
+```js
+// vite.config.js
+import { defineConfig } from "vite";
+import tish from "@tishlang/vite-plugin-tish";
+
+export default defineConfig({
+  plugins: [tish()],
+});
+```
+
+Import `.tish` modules as normal ES modules:
+
+```html
+<script type="module" src="/src/main.tish"></script>
+```
+
+```tish
+// src/main.tish
+import { makeCounter } from "./counter.tish"
+
+let next = makeCounter(0)
+console.log(next())
+```
+
+Editing `counter.tish` updates the running app without a full reload, and runtime errors point back
+to the `.tish` source in Vite's overlay and the browser debugger.
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `tishPath` | `string` | `$TISH_PATH` or `tish` | Path to the `tish` binary. |
+| `projectRoot` | `string` | Vite `root` | Root for resolving bare specifiers / `node_modules`. |
+| `mode` | `"hmr" \| "full-reload"` | `"hmr"` | `hmr` hot-swaps modules; `full-reload` reloads the whole page on any `.tish` change. |
+
+### When to use `full-reload`
+
+For apps compiled to `--target bytecode` (the wasm VM owns all engine state), per-module HMR does not
+apply — use `mode: "full-reload"` as the documented fallback.
+
+## How it works
+
+The plugin registers `resolveId` + `load` so each `.tish` import becomes one module in Vite's graph,
+compiled via `tish compile-module --target js --format esm --vite-dev`. Relative `.tish` specifiers
+are preserved so Vite resolves dependencies through the plugin per module; a self-accepting
+`import.meta.hot.accept()` boundary is injected so leaf edits hot-swap. `handleHotUpdate` returns the
+changed module node(s) to Vite for per-module invalidation instead of a full reload.
+
+## License
+
+[PIF](https://payitforwardlicense.com/)

--- a/npm/vite-plugin-tish/index.js
+++ b/npm/vite-plugin-tish/index.js
@@ -1,0 +1,96 @@
+// Vite plugin for Tish (#284). Compiles each `.tish` file into Vite's module graph one module at a
+// time via `tish compile-module`, so editing a leaf module hot-swaps without a full page reload —
+// instead of the older out-of-band "compile the whole bundle and full-reload on every change" shim.
+//
+// Dev compiles request a source map (`tish compile-module --source-map`) so Vite's error overlay
+// and the browser debugger resolve back to the original `.tish`.
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const TISH_EXT = ".tish";
+
+/**
+ * @param {object} [opts]
+ * @param {string} [opts.tishPath]   Path to the `tish` binary (default: $TISH_PATH or `tish` on PATH).
+ * @param {string} [opts.projectRoot] Root for resolving bare specifiers / node_modules (default: Vite root).
+ * @param {"hmr"|"full-reload"} [opts.mode] `hmr` (default) hot-swaps modules; `full-reload` reloads the
+ *        page on any `.tish` change (the documented fallback for `--target bytecode` apps).
+ */
+export default function tishPlugin(opts = {}) {
+  const tishPath = opts.tishPath ?? process.env.TISH_PATH ?? "tish";
+  const mode = opts.mode ?? "hmr";
+  let projectRoot = opts.projectRoot;
+
+  // Compile a single `.tish` file to one ES module. In `hmr` mode we request a source map and parse
+  // the `{ js, map }` envelope; otherwise we take raw JS on stdout.
+  function compileModule(file) {
+    const args = [
+      "compile-module",
+      file,
+      "--target",
+      "js",
+      "--format",
+      "esm",
+      "--vite-dev",
+    ];
+    args.push(mode === "hmr" ? "--source-map" : "--no-source-map");
+    if (projectRoot) args.push("--project-root", projectRoot);
+    const stdout = execFileSync(tishPath, args, {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    if (mode === "hmr") {
+      const { js, map } = JSON.parse(stdout);
+      return { code: js, map };
+    }
+    return { code: stdout, map: null };
+  }
+
+  return {
+    name: "vite-plugin-tish",
+    enforce: "pre",
+
+    configResolved(config) {
+      if (!projectRoot) projectRoot = config.root;
+    },
+
+    // Bring `.tish` imports into Vite's module graph: resolve relative `.tish` specifiers to absolute
+    // file paths so Vite addresses each module and can invalidate it individually. Root-relative URLs
+    // (`/src/x.tish`) and bare specifiers are left to Vite's resolver, which maps them to real files.
+    resolveId(source, importer) {
+      if (!source.endsWith(TISH_EXT)) return null;
+      if (source.startsWith(".") && importer) {
+        return path.resolve(path.dirname(importer.split("?")[0]), source);
+      }
+      if (path.isAbsolute(source) && existsSync(source)) {
+        return source;
+      }
+      return null;
+    },
+
+    load(id) {
+      const file = id.split("?")[0];
+      if (!file.endsWith(TISH_EXT)) return null;
+      const { code, map } = compileModule(file);
+      if (mode !== "hmr") return { code, map };
+      // Self-accepting boundary: editing this module re-runs it without reloading the page. Frameworks
+      // (e.g. Lattish) can register their own `import.meta.hot.accept` handlers on top.
+      const withBoundary = `${code}\nif (import.meta.hot) { import.meta.hot.accept(); }\n`;
+      return { code: withBoundary, map };
+    },
+
+    handleHotUpdate(ctx) {
+      const { file, server } = ctx;
+      if (!file.endsWith(TISH_EXT)) return;
+      if (mode === "full-reload") {
+        server.ws.send({ type: "full-reload" });
+        return [];
+      }
+      // Hand Vite the changed module node(s) so it performs per-module HMR rather than a full reload.
+      const mods = server.moduleGraph.getModulesByFile(file);
+      return mods ? [...mods] : undefined;
+    },
+  };
+}

--- a/npm/vite-plugin-tish/package.json
+++ b/npm/vite-plugin-tish/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@tishlang/vite-plugin-tish",
+  "version": "0.1.0",
+  "description": "Vite plugin for Tish: in-graph .tish compilation with HMR and source maps for dev.",
+  "license": "PIF",
+  "type": "module",
+  "main": "./index.js",
+  "exports": {
+    ".": {
+      "import": "./index.js",
+      "default": "./index.js"
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tishlang/tish.git",
+    "directory": "npm/vite-plugin-tish"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "vitest run"
+  },
+  "files": ["index.js", "README.md"],
+  "peerDependencies": {
+    "vite": ">=5"
+  },
+  "devDependencies": {
+    "vite": "^7",
+    "vitest": "^3"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "keywords": ["tish", "vite", "vite-plugin", "hmr", "lattish"]
+}

--- a/npm/vite-plugin-tish/package.json
+++ b/npm/vite-plugin-tish/package.json
@@ -24,7 +24,13 @@
   },
   "files": ["index.js", "README.md"],
   "peerDependencies": {
-    "vite": ">=5"
+    "vite": ">=5",
+    "@tishlang/tish": "*"
+  },
+  "peerDependenciesMeta": {
+    "@tishlang/tish": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "vite": "^7",

--- a/npm/vite-plugin-tish/test/fixtures/hmr/index.html
+++ b/npm/vite-plugin-tish/test/fixtures/hmr/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>tish + vite HMR fixture</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.tish"></script>
+  </body>
+</html>

--- a/npm/vite-plugin-tish/test/fixtures/hmr/src/counter.tish
+++ b/npm/vite-plugin-tish/test/fixtures/hmr/src/counter.tish
@@ -1,0 +1,7 @@
+export fn makeCounter(start) {
+  let n = start
+  return fn() {
+    n = n + 1
+    return n
+  }
+}

--- a/npm/vite-plugin-tish/test/fixtures/hmr/src/main.tish
+++ b/npm/vite-plugin-tish/test/fixtures/hmr/src/main.tish
@@ -1,0 +1,4 @@
+import { makeCounter } from "./counter.tish"
+
+let next = makeCounter(0)
+console.log(next() + next())

--- a/npm/vite-plugin-tish/test/hmr.integration.test.js
+++ b/npm/vite-plugin-tish/test/hmr.integration.test.js
@@ -1,0 +1,50 @@
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createServer } from "vite";
+
+import tishPlugin from "../index.js";
+import { fixtureRoot, tishPath } from "./tish-path.js";
+
+// Acceptance test for #284: a real Vite dev server resolves, loads, and transforms `.tish` modules
+// through the plugin (proving in-graph compilation), and a leaf edit yields per-module HMR rather
+// than a full page reload.
+describe("vite dev server", () => {
+  const counterTish = path.join(fixtureRoot, "src", "counter.tish");
+  const myPlugin = tishPlugin({ tishPath: tishPath(), projectRoot: fixtureRoot });
+  let server;
+
+  beforeAll(async () => {
+    server = await createServer({
+      root: fixtureRoot,
+      logLevel: "silent",
+      server: { middlewareMode: true, hmr: false },
+      optimizeDeps: { noDiscovery: true },
+      plugins: [myPlugin],
+    });
+  });
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("transforms a .tish entry into ESM and pulls its .tish import into the graph", async () => {
+    const result = await server.transformRequest("/src/main.tish");
+    expect(result).toBeTruthy();
+    expect(result.code).toContain("makeCounter");
+    // Import analysis resolved `./counter.tish` through the plugin and registered it as a module.
+    const counterMods = server.moduleGraph.getModulesByFile(counterTish);
+    expect(counterMods && counterMods.size).toBeGreaterThan(0);
+  });
+
+  it("HMR returns the changed module and sends no full-reload", async () => {
+    await server.transformRequest("/src/counter.tish");
+    const send = vi.spyOn(server.ws, "send");
+    const updated = myPlugin.handleHotUpdate({ file: counterTish, server });
+    expect(Array.isArray(updated)).toBe(true);
+    expect(updated.length).toBeGreaterThan(0);
+    const sentFullReload = send.mock.calls.some(
+      (args) => args[0] && args[0].type === "full-reload",
+    );
+    expect(sentFullReload).toBe(false);
+  });
+});

--- a/npm/vite-plugin-tish/test/plugin.test.js
+++ b/npm/vite-plugin-tish/test/plugin.test.js
@@ -1,0 +1,95 @@
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+import tishPlugin from "../index.js";
+import { fixtureRoot, tishPath } from "./tish-path.js";
+
+const mainTish = path.join(fixtureRoot, "src", "main.tish");
+const counterTish = path.join(fixtureRoot, "src", "counter.tish");
+
+function plugin(opts = {}) {
+  return tishPlugin({ tishPath: tishPath(), projectRoot: fixtureRoot, ...opts });
+}
+
+describe("resolveId", () => {
+  it("resolves a relative .tish import to an absolute path", () => {
+    const id = plugin().resolveId("./counter.tish", mainTish);
+    expect(id).toBe(counterTish);
+  });
+
+  it("passes through an absolute .tish path unchanged", () => {
+    expect(plugin().resolveId(counterTish, undefined)).toBe(counterTish);
+  });
+
+  it("ignores non-.tish specifiers", () => {
+    expect(plugin().resolveId("lattish", mainTish)).toBeNull();
+    expect(plugin().resolveId("./styles.css", mainTish)).toBeNull();
+  });
+});
+
+describe("load", () => {
+  it("compiles a .tish module to ESM", () => {
+    const out = plugin().load(counterTish);
+    expect(out.code).toContain("export function makeCounter");
+  });
+
+  it("injects a self-accepting HMR boundary", () => {
+    const out = plugin().load(counterTish);
+    expect(out.code).toContain("import.meta.hot.accept()");
+  });
+
+  it("returns a v3 source map back to the .tish file", () => {
+    const out = plugin().load(counterTish);
+    expect(out.map).toBeTruthy();
+    expect(out.map.version).toBe(3);
+    expect(out.map.sources.some((s) => s.includes("counter.tish"))).toBe(true);
+  });
+
+  it("keeps relative .tish import specifiers so they stay in Vite's graph", () => {
+    const out = plugin().load(mainTish);
+    expect(out.code).toContain('from "./counter.tish"');
+    expect(out.code).not.toContain("./counter.js");
+  });
+
+  it("omits the source map in full-reload mode", () => {
+    const out = plugin({ mode: "full-reload" }).load(counterTish);
+    expect(out.code).toContain("export function makeCounter");
+    expect(out.code).not.toContain("import.meta.hot.accept()");
+    expect(out.map).toBeNull();
+  });
+
+  it("ignores non-.tish ids", () => {
+    expect(plugin().load("/some/file.js")).toBeNull();
+  });
+});
+
+describe("handleHotUpdate", () => {
+  it("returns the changed module node(s) instead of a full reload (HMR)", () => {
+    const send = vi.fn();
+    const node = { id: counterTish };
+    const server = {
+      ws: { send },
+      moduleGraph: { getModulesByFile: () => new Set([node]) },
+    };
+    const result = plugin().handleHotUpdate({ file: counterTish, server });
+    expect(result).toEqual([node]);
+    expect(send).not.toHaveBeenCalledWith({ type: "full-reload" });
+  });
+
+  it("sends a full reload only in full-reload mode", () => {
+    const send = vi.fn();
+    const server = { ws: { send }, moduleGraph: { getModulesByFile: () => undefined } };
+    const result = plugin({ mode: "full-reload" }).handleHotUpdate({
+      file: counterTish,
+      server,
+    });
+    expect(result).toEqual([]);
+    expect(send).toHaveBeenCalledWith({ type: "full-reload" });
+  });
+
+  it("ignores non-.tish files", () => {
+    const send = vi.fn();
+    const server = { ws: { send }, moduleGraph: { getModulesByFile: () => undefined } };
+    expect(plugin().handleHotUpdate({ file: "/x/app.css", server })).toBeUndefined();
+  });
+});

--- a/npm/vite-plugin-tish/test/tish-path.js
+++ b/npm/vite-plugin-tish/test/tish-path.js
@@ -1,0 +1,25 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+// npm/vite-plugin-tish/test -> repo root
+const repoRoot = path.resolve(here, "..", "..", "..");
+
+// Resolve the `tish` binary the plugin should shell out to in tests. CI sets TISH_PATH; locally we
+// fall back to the workspace build outputs, then to `tish` on PATH.
+export function tishPath() {
+  if (process.env.TISH_PATH && existsSync(process.env.TISH_PATH)) {
+    return process.env.TISH_PATH;
+  }
+  const candidates = [
+    path.join(repoRoot, "target", "release", "tish"),
+    path.join(repoRoot, "target", "debug", "tish"),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  return "tish";
+}
+
+export const fixtureRoot = path.join(here, "fixtures", "hmr");

--- a/tests/modules/esm/vite_hmr/counter.tish
+++ b/tests/modules/esm/vite_hmr/counter.tish
@@ -1,0 +1,8 @@
+// Leaf module for the Vite HMR / single-module compile path (#284).
+export fn makeCounter(start) {
+  let n = start
+  return fn() {
+    n = n + 1
+    return n
+  }
+}

--- a/tests/modules/esm/vite_hmr/main.tish
+++ b/tests/modules/esm/vite_hmr/main.tish
@@ -1,0 +1,6 @@
+// Entry module: imports a leaf relative `.tish` module. Under `compile-module --vite-dev`
+// the specifier must stay `./counter.tish` so Vite's resolveId re-enters the plugin (#284).
+import { makeCounter } from "./counter.tish"
+
+let next = makeCounter(0)
+console.log(next() + next())


### PR DESCRIPTION
## Summary

Implements true per-module Hot Module Replacement (HMR) for `.tish` sources under Vite, resolving #284. Each `.tish` file is compiled **into Vite's module graph one module at a time**, so editing a leaf module hot-swaps in place instead of triggering a full page reload — replacing the out-of-band "build the whole bundle and `full-reload` on every change" shim every Tish + Vite app currently reimplements.

Builds on the per-module ESM output from #282 (#285, merged).

## What's included

- **Compiler** ([`crates/tish_compile_js`](crates/tish_compile_js)): new `compile_module_esm` + `ImportRewrite::ViteDev`. Compiles a single file (no dependency-graph resolution), keeps relative `.tish` specifiers and bare packages verbatim so Vite re-enters the plugin per dependency, and optionally emits a v3 source map back to the `.tish` source.
- **CLI** ([`crates/tish`](crates/tish)): `tish compile-module` subcommand. `--source-map` (default on) emits a `{ "js": …, "map": … }` JSON envelope for the plugin; `--no-source-map` prints raw JS. `--source-map` implies `--no-optimize` (same rule as bundle maps).
- **Plugin** ([`npm/vite-plugin-tish`](npm/vite-plugin-tish)): official `@tishlang/vite-plugin-tish` with `resolveId` / `load` / `handleHotUpdate`. Injects a self-accepting `import.meta.hot.accept()` boundary, returns `{ code, map }`, and returns changed module node(s) for per-module HMR. `mode: "full-reload"` is the documented fallback for `--target bytecode` apps.
- **Source maps** (#284 item 5): delivered for the Vite dev path. Errors/stack traces resolve back to `.tish`. Disk `--format esm --source-map` remains a #282 follow-up.
- **Docs**: Vite dev (HMR) sections in [`docs/js-target.md`](docs/js-target.md), [`docs/LANGUAGE.md`](docs/LANGUAGE.md), [`docs/README.md`](docs/README.md) (tishlang-web reference updated separately).
- **CI**: [`.github/workflows/vite-plugin-tish.yml`](.github/workflows/vite-plugin-tish.yml) builds the CLI and runs the plugin tests.

## Acceptance criteria (#284)

- [x] Editing a leaf `.tish` module updates the app without a full reload (HMR)
- [x] `.tish` imports participate in Vite's module graph (resolve/load/transform)
- [x] Official `@tishlang/vite-plugin-tish` documents the supported flow; `full-reload` is the documented fallback
- [x] Source maps from generated JS back to `.tish` (dev path)

## Test plan (TDD — tests written first at each layer)

- [x] `cargo test -p tishlang_compile_js` — 7 new `compile_module_esm` unit tests (ViteDev rewrite, exports, no graph resolution, native rejection, source map, no-optimize rule)
- [x] `cargo test -p tishlang --test integration_test compile_module` — 2 CLI tests (JSON envelope + map references `.tish`; `--no-source-map` raw JS)
- [x] `cd npm/vite-plugin-tish && npm test` — 14 vitest tests (resolveId, load + HMR boundary + source map, handleHotUpdate returns modules not full-reload, plus a real `createServer` acceptance test)
- [x] Existing `--format bundle` / `--format esm` behavior unchanged (export-collision test still green)