### PR TITLE
ci(npm): publish @tishlang/vite-plugin-tish on release

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -66,6 +66,10 @@ jobs:
             npm: "@tishlang/pg"
             type: source
             dir: pg
+          - label: "@tishlang/vite-plugin-tish"
+            npm: "@tishlang/vite-plugin-tish"
+            type: source
+            dir: vite-plugin-tish
           - label: "@tishlang/create-tish-app"
             npm: "@tishlang/create-tish-app"
             type: source


### PR DESCRIPTION
## Summary

`@tishlang/vite-plugin-tish` (the official Vite plugin from #284, merged in #286) was never wired into the npm publish pipeline. The release-notes step in [`npm-release.yml`](.github/workflows/npm-release.yml) already links to `@tishlang/vite-plugin-tish`, but the **publish matrix omitted it** — so on release the plugin would never reach npm and the release note would 404.

This adds the missing `type: source` matrix entry (next to `@tishlang/pg`), so the existing `Publish (source dir)` step publishes it straight from `npm/vite-plugin-tish` (version-stamped to the release version).

## Why a separate branch

#286 (which introduced the package) is already merged, so this is a small follow-up off `main`.

## Note (one-time manual step)

OIDC trusted publishing requires a one-time **Trusted Publisher** entry for `@tishlang/vite-plugin-tish` on npmjs.com (org `tishlang` / repo `tish` / workflow `npm-release.yml`) before the first publish succeeds — same requirement as the other scoped packages.

## Test plan

- [x] YAML validates (`yaml.safe_load`)
- [x] Entry mirrors the working `@tishlang/pg` source-package precedent (`type: source`, `dir: vite-plugin-tish`)
- [ ] First release after merge publishes `@tishlang/vite-plugin-tish` (verify the trusted-publisher entry exists)