### PR TITLE
perf(native): erase to_int32/to_uint32 round-trips on proven-int operands (#174)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -9265,17 +9265,31 @@ impl Codegen {
                 return Ok(Some(code));
             }
         }
+        // Integer-literal leaf: `ToInt32(<int literal>)` is a compile-time constant — emit it
+        // directly (`v as i32` = modulo 2^32 = JS ToInt32 of the integer) instead of a runtime
+        // `to_int32(1_f64)` call. Removes the constant round-trip in masks/shift-counts
+        // (`x & 255`, `x >> 1`, …). Trivially sound: the value is known.
+        if let Some(v) = Self::int_literal_value_of(e) {
+            return Ok(Some(format!("{}i32", v as i32)));
+        }
         // Leaf: fold only when it is a plain `f64` (so `to_int32` applies directly). `to_int32`
         // keeps its `is_finite` guard here — a leaf may legitimately be NaN/±Infinity (→ 0).
         let (code, ty) = self.emit_typed_expr(e)?;
         if ty == RustType::F64 {
-            // When the leaf is an ARITHMETIC node PROVABLY finite with `|x| < 2^62` (operands are
-            // i32-register reads and finite literals — e.g. the FNV `h * 16777619` excursion), drop
-            // the `is_finite` guard and Rust's saturating cast and truncate directly. Bit-identical
-            // on this domain (`x as i64` truncates toward zero = JS ToInt32 truncation; `as i32` =
-            // modulo 2^32), a few instructions cheaper per iteration. Emitted inline so the generated
-            // crate needs no new runtime symbol. Any unproven leaf keeps the guarded `to_int32`.
-            if matches!(e, Expr::Binary { .. }) && self.f64_finite_bounded_below_2pow62(e) {
+            // Drop the `is_finite` guard and truncate directly when the leaf is PROVABLY a finite
+            // integer, via either of two independent proofs:
+            //   • an ARITHMETIC node with `|x| < 2^62` (operands are i32-register reads / finite
+            //     literals — e.g. the FNV `h * 16777619` excursion); or
+            //   • the integer-range lattice proves `x ∈ (-2^53, 2^53)` (#174 — e.g. a range-bounded
+            //     induction counter `i` in `i & 255`, or `(k+1)` when `k` is range-proven).
+            // Both guarantee finiteness, so `to_int_unchecked::<i64>()` is defined and truncates
+            // toward zero (a no-op on an integer); `as i32` = modulo 2^32 = JS ToInt32. Bit-identical
+            // to the guarded `to_int32`, a few instructions cheaper per iteration. Any unproven leaf
+            // keeps the guarded `to_int32` (NaN/±Infinity → 0).
+            let proven_finite_int = (matches!(e, Expr::Binary { .. })
+                && self.f64_finite_bounded_below_2pow62(e))
+                || self.int_range(e, &self.int_range_locals).is_some();
+            if proven_finite_int {
                 Ok(Some(format!(
                     "(unsafe {{ ({}).to_int_unchecked::<i64>() }} as i32)",
                     code

--- a/crates/tish_compile/tests/perf_codegen_174.rs
+++ b/crates/tish_compile/tests/perf_codegen_174.rs
@@ -1,0 +1,110 @@
+//! Generated-Rust assertions for the #174 Int32/U32 range-lattice round-trip erasure.
+//!
+//! #174 erases redundant `tishlang_runtime::to_int32` / `to_uint32` calls in the typed bitwise/shift
+//! emitter when an operand is PROVABLY a finite integer — either an integer literal (a compile-time
+//! constant) or a value the integer-range lattice bounds within `(-2^53, 2^53)`. The guarded
+//! `to_int32` (NaN/±Infinity → 0) is retained for every unproven leaf, so the lowering is purely
+//! additive and behaviour-identical (the gauntlet's `typed == boxed == node` checksum is the gate).
+//!
+//! These run in their own test binary so any env flags set here never leak into other tests.
+
+use tishlang_compile::compile;
+use tishlang_parser::parse;
+
+/// FNV-style hash loop: the canonical bitwise hot loop. The accumulator `h` lives in an i32 register
+/// (existing lowering); #174 additionally folds the constant mask / shift counts and keeps the
+/// `(h * C) >>> 0` f64-rounding excursion intact.
+const FNV: &str = r#"
+let h = 2166136261
+for (let i = 0; i < 100; i++) {
+  h = h ^ (i & 255)
+  h = (h * 16777619) >>> 0
+  h = ((h << 13) | (h >>> 19)) >>> 0
+}
+let check = h >>> 0
+console.log(check)
+"#;
+
+#[test]
+fn issue_174_constant_mask_and_shift_counts_fold() {
+    // `i & 255`, `h << 13`, `h >>> 19`, `… >>> 0`: every integer-literal operand is a compile-time
+    // ToInt32 constant, so it must emit as a bare `i32` literal — NOT a runtime `to_int32(255_f64)`.
+    let rust = compile(&parse(FNV).unwrap()).unwrap();
+    assert!(
+        rust.contains("255i32"),
+        "the `& 255` mask must fold to an i32 constant:\n{}",
+        rust.lines().filter(|l| l.contains("255")).take(4).collect::<Vec<_>>().join("\n")
+    );
+    assert!(
+        rust.contains("13i32") && rust.contains("19i32"),
+        "shift counts 13 / 19 must fold to i32 constants"
+    );
+    // No runtime ToInt32/ToUint32 call on an integer LITERAL remains.
+    assert!(
+        !rust.contains("to_int32(255") && !rust.contains("to_uint32(13")
+            && !rust.contains("to_uint32(19") && !rust.contains("to_uint32(0"),
+        "integer-literal operands must not round-trip through a runtime to_int32/to_uint32 call:\n{}",
+        rust.lines().filter(|l| l.contains("to_uint32(") || l.contains("to_int32(")).take(8).collect::<Vec<_>>().join("\n")
+    );
+}
+
+#[test]
+fn issue_174_fnv_accumulator_still_i32_register_no_regression() {
+    // The i32-register accumulator lowering (and its `(h * C)` f64-rounding excursion) is preserved:
+    // `h` is an i32 register, there is no per-op `to_int32(h)` round-trip, and the multiply excursion
+    // lowers to an unchecked f64 truncation. (Mirror of `fnv_accumulator_lowers_to_i32_register`.)
+    let rust = compile(&parse(FNV).unwrap()).unwrap();
+    assert!(
+        rust.contains("let mut h: i32 = (2166136261u32) as i32;"),
+        "h must stay an i32 register seeded via u32 reinterpretation"
+    );
+    assert!(
+        !rust.contains("to_int32(h)"),
+        "no per-op to_int32(h) round-trip on the i32 accumulator"
+    );
+    assert!(
+        rust.contains(".to_int_unchecked::<i64>()") && rust.contains("16777619"),
+        "the `h * 16777619` excursion stays an f64 multiply with an unchecked truncation"
+    );
+}
+
+#[test]
+fn issue_174_range_proven_counter_drops_is_finite_guard() {
+    // A loop counter masked into a bitwise op is range-proven integral, so its ToInt32 drops the
+    // is_finite guard (unchecked truncation) instead of a guarded `to_int32(i)` call.
+    let src = r#"
+let acc = 0
+for (let i = 0; i < 64; i = i + 1) {
+  acc = acc ^ (i & 15)
+}
+console.log(acc >>> 0)
+"#;
+    let rust = compile(&parse(src).unwrap()).unwrap();
+    assert!(
+        rust.contains("to_int_unchecked::<i64>()"),
+        "a range-proven counter `i` in `i & 15` must drop the is_finite guard:\n{}",
+        rust.lines().filter(|l| l.contains("acc") || l.contains("to_int")).take(8).collect::<Vec<_>>().join("\n")
+    );
+}
+
+#[test]
+fn issue_174_unproven_leaf_keeps_guarded_to_int32() {
+    // SOUNDNESS: an f64 value that is NOT provably a finite integer (here a fractional accumulator —
+    // the range lattice drops it because `n = n + 0.5` is not integer-preserving) must KEEP the
+    // guarded `tishlang_runtime::to_int32`, never the unchecked truncation (a non-integer/NaN/±Inf
+    // input must map through the JS ToInt32 path, not a raw `to_int_unchecked`).
+    let src = r#"
+let n = 0.0
+for (let i = 0; i < 10; i = i + 1) { n = n + 0.5 }
+let m = n & 7
+console.log(m >>> 0)
+"#;
+    let rust = compile(&parse(src).unwrap()).unwrap();
+    assert!(
+        rust.contains("tishlang_runtime::to_int32(n)"),
+        "an unproven f64 leaf must keep the guarded to_int32 (non-integer/NaN/Inf -> JS ToInt32):\n{}",
+        rust.lines().filter(|l| l.contains("& ") || l.contains("to_int")).take(6).collect::<Vec<_>>().join("\n")
+    );
+    // The literal `7` still folds; only the unproven `n` keeps the guard.
+    assert!(rust.contains("7i32"), "the literal mask `7` still folds to a constant");
+}


### PR DESCRIPTION
## Summary

Advances #174 (Int32/U32 range lattice) — part of the #203 Beat-Node roadmap — by completing the **round-trip-erasure** portion of the work in the typed native bitwise/shift emitter (`emit_int32_operand`):

- **Integer-literal operands fold to `i32` constants.** `x & 255` now emits `& 255i32`, and shift counts emit `13i32` / `19i32` / `0i32`, instead of runtime `tishlang_runtime::to_int32(255_f64)` / `to_uint32(13_f64)` calls.
- **Range-proven leaves drop the `is_finite` guard.** A leaf the integer-range lattice proves lies in `(-2^53, 2^53)` (e.g. a bounded induction counter `i` in `i & 15`, or `k + 1` when `k` is range-proven) truncates directly via `to_int_unchecked::<i64>()` instead of a guarded `to_int32`.
- **Unproven leaves keep the guarded path.** Any f64 leaf that is not provably a finite integer still routes through `tishlang_runtime::to_int32` (NaN / ±Infinity → 0), so the change is purely additive and behaviour-identical.

## Soundness

The lowering is bit-identical to the guarded path on its proven domain (every `i32` is exact in `f64`; `to_int_unchecked::<i64>()` on a finite integer truncates to itself; `as i32` = modulo 2^32 = JS `ToInt32`). The gauntlet's `typed == boxed == node` checksum columns are the hard gate, and they stay green.

## Validation

- Full perf gauntlet: **12/21 PASS, zero `TYPED≠BOXED` / `≠NODE`, no regression** vs baseline.
- `fnv_hash` stays at parity (0.99×) with its i32-register accumulator and the `(h * 16777619) >>> 0` f64-rounding excursion intact.
- New `crates/tish_compile/tests/perf_codegen_174.rs` (4 tests): constant folding, range-proven guard removal, fnv non-regression, and the soundness case (unproven f64 leaf keeps the guarded `to_int32`).
- `cargo test -p tishlang_compile` green (61 tests).

## Scope note (honest)

The `mandelbrot` and `fannkuch` flips that issue #174 optimistically groups here are **not reachable from the int-lattice alone**, which I confirmed by inspecting the generated Rust:

- `mandelbrot` is already fully native `f64` in its hot loop with no bitwise ops; its ~1.2× gap is f64 arithmetic that V8 also runs in doubles (the issue itself notes "inside jitter margin").
- `fannkuch`'s residual cost is the resize-guarded array store + `.get().unwrap_or(NaN)` read pattern — the in-bounds store/read elision tracked as **#173 part 3** (out of scope here). The integer-inference wins #174 listed for fannkuch already landed via #170 / #172 (1399ms → ~350ms).

So this PR lands the sound, on-theme lattice/round-trip-erasure deliverable; the remaining benchmark flips are gated on #173 part 3 (fannkuch) and are jitter-bound for mandelbrot. Leaving #174 open for a maintainer call on whether the round-trip-erasure portion closes it.

## Test plan

- [x] `cargo test -p tishlang_compile` (incl. new `perf_codegen_174.rs`)
- [x] `scripts/run_perf_gauntlet.sh --runs 3` — 12/21 PASS, soundness columns clean
- [x] `fnv_accumulator_lowers_to_i32_register` non-regression