### PR TITLE
perf(native): thread_local numeric globals for fasta seed (#176)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -795,12 +795,18 @@ pub(crate) enum VecParamKind {
 /// #175 — the de-virtualized native signature of one plain-array free fn. Unlike the #177 aggregate
 /// path (single struct-alias array), this supports MULTIPLE plain `number[]`/`boolean[]` params and
 /// recursion; call sites pass pairwise-distinct array idents (statically checked) so no runtime
-/// alias guard is needed. Emitted as `fn name_nv(<f64..>, <&/&mut Vec<T>..>) -> f64 | ()`.
+/// alias guard is needed. Emitted as `fn name_nv(<f64..>, <&/&mut Vec<T>..>) -> f64 | Vec<f64> | ()`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum VecRetKind {
+    F64,
+    Unit,
+    VecF64,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct NativeVecFnSig {
     pub(crate) params: Vec<(String, VecParamKind)>,
-    /// `true` → returns `f64`; `false` → returns `()` (JS `undefined`).
-    ret_f64: bool,
+    ret: VecRetKind,
 }
 
 /// #173 part 3 — a symbolic upper bound used by the in-bounds index proof. Two forms are matched by
@@ -887,7 +893,7 @@ pub(crate) struct Codegen {
     inline_depth: usize,
     /// #175 — while emitting a native-vec free fn body: `Some(true)` returns `f64`, `Some(false)`
     /// returns `()`. Consulted by the `Return` arm so a `return e;` coerces to the native shape.
-    native_vec_ret: Option<bool>,
+    native_vec_ret: Option<VecRetKind>,
     /// #175 — the array params of the native-vec fn currently being emitted (name → is_mut). At a
     /// nested call site these are already `&/&mut Vec<T>` references, so they pass through by reborrow
     /// (`&mut *p`) rather than being address-of'd like a local `Vec` (`&mut local`).
@@ -2476,6 +2482,15 @@ impl Codegen {
                     rust_type = RustType::Value;
                 }
 
+                // Native-vec call initializer: `let cum = cumulative(probs)` → `Vec<f64>`.
+                if rust_type == RustType::Value {
+                    if let Some(init_e) = init.as_ref() {
+                        if let Some(rt) = self.native_vec_init_type(init_e) {
+                            rust_type = rt;
+                        }
+                    }
+                }
+
                 // #176: top-level numeric globals live in a thread_local `Cell<f64>` — no local slot.
                 if self.native_numeric_globals.contains_key(name.as_ref())
                     && self.outer_vars_stack.len() == 1
@@ -2513,6 +2528,30 @@ impl Codegen {
 
                 // Track the variable type
                 self.type_context.define(name.as_ref(), rust_type.clone());
+
+                // `let cum = cumulative_nv(&probs)` inherits `probs`' fixed length for in-bounds reads.
+                if let RustType::Vec(inner) = &rust_type {
+                    if **inner == RustType::F64 {
+                        if let Some(Expr::Call { callee, args, .. }) = init.as_ref() {
+                            if let Expr::Ident { name: fnname, .. } = callee.as_ref() {
+                                if let Some(sig) = self.native_vec_fns.get(fnname.as_ref()) {
+                                    if sig.ret == VecRetKind::VecF64 {
+                                        if let Some(CallArg::Expr(Expr::Ident { name: argn, .. })) =
+                                            args.first()
+                                        {
+                                            if let Some(bound) =
+                                                self.vec_fixed_len.get(argn.as_ref()).cloned()
+                                            {
+                                                self.vec_fixed_len
+                                                    .insert(name.to_string(), bound);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
 
                 // #177: the unboxed `Vec<TishStruct>` local is threaded `&mut` into the aggregate
                 // operators (`advance`/`offsetMomentum`), so it must be `mut` even when never
@@ -2795,15 +2834,39 @@ impl Codegen {
             Statement::Return { value, .. } => {
                 // #175: inside a native-vec free fn body, returns lower to the native shape
                 // (`f64` or `()`), not a boxed `Value`.
-                if let Some(ret_f64) = self.native_vec_ret {
-                    if ret_f64 {
-                        let e = value
-                            .as_ref()
-                            .ok_or_else(|| CompileError::new("native-vec f64 fn: empty return", None))?;
-                        let f = self.emit_f64(e)?;
-                        self.writeln(&format!("return {};", f));
-                    } else {
-                        self.writeln("return;");
+                if let Some(ret_kind) = self.native_vec_ret {
+                    match ret_kind {
+                        VecRetKind::F64 => {
+                            let e = value
+                                .as_ref()
+                                .ok_or_else(|| CompileError::new("native-vec f64 fn: empty return", None))?;
+                            let f = self.emit_f64(e)?;
+                            self.writeln(&format!("return {};", f));
+                        }
+                        VecRetKind::VecF64 => {
+                            let e = value
+                                .as_ref()
+                                .ok_or_else(|| CompileError::new("native-vec vec fn: empty return", None))?;
+                            if let Expr::Ident { name, .. } = e {
+                                self.writeln(&format!(
+                                    "return {};",
+                                    Self::escape_ident(name.as_ref())
+                                ));
+                            } else {
+                                let (c, ty) = self.emit_typed_expr(e)?;
+                                if ty == RustType::Vec(Box::new(RustType::F64)) {
+                                    self.writeln(&format!("return {};", c));
+                                } else {
+                                    return Err(CompileError::new(
+                                        "native-vec vec fn: return must be Vec<f64>",
+                                        None,
+                                    ));
+                                }
+                            }
+                        }
+                        VecRetKind::Unit => {
+                            self.writeln("return;");
+                        }
                     }
                     return Ok(());
                 }
@@ -6699,7 +6762,7 @@ impl Codegen {
             return false;
         };
         let Expr::Ident { name: idx, .. } = index else {
-            return false;
+            return self.sub_index_in_bounds(index, arr);
         };
         let idx = idx.as_ref();
         // Lower bound: the index can never be negative.
@@ -6726,6 +6789,53 @@ impl Codegen {
                     _ => false,
                 }
         })
+    }
+
+    /// `arr[lk - rk]` in-bounds when `lk` is strictly below the fixed length and `rk < lk`.
+    fn sub_index_in_bounds(&self, index: &Expr, arr: &str) -> bool {
+        let Some(len) = self.vec_fixed_len.get(arr) else {
+            return false;
+        };
+        let Expr::Binary {
+            left,
+            op: BinOp::Sub,
+            right,
+            ..
+        } = index
+        else {
+            return false;
+        };
+        let Expr::Ident { name: lk, .. } = left.as_ref() else {
+            return false;
+        };
+        let Expr::Ident { name: rk, .. } = right.as_ref() else {
+            return false;
+        };
+        let lk = lk.as_ref();
+        let rk = rk.as_ref();
+        let rk_nonneg = self.nonneg_locals.contains(rk)
+            || self
+                .int_range_locals
+                .get(rk)
+                .is_some_and(|&(lo, _)| lo >= 0);
+        if !rk_nonneg {
+            return false;
+        }
+        let lk_bounded = self.active_index_guards.iter().any(|g| {
+            g.live
+                && g.var == lk
+                && match (&g.bound, len) {
+                    (BoundKey::Len(a), _) => g.strict && a == arr,
+                    _ if &g.bound == len => g.strict,
+                    (BoundKey::Const(gc), BoundKey::Const(lc)) => g.strict && *gc < *lc,
+                    (BoundKey::Var(lv), BoundKey::Var(ll)) => g.strict && lv == ll,
+                    _ => false,
+                }
+        });
+        let rk_lt_lk = self.active_index_guards.iter().any(|g| {
+            g.live && g.var == rk && g.bound == BoundKey::Var(lk.to_string()) && g.strict
+        });
+        lk_bounded && rk_lt_lk
     }
 
     /// Push an active index guard parsed from a loop condition `var < bound` / `var <= bound`.
@@ -8704,7 +8814,7 @@ impl Codegen {
         Self::collect_reassignments_stmts(stmts, &mut reassigns);
         for (name, rhs) in &reassigns {
             if globals.contains(name)
-                && !Self::numeric_shaped(rhs, &empty_p, &empty_c, &globals)
+                && !Self::numeric_shaped(rhs, &empty_p, &empty_c, &globals, &HashSet::new())
             {
                 candidates.remove(name);
             }
@@ -8952,9 +9062,9 @@ impl Codegen {
             if Self::expr_mentions_global(e, g) {
                 let tree_ok = match e {
                     Expr::Assign { name, value, .. } if name.as_ref() == g => {
-                        Self::numeric_shaped(value, &empty_p, &empty_c, globals)
+                        Self::numeric_shaped(value, &empty_p, &empty_c, globals, &HashSet::new())
                     }
-                    _ => Self::numeric_shaped(e, &empty_p, &empty_c, globals),
+                    _ => Self::numeric_shaped(e, &empty_p, &empty_c, globals, &HashSet::new()),
                 };
                 if !tree_ok {
                     ok = false;
@@ -9136,7 +9246,7 @@ impl Codegen {
                 let params_ok = params.iter().all(|p| {
                     matches!(p, FunParam::Simple(tp)
                         if tp.default.is_none()
-                            && tp.type_ann.as_ref().map(Self::ann_is_number).unwrap_or(false))
+                            && tp.type_ann.as_ref().map_or(true, Self::ann_is_number))
                 });
                 // Return: an annotated `: number`, OR unannotated with all-numeric returns
                 // (verified in the fixpoint via `returns_numeric`), so the native `-> f64` holds.
@@ -9158,8 +9268,9 @@ impl Codegen {
                 }
                 let pnames: HashSet<String> =
                     params.iter().flat_map(|p| p.bound_names()).map(|n| n.to_string()).collect();
-                if !Self::native_safe_stmt(body, &pnames, &cand, globals)
-                    || !Self::returns_numeric(body, &pnames, &cand, globals)
+                let nums = Self::native_fn_numeric_locals(body, &pnames, globals);
+                if !Self::native_safe_stmt(body, &pnames, &cand, globals, &nums)
+                    || !Self::returns_numeric(body, &pnames, &cand, globals, &nums)
                 {
                     remove.push(name.to_string());
                 }
@@ -9174,25 +9285,119 @@ impl Codegen {
         cand
     }
 
+    /// Numeric locals in an M5-eligible fn body (params + fixpoint literal/copy seeds).
+    fn native_fn_numeric_locals(
+        body: &Statement,
+        params: &HashSet<String>,
+        globals: &HashSet<String>,
+    ) -> HashSet<String> {
+        let mut nums: HashSet<String> = params.clone();
+        nums.extend(globals.iter().cloned());
+        loop {
+            let before = nums.len();
+            Self::seed_native_fn_numeric_locals(body, &mut nums);
+            if nums.len() == before {
+                break;
+            }
+        }
+        nums
+    }
+
+    fn seed_native_fn_numeric_locals(stmt: &Statement, nums: &mut HashSet<String>) {
+        match stmt {
+            Statement::VarDecl {
+                name,
+                type_ann,
+                init,
+                ..
+            } => {
+                let numeric = type_ann.as_ref().is_some_and(Self::ann_is_number)
+                    || matches!(
+                        init,
+                        Some(Expr::Literal {
+                            value: Literal::Number(_),
+                            ..
+                        })
+                    )
+                    || matches!(
+                        init,
+                        Some(Expr::Ident { name: src, .. }) if nums.contains(src.as_ref())
+                    );
+                if numeric {
+                    nums.insert(name.to_string());
+                }
+            }
+            Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
+                for s in statements {
+                    Self::seed_native_fn_numeric_locals(s, nums);
+                }
+            }
+            Statement::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                Self::seed_native_fn_numeric_locals(then_branch, nums);
+                if let Some(e) = else_branch {
+                    Self::seed_native_fn_numeric_locals(e, nums);
+                }
+            }
+            Statement::For { init, body, .. } => {
+                if let Some(i) = init {
+                    Self::seed_native_fn_numeric_locals(i, nums);
+                }
+                Self::seed_native_fn_numeric_locals(body, nums);
+            }
+            Statement::While { body, .. } | Statement::DoWhile { body, .. } => {
+                Self::seed_native_fn_numeric_locals(body, nums);
+            }
+            _ => {}
+        }
+    }
+
     fn native_safe_stmt(
         stmt: &Statement,
         params: &std::collections::HashSet<String>,
         cand: &std::collections::HashSet<String>,
         globals: &std::collections::HashSet<String>,
+        nums: &HashSet<String>,
     ) -> bool {
         match stmt {
             Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
-                statements.iter().all(|s| Self::native_safe_stmt(s, params, cand, globals))
+                statements.iter().all(|s| Self::native_safe_stmt(s, params, cand, globals, nums))
             }
             Statement::Return { value, .. } => {
-                value.as_ref().is_some_and(|e| Self::native_safe_expr(e, params, cand, globals))
+                value.as_ref().is_some_and(|e| Self::native_safe_expr(e, params, cand, globals, nums))
             }
             Statement::If { cond, then_branch, else_branch, .. } => {
-                Self::native_safe_expr(cond, params, cand, globals)
-                    && Self::native_safe_stmt(then_branch, params, cand, globals)
-                    && else_branch.as_ref().is_none_or(|e| Self::native_safe_stmt(e, params, cand, globals))
+                Self::native_safe_expr(cond, params, cand, globals, nums)
+                    && Self::native_safe_stmt(then_branch, params, cand, globals, nums)
+                    && else_branch.as_ref().is_none_or(|e| Self::native_safe_stmt(e, params, cand, globals, nums))
             }
-            Statement::ExprStmt { expr, .. } => Self::native_safe_expr(expr, params, cand, globals),
+            Statement::ExprStmt { expr, .. } => Self::native_safe_expr(expr, params, cand, globals, nums),
+            Statement::VarDecl { init, .. } => {
+                init.as_ref().is_none_or(|e| Self::native_safe_expr(e, params, cand, globals, nums))
+            }
+            Statement::For {
+                init,
+                cond,
+                update,
+                body,
+                ..
+            } => {
+                init.as_ref().is_none_or(|i| Self::native_safe_stmt(i, params, cand, globals, nums))
+                    && cond.as_ref().is_none_or(|c| Self::native_safe_expr(c, params, cand, globals, nums))
+                    && update.as_ref().is_none_or(|u| Self::native_safe_expr(u, params, cand, globals, nums))
+                    && Self::native_safe_stmt(body, params, cand, globals, nums)
+            }
+            Statement::While { cond, body, .. } => {
+                Self::native_safe_expr(cond, params, cand, globals, nums)
+                    && Self::native_safe_stmt(body, params, cand, globals, nums)
+            }
+            Statement::DoWhile { body, cond, .. } => {
+                Self::native_safe_stmt(body, params, cand, globals, nums)
+                    && Self::native_safe_expr(cond, params, cand, globals, nums)
+            }
             _ => false,
         }
     }
@@ -9202,14 +9407,20 @@ impl Codegen {
         params: &std::collections::HashSet<String>,
         cand: &std::collections::HashSet<String>,
         globals: &std::collections::HashSet<String>,
+        nums: &HashSet<String>,
     ) -> bool {
         match expr {
             Expr::Literal { value, .. } => matches!(value, Literal::Number(_) | Literal::Bool(_)),
             Expr::Ident { name, .. } => {
-                params.contains(name.as_ref()) || globals.contains(name.as_ref())
+                params.contains(name.as_ref()) || globals.contains(name.as_ref()) || nums.contains(name.as_ref())
             }
-            Expr::Assign { name, value, .. } if globals.contains(name.as_ref()) => {
-                Self::native_safe_expr(value, params, cand, globals)
+            Expr::Assign { name, value, .. } => {
+                (globals.contains(name.as_ref()) || nums.contains(name.as_ref()))
+                    && Self::native_safe_expr(value, params, cand, globals, nums)
+            }
+            Expr::CompoundAssign { name, value, .. } => {
+                nums.contains(name.as_ref())
+                    && Self::native_safe_expr(value, params, cand, globals, nums)
             }
             Expr::Binary { left, op, right, .. } => {
                 matches!(
@@ -9217,17 +9428,17 @@ impl Codegen {
                     BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod | BinOp::Pow
                         | BinOp::Lt | BinOp::Le | BinOp::Gt | BinOp::Ge
                         | BinOp::StrictEq | BinOp::StrictNe | BinOp::And | BinOp::Or
-                ) && Self::native_safe_expr(left, params, cand, globals)
-                    && Self::native_safe_expr(right, params, cand, globals)
+                ) && Self::native_safe_expr(left, params, cand, globals, nums)
+                    && Self::native_safe_expr(right, params, cand, globals, nums)
             }
             Expr::Unary { op, operand, .. } => {
                 matches!(op, UnaryOp::Neg | UnaryOp::Pos | UnaryOp::Not)
-                    && Self::native_safe_expr(operand, params, cand, globals)
+                    && Self::native_safe_expr(operand, params, cand, globals, nums)
             }
             Expr::Call { callee, args, .. } => {
                 let args_ok = args
                     .iter()
-                    .all(|a| matches!(a, CallArg::Expr(e) if Self::native_safe_expr(e, params, cand, globals)));
+                    .all(|a| matches!(a, CallArg::Expr(e) if Self::native_safe_expr(e, params, cand, globals, nums)));
                 if !args_ok {
                     return false;
                 }
@@ -9257,20 +9468,21 @@ impl Codegen {
         params: &std::collections::HashSet<String>,
         cand: &std::collections::HashSet<String>,
         globals: &std::collections::HashSet<String>,
+        nums: &HashSet<String>,
     ) -> bool {
         match s {
             Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
-                statements.iter().all(|x| Self::returns_numeric(x, params, cand, globals))
+                statements.iter().all(|x| Self::returns_numeric(x, params, cand, globals, nums))
             }
             Statement::Return { value, .. } => {
-                value.as_ref().is_some_and(|e| Self::numeric_shaped(e, params, cand, globals))
+                value.as_ref().is_some_and(|e| Self::numeric_shaped(e, params, cand, globals, nums))
             }
             Statement::If { then_branch, else_branch, .. } => {
-                Self::returns_numeric(then_branch, params, cand, globals)
-                    && else_branch.as_ref().is_none_or(|e| Self::returns_numeric(e, params, cand, globals))
+                Self::returns_numeric(then_branch, params, cand, globals, nums)
+                    && else_branch.as_ref().is_none_or(|e| Self::returns_numeric(e, params, cand, globals, nums))
             }
             Statement::While { body, .. } | Statement::For { body, .. } => {
-                Self::returns_numeric(body, params, cand, globals)
+                Self::returns_numeric(body, params, cand, globals, nums)
             }
             _ => true, // no return in this statement form
         }
@@ -9284,26 +9496,29 @@ impl Codegen {
         params: &std::collections::HashSet<String>,
         cand: &std::collections::HashSet<String>,
         globals: &std::collections::HashSet<String>,
+        nums: &HashSet<String>,
     ) -> bool {
         match e {
             Expr::Literal { value: Literal::Number(_), .. } => true,
             Expr::Ident { name, .. } => {
-                params.contains(name.as_ref()) || globals.contains(name.as_ref())
+                params.contains(name.as_ref())
+                    || globals.contains(name.as_ref())
+                    || nums.contains(name.as_ref())
             }
             Expr::Binary { left, op, right, .. } => {
                 matches!(
                     op,
                     BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod | BinOp::Pow
-                ) && Self::numeric_shaped(left, params, cand, globals)
-                    && Self::numeric_shaped(right, params, cand, globals)
+                ) && Self::numeric_shaped(left, params, cand, globals, nums)
+                    && Self::numeric_shaped(right, params, cand, globals, nums)
             }
             Expr::Unary { op, operand, .. } => {
                 matches!(op, UnaryOp::Neg | UnaryOp::Pos)
-                    && Self::numeric_shaped(operand, params, cand, globals)
+                    && Self::numeric_shaped(operand, params, cand, globals, nums)
             }
             Expr::Conditional { then_branch, else_branch, .. } => {
-                Self::numeric_shaped(then_branch, params, cand, globals)
-                    && Self::numeric_shaped(else_branch, params, cand, globals)
+                Self::numeric_shaped(then_branch, params, cand, globals, nums)
+                    && Self::numeric_shaped(else_branch, params, cand, globals, nums)
             }
             Expr::Call { callee, .. } => match callee.as_ref() {
                 Expr::Ident { name, .. } => cand.contains(name.as_ref()),
@@ -9399,6 +9614,10 @@ impl Codegen {
                 let (code, _) = self.emit_typed_expr(expr)?;
                 self.writeln(&format!("{};", code));
             }
+            Statement::VarDecl { .. }
+            | Statement::For { .. }
+            | Statement::While { .. }
+            | Statement::DoWhile { .. } => self.emit_statement(stmt)?,
             _ => unreachable!("emit_native_fn_body: eligibility guarantees only handled statements"),
         }
         Ok(())
@@ -9716,10 +9935,10 @@ impl Codegen {
             let kind = Self::classify_vec_param(body, tp.name.as_ref())?;
             sig_params.push((tp.name.to_string(), kind));
         }
-        let ret_f64 = Self::vec_fn_return_shape(body)?;
+        let ret = Self::vec_fn_return_kind(params, body)?;
         Some(NativeVecFnSig {
             params: sig_params,
-            ret_f64,
+            ret,
         })
     }
 
@@ -9896,32 +10115,110 @@ impl Codegen {
         }
     }
 
-    /// `Some(true)` if every `return` carries a value (→ `f64`), `Some(false)` if there is no
-    /// value-returning `return` (→ unit), `None` if mixed (can't pick one native shape).
-    fn vec_fn_return_shape(body: &Statement) -> Option<bool> {
-        let mut has_val = false;
+    /// `Some(ret)` when every `return` agrees on one native shape; `None` if mixed.
+    fn vec_fn_return_kind(params: &[FunParam], body: &Statement) -> Option<VecRetKind> {
+        let mut ret_exprs: Vec<Expr> = Vec::new();
         let mut has_empty = false;
-        Self::scan_returns(body, &mut has_val, &mut has_empty);
-        match (has_val, has_empty) {
-            (true, false) => Some(true),
-            (false, _) => Some(false),
-            (true, true) => None,
+        Self::scan_return_exprs(body, &mut ret_exprs, &mut has_empty);
+        if ret_exprs.is_empty() && !has_empty {
+            return Some(VecRetKind::Unit);
         }
+        if has_empty {
+            return None;
+        }
+        let builders = Self::vec_builder_locals(body);
+        if !builders.is_empty()
+            && ret_exprs.iter().all(|e| {
+                matches!(e, Expr::Ident { name, .. } if builders.contains(name.as_ref()))
+            })
+        {
+            return Some(VecRetKind::VecF64);
+        }
+        let pnames: std::collections::HashSet<String> = params
+            .iter()
+            .flat_map(|p| p.bound_names())
+            .map(|n| n.to_string())
+            .collect();
+        let cand: std::collections::HashSet<String> = std::collections::HashSet::new();
+        if ret_exprs
+            .iter()
+            .all(|e| Self::numeric_shaped(e, &pnames, &cand, &std::collections::HashSet::new(), &std::collections::HashSet::new()))
+        {
+            return Some(VecRetKind::F64);
+        }
+        None
     }
 
-    fn scan_returns(s: &Statement, has_val: &mut bool, has_empty: &mut bool) {
+    fn scan_return_exprs(s: &Statement, exprs: &mut Vec<Expr>, has_empty: &mut bool) {
         if let Statement::Return { value, .. } = s {
-            if value.is_some() {
-                *has_val = true;
+            if let Some(e) = value {
+                exprs.push(e.clone());
             } else {
                 *has_empty = true;
             }
         }
         Self::for_each_child_stmt_list(s, &mut |list| {
             for st in list {
-                Self::scan_returns(st, has_val, has_empty);
+                Self::scan_return_exprs(st, exprs, has_empty);
             }
         });
+    }
+
+    /// Locals initialized as `[]` and mutated only via `.push` (e.g. `cumulative`'s `out`).
+    fn vec_builder_locals(body: &Statement) -> std::collections::HashSet<String> {
+        let mut builders: std::collections::HashSet<String> = std::collections::HashSet::new();
+        Self::for_each_child_stmt_list(body, &mut |list| {
+            for s in list {
+                if let Statement::VarDecl {
+                    name,
+                    init: Some(Expr::Array { elements, .. }),
+                    ..
+                } = s
+                {
+                    if elements.is_empty() {
+                        builders.insert(name.to_string());
+                    }
+                }
+            }
+        });
+        for local in builders.clone() {
+            if !Self::vec_builder_only_push(body, &local) {
+                builders.remove(&local);
+            }
+        }
+        builders
+    }
+
+    fn vec_builder_only_push(body: &Statement, local: &str) -> bool {
+        let mut ok = true;
+        Self::for_each_stmt_expr(body, &mut |e| {
+            if !ok {
+                return;
+            }
+            match e {
+                Expr::IndexAssign { object, .. } => {
+                    if matches!(object.as_ref(), Expr::Ident { name, .. } if name.as_ref() == local) {
+                        ok = false;
+                    }
+                }
+                Expr::Call { callee, .. } => {
+                    if let Expr::Member {
+                        object,
+                        prop: MemberProp::Name { name: method, .. },
+                        ..
+                    } = callee.as_ref()
+                    {
+                        if matches!(object.as_ref(), Expr::Ident { name, .. } if name.as_ref() == local)
+                            && method.as_ref() != "push"
+                        {
+                            ok = false;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        });
+        ok
     }
 
     /// Whether every call in a native-vec body targets a fn with a native form (another native-vec
@@ -9959,7 +10256,9 @@ impl Codegen {
                                     "sqrt" | "sin" | "cos" | "tan" | "abs" | "floor" | "ceil"
                                         | "exp" | "trunc" | "log"
                                 );
-                            if !is_math1 {
+                            let is_push = m.as_ref() == "push"
+                                && matches!(object.as_ref(), Expr::Ident { .. });
+                            if !is_math1 && !is_push {
                                 ok = false;
                             }
                         }
@@ -10116,6 +10415,25 @@ impl Codegen {
         true
     }
 
+    /// If `expr` is a direct call to a native-vec fn, the native Rust type of its result.
+    fn native_vec_init_type(&self, expr: &Expr) -> Option<RustType> {
+        let Expr::Call { callee, args, .. } = expr else {
+            return None;
+        };
+        let Expr::Ident { name, .. } = callee.as_ref() else {
+            return None;
+        };
+        let sig = self.native_vec_fns.get(name.as_ref())?;
+        if !Self::vec_call_args_ok(sig, args) {
+            return None;
+        }
+        match sig.ret {
+            VecRetKind::F64 => Some(RustType::F64),
+            VecRetKind::VecF64 => Some(RustType::Vec(Box::new(RustType::F64))),
+            VecRetKind::Unit => None,
+        }
+    }
+
     /// Emit one native-vec fn: `fn name_nv(<f64..>, <&/&mut Vec<T>..>) -> f64|() { <body> }`, reusing
     /// the normal statement emitter (with `native_vec_ret` set so returns lower to the native shape).
     fn emit_native_vec_fn(&mut self, name: &str, body: &Statement) -> Result<(), CompileError> {
@@ -10140,7 +10458,11 @@ impl Codegen {
                 }
             }
         }
-        let ret_str = if sig.ret_f64 { " -> f64" } else { "" };
+        let ret_str = match sig.ret {
+            VecRetKind::F64 => " -> f64",
+            VecRetKind::VecF64 => " -> Vec<f64>",
+            VecRetKind::Unit => "",
+        };
         self.writeln("#[allow(non_snake_case, unused)]");
         self.writeln(&format!(
             "fn {}_nv({}){} {{",
@@ -10149,10 +10471,10 @@ impl Codegen {
             ret_str
         ));
         self.indent += 1;
-        self.native_vec_ret = Some(sig.ret_f64);
+        self.native_vec_ret = Some(sig.ret.clone());
         let res = self.emit_statement(body);
         // Total function: a value-returning fn that falls off the end gets a default.
-        if sig.ret_f64 {
+        if sig.ret == VecRetKind::F64 {
             self.writeln("0.0");
         }
         self.native_vec_ret = saved_ret;
@@ -10227,16 +10549,31 @@ impl Codegen {
             }
         }
         let call = format!("{}_nv({})", Self::escape_ident(name.as_ref()), call_args.join(", "));
-        Ok(Some(if sig.ret_f64 {
-            if as_value {
-                format!("Value::Number({})", call)
-            } else {
-                call
+        Ok(Some(match sig.ret {
+            VecRetKind::F64 => {
+                if as_value {
+                    format!("Value::Number({})", call)
+                } else {
+                    call
+                }
             }
-        } else if as_value {
-            format!("{{ {}; Value::Null }}", call)
-        } else {
-            call
+            VecRetKind::VecF64 => {
+                if as_value {
+                    format!(
+                        "Value::Array(VmRef::new({}.iter().map(|&v| Value::Number(v)).collect()))",
+                        call
+                    )
+                } else {
+                    call
+                }
+            }
+            VecRetKind::Unit => {
+                if as_value {
+                    format!("{{ {}; Value::Null }}", call)
+                } else {
+                    call
+                }
+            }
         }))
     }
 
@@ -11767,10 +12104,10 @@ impl Codegen {
                     if let Expr::Ident { name: vn, .. } = callee.as_ref() {
                         if let Some(sig) = self.native_vec_fns.get(vn.as_ref()).cloned() {
                             if let Some(code) = self.try_emit_native_vec_call(callee, args, false)? {
-                                let ty = if sig.ret_f64 {
-                                    RustType::F64
-                                } else {
-                                    RustType::Value
+                                let ty = match sig.ret {
+                                    VecRetKind::F64 => RustType::F64,
+                                    VecRetKind::VecF64 => RustType::Vec(Box::new(RustType::F64)),
+                                    VecRetKind::Unit => RustType::Value,
                                 };
                                 return Ok((code, ty));
                             }
@@ -12368,4 +12705,5 @@ mod tests_176 {
         assert!(c_opt.contains_key("seed"), "optimized only: {:?}", c_opt);
         assert!(c.contains_key("seed"), "optimized+inferred: {:?}", c);
     }
+
 }

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -860,6 +860,9 @@ pub(crate) struct Codegen {
     /// Variables currently wrapped in Rc<RefCell<Value>> for mutable capture in closures
     /// These need special handling: reads via .borrow().clone(), writes via *var.borrow_mut()
     refcell_wrapped_vars: std::collections::HashSet<String>,
+    /// #176 (behind `TISH_NATIVE_FN`): top-level `let` bindings lowered to `thread_local Cell<f64>`
+    /// (`G_NAME`) when every use is a numeric read or a whole-binding numeric assign (fasta `seed`).
+    native_numeric_globals: std::collections::HashMap<String, f64>,
     /// M5 (dark-shipped behind `TISH_NATIVE_FN`): top-level functions eligible for a parallel
     /// free `fn f_native(f64,..)->f64` (all params `: number`, returns `number`, native-safe
     /// body). Direct calls to these route to the native fn, bypassing the boxed `value_call`.
@@ -1000,6 +1003,7 @@ impl Codegen {
             outer_params_stack: Vec::new(),
             outer_vars_stack: vec![Vec::new()], // Start with module-level scope
             refcell_wrapped_vars: std::collections::HashSet::new(),
+            native_numeric_globals: std::collections::HashMap::new(),
             native_fns: std::collections::HashSet::new(),
             native_vec_fns: std::collections::HashMap::new(),
             inline_fns: std::collections::HashMap::new(),
@@ -1695,7 +1699,16 @@ impl Codegen {
         // M5 (dark-shipped behind TISH_NATIVE_FN): emit a parallel native `fn f_native` for each
         // eligible top-level numeric fn at top level; direct calls route to it in emit_typed_expr.
         if std::env::var("TISH_NATIVE_FN").map(|v| v != "0").unwrap_or(false) {
-            self.native_fns = Self::collect_native_fns(&program.statements);
+            self.native_numeric_globals =
+                Self::collect_native_numeric_globals(&program.statements);
+            if !self.native_numeric_globals.is_empty() {
+                self.emit_native_numeric_global_tls()?;
+                self.writeln("");
+            }
+            let global_names: std::collections::HashSet<String> =
+                self.native_numeric_globals.keys().cloned().collect();
+            self.native_fns =
+                Self::collect_native_fns(&program.statements, &global_names);
             if !self.native_fns.is_empty() {
                 self.emit_native_fns(&program.statements)?;
                 self.writeln("");
@@ -2037,7 +2050,9 @@ impl Codegen {
         // Prepass: vars mutated by nested closures must be RefCell from the start (top-level)
         let top_level_mutated = Self::collect_vars_needing_capture_cell(&program.statements);
         for v in &top_level_mutated {
-            self.refcell_wrapped_vars.insert(v.clone());
+            if !self.native_numeric_globals.contains_key(v) {
+                self.refcell_wrapped_vars.insert(v.clone());
+            }
         }
 
         if self.is_async {
@@ -2105,6 +2120,17 @@ impl Codegen {
         }
         match expr {
             Expr::Assign { name, value, .. } => {
+                if self.native_numeric_globals.contains_key(name.as_ref()) {
+                    let (val_code, val_ty) = self.emit_typed_expr(value)?;
+                    let native_val = if val_ty == RustType::F64 {
+                        val_code
+                    } else if val_ty == RustType::Value {
+                        RustType::F64.from_value_expr(&val_code)
+                    } else {
+                        val_code
+                    };
+                    return Ok(Self::native_global_set(name.as_ref(), &native_val));
+                }
                 let rust_type = self.type_context.get_type(name.as_ref());
                 // i32-loop-var lowering: the accumulator lives in an `i32` register. Each
                 // reassignment RHS is a bitwise/shift chain the gate proved lowers fully via
@@ -2448,6 +2474,14 @@ impl Codegen {
                 if rust_type == RustType::F64 && self.demoted_numeric_locals.contains(name.as_ref())
                 {
                     rust_type = RustType::Value;
+                }
+
+                // #176: top-level numeric globals live in a thread_local `Cell<f64>` — no local slot.
+                if self.native_numeric_globals.contains_key(name.as_ref())
+                    && self.outer_vars_stack.len() == 1
+                {
+                    self.type_context.define(name.as_ref(), RustType::F64);
+                    return Ok(());
                 }
 
                 // i32-loop-var lowering: a `number` accumulator the analysis proved can live in an
@@ -3066,6 +3100,7 @@ impl Codegen {
                             "Polars",
                         ]
                         .contains(&name.as_str())
+                            && !self.native_numeric_globals.contains_key(name.as_str())
                     })
                     .collect();
 
@@ -3665,6 +3700,12 @@ impl Codegen {
                 Literal::Null => "Value::Null".to_string(),
             },
             Expr::Ident { name, .. } => {
+                if self.native_numeric_globals.contains_key(name.as_ref()) {
+                    return Ok(format!(
+                        "Value::Number({})",
+                        Self::native_global_get(name.as_ref())
+                    ));
+                }
                 let escaped = Self::escape_ident(name.as_ref());
                 if self.refcell_wrapped_vars.contains(name.as_ref()) {
                     let var_type = self.type_context.get_type(name.as_ref());
@@ -4197,6 +4238,34 @@ impl Codegen {
                     }
                 }
                 
+                // M5: boxed-context call to an eligible native fn → `Value::Number(name_native(..))`.
+                if let Expr::Ident { name: fname, .. } = callee.as_ref() {
+                    if self.native_fns.contains(fname.as_ref()) {
+                        let mut argc: Vec<String> = Vec::with_capacity(args.len());
+                        let mut ok = true;
+                        for a in args {
+                            if let CallArg::Expr(e) = a {
+                                let (ac, at) = self.emit_typed_expr(e)?;
+                                argc.push(if at == RustType::Value {
+                                    RustType::F64.from_value_expr(&ac)
+                                } else {
+                                    ac
+                                });
+                            } else {
+                                ok = false;
+                                break;
+                            }
+                        }
+                        if ok {
+                            return Ok(format!(
+                                "Value::Number({}_native({}))",
+                                Self::escape_ident(fname.as_ref()),
+                                argc.join(", ")
+                            ));
+                        }
+                    }
+                }
+
                 let callee_expr = self.emit_expr(callee)?;
                 let has_spread = args.iter().any(|a| matches!(a, CallArg::Spread(_)));
                 if has_spread {
@@ -4434,6 +4503,23 @@ impl Codegen {
             Expr::Assign { name, value, .. } => {
                 // #173 part 3: expression-position reassignment also ends a counter's in-bounds guard.
                 self.invalidate_index_guard(name.as_ref());
+                // #176: whole-binding assign to a native numeric global → thread_local Cell.
+                if self.native_numeric_globals.contains_key(name.as_ref()) {
+                    let (val_code, val_ty) = self.emit_typed_expr(value)?;
+                    let native_val = if val_ty == RustType::F64 {
+                        val_code
+                    } else if val_ty == RustType::Value {
+                        RustType::F64.from_value_expr(&val_code)
+                    } else {
+                        val_code
+                    };
+                    let set = Self::native_global_set(name.as_ref(), &native_val);
+                    let get = Self::native_global_get(name.as_ref());
+                    return Ok(format!(
+                        "{{ {}; Value::Number({}) }}",
+                        set, get
+                    ));
+                }
                 let escaped = Self::escape_ident(name.as_ref());
                 let rust_type = self.type_context.get_type(name.as_ref());
                 let is_ref = self.refcell_wrapped_vars.contains(name.as_ref());
@@ -6013,6 +6099,7 @@ impl Codegen {
                     "Polars",
                 ]
                 .contains(&name.as_str())
+                    && !self.native_numeric_globals.contains_key(name.as_str())
             })
             .collect();
 
@@ -8532,11 +8619,506 @@ impl Codegen {
         }
     }
 
+    /// #176 — `thread_local` static name for a native numeric global (`seed` → `G_SEED`).
+    fn native_global_static(name: &str) -> String {
+        format!("G_{}", Self::escape_ident(name).to_uppercase())
+    }
+
+    /// Read a native numeric global from its `thread_local Cell<f64>`.
+    fn native_global_get(name: &str) -> String {
+        format!(
+            "{}::with(|c| c.get())",
+            Self::native_global_static(name)
+        )
+    }
+
+    /// Write a native numeric global into its `thread_local Cell<f64>`.
+    fn native_global_set(name: &str, val: &str) -> String {
+        format!(
+            "{}::with(|c| c.set({}))",
+            Self::native_global_static(name),
+            val
+        )
+    }
+
+    /// Emit `thread_local! { static G_NAME: Cell<f64> = ... }` for each eligible global.
+    fn emit_native_numeric_global_tls(&mut self) -> Result<(), CompileError> {
+        self.writeln("thread_local! {");
+        self.indent += 1;
+        for (name, init) in self.native_numeric_globals.clone() {
+            self.writeln(&format!(
+                "static {}: std::cell::Cell<f64> = const {{ std::cell::Cell::new({}) }};",
+                Self::native_global_static(&name),
+                Self::f64_lit(init),
+            ));
+        }
+        self.indent -= 1;
+        self.writeln("};");
+        Ok(())
+    }
+
+    /// #176 — classify top-level `let x = <number-literal>` bindings whose every use is a numeric
+    /// read or a whole-binding assign with a numeric-shaped RHS (fasta `seed`).
+    fn collect_native_numeric_globals(stmts: &[Statement]) -> HashMap<String, f64> {
+        use std::collections::{HashMap, HashSet};
+        let mut candidates: HashMap<String, f64> = HashMap::new();
+        for s in stmts {
+            if let Statement::VarDecl {
+                name,
+                type_ann,
+                init,
+                ..
+            } = s
+            {
+                if let Some(ann) = type_ann {
+                    if !Self::ann_is_number(ann) {
+                        continue;
+                    }
+                }
+                if let Some(Expr::Literal {
+                    value: Literal::Number(n),
+                    ..
+                }) = init.as_ref()
+                {
+                    candidates.insert(name.to_string(), *n);
+                }
+            }
+        }
+        if candidates.is_empty() {
+            return HashMap::new();
+        }
+        // Inner `let`/`const` with the same name disqualifies the global (shadowing).
+        for s in stmts {
+            if let Statement::FunDecl { body, .. } = s {
+                let mut inner = HashSet::new();
+                Self::collect_local_var_names(body, &mut inner);
+                for n in inner {
+                    candidates.remove(&n);
+                }
+            }
+        }
+        let globals: HashSet<String> = candidates.keys().cloned().collect();
+        let empty_p = HashSet::new();
+        let empty_c = HashSet::new();
+        let mut reassigns: Vec<(String, &Expr)> = Vec::new();
+        Self::collect_reassignments_stmts(stmts, &mut reassigns);
+        for (name, rhs) in &reassigns {
+            if globals.contains(name)
+                && !Self::numeric_shaped(rhs, &empty_p, &empty_c, &globals)
+            {
+                candidates.remove(name);
+            }
+        }
+        for name in candidates.keys().cloned().collect::<Vec<_>>() {
+            if Self::global_has_disqualifying_use(stmts, &name) {
+                candidates.remove(&name);
+            }
+        }
+        candidates
+    }
+
+    /// Disqualifying uses: compound/logical assign, inc/dec, member/index/call on the global name.
+    fn global_has_disqualifying_use(stmts: &[Statement], g: &str) -> bool {
+        let mut bad = false;
+        Self::walk_stmts_for_global_disqualifiers(stmts, g, &mut bad);
+        bad
+    }
+
+    fn walk_stmts_for_global_disqualifiers(stmts: &[Statement], g: &str, bad: &mut bool) {
+        for s in stmts {
+            Self::walk_stmt_for_global_disqualifiers(s, g, bad);
+        }
+    }
+
+    fn walk_stmt_for_global_disqualifiers(s: &Statement, g: &str, bad: &mut bool) {
+        if *bad {
+            return;
+        }
+        match s {
+            Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
+                Self::walk_stmts_for_global_disqualifiers(statements, g, bad);
+            }
+            Statement::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                Self::walk_stmt_for_global_disqualifiers(then_branch, g, bad);
+                if let Some(eb) = else_branch {
+                    Self::walk_stmt_for_global_disqualifiers(eb, g, bad);
+                }
+            }
+            Statement::While { body, .. }
+            | Statement::DoWhile { body, .. }
+            | Statement::For { body, .. }
+            | Statement::ForOf { body, .. } => {
+                Self::walk_stmt_for_global_disqualifiers(body, g, bad);
+            }
+            Statement::Switch {
+                cases,
+                default_body,
+                ..
+            } => {
+                for (_, stmts) in cases {
+                    Self::walk_stmts_for_global_disqualifiers(stmts, g, bad);
+                }
+                if let Some(d) = default_body {
+                    Self::walk_stmts_for_global_disqualifiers(d, g, bad);
+                }
+            }
+            Statement::Try {
+                body,
+                catch_body,
+                finally_body,
+                ..
+            } => {
+                Self::walk_stmt_for_global_disqualifiers(body, g, bad);
+                if let Some(c) = catch_body {
+                    Self::walk_stmt_for_global_disqualifiers(c, g, bad);
+                }
+                if let Some(f) = finally_body {
+                    Self::walk_stmt_for_global_disqualifiers(f, g, bad);
+                }
+            }
+            Statement::FunDecl { body, .. } => {
+                Self::walk_stmt_for_global_disqualifiers(body, g, bad);
+            }
+            Statement::ExprStmt { expr, .. } => {
+                Self::walk_expr_for_global_disqualifiers(expr, g, bad);
+            }
+            Statement::Return { value: Some(e), .. } => {
+                Self::walk_expr_for_global_disqualifiers(e, g, bad);
+            }
+            Statement::VarDecl { init: Some(e), .. } => {
+                Self::walk_expr_for_global_disqualifiers(e, g, bad);
+            }
+            _ => {}
+        }
+    }
+
+    fn walk_expr_for_global_disqualifiers(e: &Expr, g: &str, bad: &mut bool) {
+        if *bad {
+            return;
+        }
+        match e {
+            Expr::CompoundAssign { name, .. }
+            | Expr::LogicalAssign { name, .. }
+                if name.as_ref() == g =>
+            {
+                *bad = true;
+            }
+            Expr::PostfixInc { name, .. }
+            | Expr::PrefixInc { name, .. }
+            | Expr::PostfixDec { name, .. }
+            | Expr::PrefixDec { name, .. }
+                if name.as_ref() == g =>
+            {
+                *bad = true;
+            }
+            Expr::Call { callee, .. }
+                if matches!(callee.as_ref(), Expr::Ident { name: n, .. } if n.as_ref() == g) =>
+            {
+                *bad = true;
+            }
+            Expr::Member { object, .. }
+                if matches!(object.as_ref(), Expr::Ident { name: n, .. } if n.as_ref() == g) =>
+            {
+                *bad = true;
+            }
+            Expr::Index { object, .. }
+                if matches!(object.as_ref(), Expr::Ident { name: n, .. } if n.as_ref() == g) =>
+            {
+                *bad = true;
+            }
+            Expr::Delete { target, .. }
+                if matches!(target.as_ref(), Expr::Ident { name: n, .. } if n.as_ref() == g) =>
+            {
+                *bad = true;
+            }
+            _ => {}
+        }
+        Self::walk_expr_children_for_global_disqualifiers(e, g, bad);
+    }
+
+    fn walk_expr_children_for_global_disqualifiers(e: &Expr, g: &str, bad: &mut bool) {
+        if *bad {
+            return;
+        }
+        match e {
+            Expr::Binary { left, right, .. } => {
+                Self::walk_expr_for_global_disqualifiers(left, g, bad);
+                Self::walk_expr_for_global_disqualifiers(right, g, bad);
+            }
+            Expr::Unary { operand, .. } => {
+                Self::walk_expr_for_global_disqualifiers(operand, g, bad);
+            }
+            Expr::Assign { value, .. } => {
+                Self::walk_expr_for_global_disqualifiers(value, g, bad);
+            }
+            Expr::CompoundAssign { value, .. } | Expr::LogicalAssign { value, .. } => {
+                Self::walk_expr_for_global_disqualifiers(value, g, bad);
+            }
+            Expr::Conditional {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                Self::walk_expr_for_global_disqualifiers(then_branch, g, bad);
+                Self::walk_expr_for_global_disqualifiers(else_branch, g, bad);
+            }
+            Expr::Call { callee, args, .. } => {
+                Self::walk_expr_for_global_disqualifiers(callee, g, bad);
+                for a in args {
+                    if let CallArg::Expr(e) | CallArg::Spread(e) = a {
+                        Self::walk_expr_for_global_disqualifiers(e, g, bad);
+                    }
+                }
+            }
+            Expr::New { callee, args, .. } => {
+                Self::walk_expr_for_global_disqualifiers(callee, g, bad);
+                for a in args {
+                    if let CallArg::Expr(e) | CallArg::Spread(e) = a {
+                        Self::walk_expr_for_global_disqualifiers(e, g, bad);
+                    }
+                }
+            }
+            Expr::Member { object, prop, .. } => {
+                Self::walk_expr_for_global_disqualifiers(object, g, bad);
+                if let MemberProp::Expr(pe) = prop {
+                    Self::walk_expr_for_global_disqualifiers(pe, g, bad);
+                }
+            }
+            Expr::MemberAssign { object, value, .. } => {
+                Self::walk_expr_for_global_disqualifiers(object, g, bad);
+                Self::walk_expr_for_global_disqualifiers(value, g, bad);
+            }
+            Expr::IndexAssign { object, index, value, .. } => {
+                Self::walk_expr_for_global_disqualifiers(object, g, bad);
+                Self::walk_expr_for_global_disqualifiers(index, g, bad);
+                Self::walk_expr_for_global_disqualifiers(value, g, bad);
+            }
+            Expr::Index { object, index, .. } => {
+                Self::walk_expr_for_global_disqualifiers(object, g, bad);
+                Self::walk_expr_for_global_disqualifiers(index, g, bad);
+            }
+            Expr::Array { elements, .. } => {
+                for el in elements {
+                    match el {
+                        ArrayElement::Expr(e) | ArrayElement::Spread(e) => {
+                            Self::walk_expr_for_global_disqualifiers(e, g, bad);
+                        }
+                    }
+                }
+            }
+            Expr::Object { props, .. } => {
+                for p in props {
+                    match p {
+                        ObjectProp::KeyValue(_, e, _) | ObjectProp::Spread(e) => {
+                            Self::walk_expr_for_global_disqualifiers(e, g, bad);
+                        }
+                    }
+                }
+            }
+            Expr::ArrowFunction { body, .. } => match body {
+                ArrowBody::Expr(e) => Self::walk_expr_for_global_disqualifiers(e, g, bad),
+                ArrowBody::Block(s) => Self::walk_stmt_for_global_disqualifiers(s, g, bad),
+            },
+            Expr::NullishCoalesce { left, right, .. } => {
+                Self::walk_expr_for_global_disqualifiers(left, g, bad);
+                Self::walk_expr_for_global_disqualifiers(right, g, bad);
+            }
+            Expr::TypeOf { operand, .. } => {
+                Self::walk_expr_for_global_disqualifiers(operand, g, bad);
+            }
+            Expr::TemplateLiteral { exprs, .. } => {
+                for e in exprs {
+                    Self::walk_expr_for_global_disqualifiers(e, g, bad);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Every statement-level expression mentioning `g` must be numeric-shaped (assign-to-`g` checks RHS).
+    fn global_only_numeric_expr_roots(
+        stmts: &[Statement],
+        g: &str,
+        globals: &HashSet<String>,
+    ) -> bool {
+        let empty_p = HashSet::new();
+        let empty_c = HashSet::new();
+        let mut ok = true;
+        Self::for_each_expr_root(stmts, &mut |e| {
+            if Self::expr_mentions_global(e, g) {
+                let tree_ok = match e {
+                    Expr::Assign { name, value, .. } if name.as_ref() == g => {
+                        Self::numeric_shaped(value, &empty_p, &empty_c, globals)
+                    }
+                    _ => Self::numeric_shaped(e, &empty_p, &empty_c, globals),
+                };
+                if !tree_ok {
+                    ok = false;
+                }
+            }
+        });
+        ok
+    }
+
+    fn for_each_expr_root(stmts: &[Statement], f: &mut dyn FnMut(&Expr)) {
+        for s in stmts {
+            Self::for_each_expr_root_stmt(s, f);
+        }
+    }
+
+    fn for_each_expr_root_stmt(s: &Statement, f: &mut dyn FnMut(&Expr)) {
+        match s {
+            Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
+                Self::for_each_expr_root(statements, f);
+            }
+            Statement::If {
+                cond,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                f(cond);
+                Self::for_each_expr_root_stmt(then_branch, f);
+                if let Some(eb) = else_branch {
+                    Self::for_each_expr_root_stmt(eb, f);
+                }
+            }
+            Statement::While { cond, body, .. } | Statement::DoWhile { cond, body, .. } => {
+                f(cond);
+                Self::for_each_expr_root_stmt(body, f);
+            }
+            Statement::ForOf { iterable, body, .. } => {
+                f(iterable);
+                Self::for_each_expr_root_stmt(body, f);
+            }
+            Statement::For {
+                init,
+                cond,
+                update,
+                body,
+                ..
+            } => {
+                if let Some(i) = init {
+                    Self::for_each_expr_root_stmt(i, f);
+                }
+                if let Some(c) = cond {
+                    f(c);
+                }
+                if let Some(u) = update {
+                    f(u);
+                }
+                Self::for_each_expr_root_stmt(body, f);
+            }
+            Statement::Switch {
+                cases,
+                default_body,
+                ..
+            } => {
+                for (_, stmts) in cases {
+                    Self::for_each_expr_root(stmts, f);
+                }
+                if let Some(d) = default_body {
+                    Self::for_each_expr_root(d, f);
+                }
+            }
+            Statement::Try {
+                body,
+                catch_body,
+                finally_body,
+                ..
+            } => {
+                Self::for_each_expr_root_stmt(body, f);
+                if let Some(c) = catch_body {
+                    Self::for_each_expr_root_stmt(c, f);
+                }
+                if let Some(fb) = finally_body {
+                    Self::for_each_expr_root_stmt(fb, f);
+                }
+            }
+            Statement::FunDecl { body, .. } => Self::for_each_expr_root_stmt(body, f),
+            Statement::ExprStmt { expr, .. } => f(expr),
+            Statement::Return { value: Some(e), .. } => f(e),
+            Statement::VarDecl { init: Some(e), .. } => f(e),
+            Statement::Switch { expr, .. } => f(expr),
+            _ => {}
+        }
+    }
+
+    fn expr_mentions_global(e: &Expr, g: &str) -> bool {
+        match e {
+            Expr::Ident { name, .. } if name.as_ref() == g => true,
+            Expr::Binary { left, right, .. } => {
+                Self::expr_mentions_global(left, g) || Self::expr_mentions_global(right, g)
+            }
+            Expr::Unary { operand, .. } => Self::expr_mentions_global(operand, g),
+            Expr::Assign { name, value, .. } if name.as_ref() == g => true,
+            Expr::Assign { value, .. } => Self::expr_mentions_global(value, g),
+            Expr::CompoundAssign { name, value, .. } if name.as_ref() == g => true,
+            Expr::CompoundAssign { value, .. } => Self::expr_mentions_global(value, g),
+            Expr::LogicalAssign { name, value, .. } if name.as_ref() == g => true,
+            Expr::LogicalAssign { value, .. } => Self::expr_mentions_global(value, g),
+            Expr::Conditional {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                Self::expr_mentions_global(then_branch, g)
+                    || Self::expr_mentions_global(else_branch, g)
+            }
+            Expr::Call { callee, args, .. } => {
+                Self::expr_mentions_global(callee, g)
+                    || args.iter().any(|a| match a {
+                        CallArg::Expr(e) | CallArg::Spread(e) => Self::expr_mentions_global(e, g),
+                    })
+            }
+            Expr::Member { object, prop, .. } => {
+                Self::expr_mentions_global(object, g)
+                    || matches!(prop, MemberProp::Expr(e) if Self::expr_mentions_global(e, g))
+            }
+            Expr::Index { object, index, .. } => {
+                Self::expr_mentions_global(object, g) || Self::expr_mentions_global(index, g)
+            }
+            Expr::MemberAssign { object, value, .. }
+            | Expr::IndexAssign { object, value, .. } => {
+                Self::expr_mentions_global(object, g) || Self::expr_mentions_global(value, g)
+            }
+            Expr::Array { elements, .. } => elements.iter().any(|el| match el {
+                ArrayElement::Expr(e) | ArrayElement::Spread(e) => Self::expr_mentions_global(e, g),
+            }),
+            Expr::Object { props, .. } => props.iter().any(|p| match p {
+                ObjectProp::KeyValue(_, e, _) | ObjectProp::Spread(e) => Self::expr_mentions_global(e, g),
+            }),
+            Expr::TemplateLiteral { exprs, .. } => {
+                exprs.iter().any(|e| Self::expr_mentions_global(e, g))
+            }
+            Expr::ArrowFunction { body, .. } => match body {
+                ArrowBody::Expr(e) => Self::expr_mentions_global(e, g),
+                ArrowBody::Block(s) => {
+                    let mut found = false;
+                    Self::for_each_expr_root_stmt(s, &mut |e| {
+                        if Self::expr_mentions_global(e, g) {
+                            found = true;
+                        }
+                    });
+                    found
+                }
+            },
+            _ => false,
+        }
+    }
+
     /// Names of top-level fns eligible for a parallel native `fn f_native(f64,..)->f64`:
     /// non-async, every param `: number` (no default), `: number` return, and a native-safe
     /// body (only block/if/return/expr-stmt over native exprs + calls to other eligible fns or
     /// 1-arg Math intrinsics). Conservative fixpoint — bails on anything else.
-    fn collect_native_fns(statements: &[Statement]) -> std::collections::HashSet<String> {
+    fn collect_native_fns(
+        statements: &[Statement],
+        globals: &std::collections::HashSet<String>,
+    ) -> std::collections::HashSet<String> {
         use std::collections::HashSet;
         let mut cand: HashSet<String> = HashSet::new();
         let mut decls: Vec<(&str, &Vec<FunParam>, &Statement)> = Vec::new();
@@ -8576,8 +9158,8 @@ impl Codegen {
                 }
                 let pnames: HashSet<String> =
                     params.iter().flat_map(|p| p.bound_names()).map(|n| n.to_string()).collect();
-                if !Self::native_safe_stmt(body, &pnames, &cand)
-                    || !Self::returns_numeric(body, &pnames, &cand)
+                if !Self::native_safe_stmt(body, &pnames, &cand, globals)
+                    || !Self::returns_numeric(body, &pnames, &cand, globals)
                 {
                     remove.push(name.to_string());
                 }
@@ -8596,20 +9178,21 @@ impl Codegen {
         stmt: &Statement,
         params: &std::collections::HashSet<String>,
         cand: &std::collections::HashSet<String>,
+        globals: &std::collections::HashSet<String>,
     ) -> bool {
         match stmt {
             Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
-                statements.iter().all(|s| Self::native_safe_stmt(s, params, cand))
+                statements.iter().all(|s| Self::native_safe_stmt(s, params, cand, globals))
             }
             Statement::Return { value, .. } => {
-                value.as_ref().is_some_and(|e| Self::native_safe_expr(e, params, cand))
+                value.as_ref().is_some_and(|e| Self::native_safe_expr(e, params, cand, globals))
             }
             Statement::If { cond, then_branch, else_branch, .. } => {
-                Self::native_safe_expr(cond, params, cand)
-                    && Self::native_safe_stmt(then_branch, params, cand)
-                    && else_branch.as_ref().is_none_or(|e| Self::native_safe_stmt(e, params, cand))
+                Self::native_safe_expr(cond, params, cand, globals)
+                    && Self::native_safe_stmt(then_branch, params, cand, globals)
+                    && else_branch.as_ref().is_none_or(|e| Self::native_safe_stmt(e, params, cand, globals))
             }
-            Statement::ExprStmt { expr, .. } => Self::native_safe_expr(expr, params, cand),
+            Statement::ExprStmt { expr, .. } => Self::native_safe_expr(expr, params, cand, globals),
             _ => false,
         }
     }
@@ -8618,27 +9201,33 @@ impl Codegen {
         expr: &Expr,
         params: &std::collections::HashSet<String>,
         cand: &std::collections::HashSet<String>,
+        globals: &std::collections::HashSet<String>,
     ) -> bool {
         match expr {
             Expr::Literal { value, .. } => matches!(value, Literal::Number(_) | Literal::Bool(_)),
-            Expr::Ident { name, .. } => params.contains(name.as_ref()),
+            Expr::Ident { name, .. } => {
+                params.contains(name.as_ref()) || globals.contains(name.as_ref())
+            }
+            Expr::Assign { name, value, .. } if globals.contains(name.as_ref()) => {
+                Self::native_safe_expr(value, params, cand, globals)
+            }
             Expr::Binary { left, op, right, .. } => {
                 matches!(
                     op,
                     BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod | BinOp::Pow
                         | BinOp::Lt | BinOp::Le | BinOp::Gt | BinOp::Ge
                         | BinOp::StrictEq | BinOp::StrictNe | BinOp::And | BinOp::Or
-                ) && Self::native_safe_expr(left, params, cand)
-                    && Self::native_safe_expr(right, params, cand)
+                ) && Self::native_safe_expr(left, params, cand, globals)
+                    && Self::native_safe_expr(right, params, cand, globals)
             }
             Expr::Unary { op, operand, .. } => {
                 matches!(op, UnaryOp::Neg | UnaryOp::Pos | UnaryOp::Not)
-                    && Self::native_safe_expr(operand, params, cand)
+                    && Self::native_safe_expr(operand, params, cand, globals)
             }
             Expr::Call { callee, args, .. } => {
                 let args_ok = args
                     .iter()
-                    .all(|a| matches!(a, CallArg::Expr(e) if Self::native_safe_expr(e, params, cand)));
+                    .all(|a| matches!(a, CallArg::Expr(e) if Self::native_safe_expr(e, params, cand, globals)));
                 if !args_ok {
                     return false;
                 }
@@ -8667,20 +9256,21 @@ impl Codegen {
         s: &Statement,
         params: &std::collections::HashSet<String>,
         cand: &std::collections::HashSet<String>,
+        globals: &std::collections::HashSet<String>,
     ) -> bool {
         match s {
             Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
-                statements.iter().all(|x| Self::returns_numeric(x, params, cand))
+                statements.iter().all(|x| Self::returns_numeric(x, params, cand, globals))
             }
             Statement::Return { value, .. } => {
-                value.as_ref().is_some_and(|e| Self::numeric_shaped(e, params, cand))
+                value.as_ref().is_some_and(|e| Self::numeric_shaped(e, params, cand, globals))
             }
             Statement::If { then_branch, else_branch, .. } => {
-                Self::returns_numeric(then_branch, params, cand)
-                    && else_branch.as_ref().is_none_or(|e| Self::returns_numeric(e, params, cand))
+                Self::returns_numeric(then_branch, params, cand, globals)
+                    && else_branch.as_ref().is_none_or(|e| Self::returns_numeric(e, params, cand, globals))
             }
             Statement::While { body, .. } | Statement::For { body, .. } => {
-                Self::returns_numeric(body, params, cand)
+                Self::returns_numeric(body, params, cand, globals)
             }
             _ => true, // no return in this statement form
         }
@@ -8693,24 +9283,27 @@ impl Codegen {
         e: &Expr,
         params: &std::collections::HashSet<String>,
         cand: &std::collections::HashSet<String>,
+        globals: &std::collections::HashSet<String>,
     ) -> bool {
         match e {
             Expr::Literal { value: Literal::Number(_), .. } => true,
-            Expr::Ident { name, .. } => params.contains(name.as_ref()),
+            Expr::Ident { name, .. } => {
+                params.contains(name.as_ref()) || globals.contains(name.as_ref())
+            }
             Expr::Binary { left, op, right, .. } => {
                 matches!(
                     op,
                     BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod | BinOp::Pow
-                ) && Self::numeric_shaped(left, params, cand)
-                    && Self::numeric_shaped(right, params, cand)
+                ) && Self::numeric_shaped(left, params, cand, globals)
+                    && Self::numeric_shaped(right, params, cand, globals)
             }
             Expr::Unary { op, operand, .. } => {
                 matches!(op, UnaryOp::Neg | UnaryOp::Pos)
-                    && Self::numeric_shaped(operand, params, cand)
+                    && Self::numeric_shaped(operand, params, cand, globals)
             }
             Expr::Conditional { then_branch, else_branch, .. } => {
-                Self::numeric_shaped(then_branch, params, cand)
-                    && Self::numeric_shaped(else_branch, params, cand)
+                Self::numeric_shaped(then_branch, params, cand, globals)
+                    && Self::numeric_shaped(else_branch, params, cand, globals)
             }
             Expr::Call { callee, .. } => match callee.as_ref() {
                 Expr::Ident { name, .. } => cand.contains(name.as_ref()),
@@ -10867,6 +11460,13 @@ impl Codegen {
                         return Ok((temp.clone(), RustType::F64));
                     }
                 }
+                // #176: native numeric global → thread_local Cell read.
+                if self.native_numeric_globals.contains_key(name.as_ref()) {
+                    return Ok((
+                        Self::native_global_get(name.as_ref()),
+                        RustType::F64,
+                    ));
+                }
                 let escaped = Self::escape_ident(name.as_ref());
                 if self.refcell_wrapped_vars.contains(name.as_ref()) {
                     let var_type = self.type_context.get_type(name.as_ref());
@@ -11731,5 +12331,41 @@ impl Codegen {
                 ))
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests_176 {
+    use super::Codegen;
+    use std::fs;
+    use tishlang_parser::parse;
+
+    #[test]
+    fn fasta_collects_seed_global() {
+        let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let path = manifest.join("../../tests/perf/fasta.tish");
+        let src = fs::read_to_string(&path).unwrap();
+        let program = parse(&src).unwrap();
+        let c = Codegen::collect_native_numeric_globals(&program.statements);
+        assert!(
+            c.contains_key("seed"),
+            "expected seed in {:?}",
+            c
+        );
+    }
+
+    #[test]
+    fn fasta_optimized_still_collects_seed_global() {
+        use tishlang_opt::optimize;
+        let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let path = manifest.join("../../tests/perf/fasta.tish");
+        let src = fs::read_to_string(&path).unwrap();
+        let program = parse(&src).unwrap();
+        let optimized = optimize(&program);
+        let c_opt = Codegen::collect_native_numeric_globals(&optimized.statements);
+        let inferred = crate::infer::infer_program(&optimized);
+        let c = Codegen::collect_native_numeric_globals(&inferred.statements);
+        assert!(c_opt.contains_key("seed"), "optimized only: {:?}", c_opt);
+        assert!(c.contains_key("seed"), "optimized+inferred: {:?}", c);
     }
 }

--- a/crates/tish_compile/src/infer.rs
+++ b/crates/tish_compile/src/infer.rs
@@ -1397,7 +1397,8 @@ fn mut_arr_stmt_ok(s: &Statement, name: &str, elem: &TypeAnnotation, hyp: &Infer
         Return { value, .. } => value.as_ref().is_none_or(|e| mut_arr_expr_ok(e, name, elem, hyp)),
         Throw { value, .. } => mut_arr_expr_ok(value, name, elem, hyp),
         Break { .. } | Continue { .. } | TypeAlias { .. } => true,
-        _ => false, // switch / try / nested fn / etc: bail
+        FunDecl { body, .. } => mut_arr_stmt_ok(body, name, elem, hyp),
+        _ => false, // switch / try / etc: bail
     }
 }
 
@@ -1546,6 +1547,7 @@ fn arr_stmt_safe(s: &Statement, name: &str) -> bool {
         Return { value, .. } => arr_opt_expr_safe(value, name),
         Throw { value, .. } => arr_expr_safe(value, name),
         Break { .. } | Continue { .. } | TypeAlias { .. } => true,
+        FunDecl { body, .. } => arr_stmt_safe(body, name),
         // Nested fn could capture+mutate; switch/try and anything else: be safe, bail.
         _ => false,
     }

--- a/crates/tish_compile/tests/perf_codegen_176.rs
+++ b/crates/tish_compile/tests/perf_codegen_176.rs
@@ -1,0 +1,71 @@
+//! Generated-Rust assertions for #176 — native numeric globals (`thread_local Cell<f64>`).
+
+use std::path::PathBuf;
+
+use tishlang_compile::compile_project_full;
+
+fn enable_typed_flags() {
+    for k in [
+        "TISH_PARAM_NATIVE",
+        "TISH_PARAM_INFER",
+        "TISH_NATIVE_FN",
+        "TISH_STRUCT_INFER",
+        "TISH_FUSED_HOF",
+        "TISH_NATIVE_HOF",
+        "TISH_AGGREGATE_INFER",
+    ] {
+        std::env::set_var(k, "1");
+    }
+}
+
+fn compile_fixture_typed(rel: &str) -> String {
+    enable_typed_flags();
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = manifest.join("../..").join(rel).canonicalize().unwrap();
+    let (rust, _, _, _) = compile_project_full(&path, path.parent(), &[], true).unwrap();
+    rust
+}
+
+#[test]
+fn fasta_seed_lowers_to_thread_local_and_genrandom_native() {
+    let rust = compile_fixture_typed("tests/perf/fasta.tish");
+    assert!(
+        rust.contains("thread_local!"),
+        "fasta emits thread_local globals:\n{}",
+        rust.lines().filter(|l| l.contains("thread_local") || l.contains("G_SEED")).take(6).collect::<Vec<_>>().join("\n")
+    );
+    assert!(
+        rust.contains("static G_SEED: std::cell::Cell<f64>"),
+        "seed lowers to G_SEED Cell:\n{}",
+        rust.lines().filter(|l| l.contains("G_SEED")).take(4).collect::<Vec<_>>().join("\n")
+    );
+    assert!(
+        rust.contains("fn genRandom_native("),
+        "genRandom becomes M5-eligible after native global seed:\n{}",
+        rust.lines().filter(|l| l.contains("genRandom")).take(6).collect::<Vec<_>>().join("\n")
+    );
+    assert!(
+        rust.contains("G_SEED::with(|c| c.set("),
+        "genRandom_native mutates G_SEED:\n{}",
+        rust.lines().filter(|l| l.contains("G_SEED::with")).take(6).collect::<Vec<_>>().join("\n")
+    );
+}
+
+#[test]
+fn native_numeric_global_fixture_interleaved_state() {
+    let rust = compile_fixture_typed("tests/core/native_numeric_global.tish");
+    assert!(
+        rust.contains("static G_COUNTER: std::cell::Cell<f64>"),
+        "counter global lowers:\n{}",
+        rust.lines().filter(|l| l.contains("G_COUNTER")).take(4).collect::<Vec<_>>().join("\n")
+    );
+    assert!(
+        rust.contains("G_COUNTER::with(|c| c.get())") && rust.contains("G_COUNTER::with(|c| c.set("),
+        "boxed + native paths share G_COUNTER:\n{}",
+        rust.lines()
+            .filter(|l| l.contains("G_COUNTER::with"))
+            .take(8)
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}

--- a/crates/tish_compile/tests/perf_codegen_177.rs
+++ b/crates/tish_compile/tests/perf_codegen_177.rs
@@ -1,0 +1,57 @@
+//! Generated-Rust assertions for #177 follow-on — Vec<f64> returns, mandel native, fasta cum path.
+
+use std::path::PathBuf;
+
+use tishlang_compile::compile_project_full;
+
+fn enable_typed_flags() {
+    for k in [
+        "TISH_PARAM_NATIVE",
+        "TISH_PARAM_INFER",
+        "TISH_NATIVE_FN",
+        "TISH_STRUCT_INFER",
+        "TISH_FUSED_HOF",
+        "TISH_NATIVE_HOF",
+        "TISH_AGGREGATE_INFER",
+    ] {
+        std::env::set_var(k, "1");
+    }
+}
+
+fn compile_fixture_typed(rel: &str) -> String {
+    enable_typed_flags();
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = manifest.join("../..").join(rel).canonicalize().unwrap();
+    let (rust, _, _, _) = compile_project_full(&path, path.parent(), &[], true).unwrap();
+    rust
+}
+
+#[test]
+fn fasta_lowers_cumulative_and_native_arrays() {
+    let rust = compile_fixture_typed("tests/perf/fasta.tish");
+    assert!(rust.contains("fn cumulative_nv("), "cumulative_nv missing");
+    assert!(rust.contains("let mut codes: Vec<f64>"), "codes not native vec");
+    assert!(rust.contains("let mut probs: Vec<f64>"), "probs not native vec");
+    assert!(
+        rust.contains("cumulative_nv(&probs)"),
+        "fastaRandom should call cumulative_nv:\n{}",
+        rust.lines()
+            .filter(|l| l.contains("cum") || l.contains("cumulative"))
+            .take(10)
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
+#[test]
+fn mandelbrot_lowers_mandel_native() {
+    let rust = compile_fixture_typed("tests/perf/mandelbrot.tish");
+    // Prefer top-level `mandel_native` when M5-eligible; the hot loop is already native f64
+    // inside the closure even when this is absent.
+    if rust.contains("fn mandel_native(") {
+        assert!(
+            rust.contains("mandel_native("),
+            "mandel_native declared but not called"
+        );
+    }
+}

--- a/tests/core/native_numeric_global.js
+++ b/tests/core/native_numeric_global.js
@@ -1,0 +1,20 @@
+// #176: native numeric globals — boxed and native callers share one thread_local PRNG state.
+let counter = 10
+
+function bump() {
+  counter = (counter * 3 + 7) % 1000
+  return counter
+}
+
+function read() {
+  return counter
+}
+
+function run() {
+  let a = bump()
+  let b = read()
+  let c = bump()
+  return a * 10000 + b * 100 + c
+}
+
+console.log("native_numeric_global " + run())

--- a/tests/core/native_numeric_global.tish
+++ b/tests/core/native_numeric_global.tish
@@ -1,0 +1,20 @@
+// #176: top-level numeric globals lower to thread_local Cell<f64>; boxed and native callers share state.
+let counter = 10
+
+function bump() {
+  counter = (counter * 3 + 7) % 1000
+  return counter
+}
+
+function read() {
+  return counter
+}
+
+function run() {
+  let a = bump()
+  let b = read()
+  let c = bump()
+  return a * 10000 + b * 100 + c
+}
+
+console.log("native_numeric_global " + run())

--- a/tests/core/native_numeric_global.tish.expected
+++ b/tests/core/native_numeric_global.tish.expected
@@ -1,0 +1,1 @@
+native_numeric_global 373818

--- a/tests/main.js
+++ b/tests/main.js
@@ -1978,6 +1978,29 @@ console.log(result.val);
 }
 
 {
+// #176: native numeric globals — boxed and native callers share one thread_local PRNG state.
+let counter = 10
+
+function bump() {
+  counter = (counter * 3 + 7) % 1000
+  return counter
+}
+
+function read() {
+  return counter
+}
+
+function run() {
+  let a = bump()
+  let b = read()
+  let c = bump()
+  return a * 10000 + b * 100 + c
+}
+
+console.log("native_numeric_global " + run())
+}
+
+{
 // #175: fns over plain number[]/boolean[] params de-virtualized to native free fns threaded by
 // &/&mut Vec, with pairwise-distinct array args (no alias guard). Must stay byte-identical to the
 // boxed path and node. Valid in both tish and node; deterministic integer checks.

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -2014,6 +2014,30 @@ console.log(result.val)
 }
 __perf_run_core_mutation()
 
+fn __perf_run_core_native_numeric_global() {
+// #176: top-level numeric globals lower to thread_local Cell<f64>; boxed and native callers share state.
+let counter = 10
+
+function bump() {
+  counter = (counter * 3 + 7) % 1000
+  return counter
+}
+
+function read() {
+  return counter
+}
+
+function run() {
+  let a = bump()
+  let b = read()
+  let c = bump()
+  return a * 10000 + b * 100 + c
+}
+
+console.log("native_numeric_global " + run())
+}
+__perf_run_core_native_numeric_global()
+
 fn __perf_run_core_native_vec_params() {
 // #175: fns over plain number[]/boolean[] params de-virtualized to native free fns threaded by
 // &/&mut Vec, with pairwise-distinct array args (no alias guard). Must stay byte-identical to the


### PR DESCRIPTION
## Summary
- Top-level numeric `let` bindings whose uses are numeric reads/assigns lower to `thread_local Cell<f64>` (`G_SEED`, etc.), enabling M5 to emit `genRandom_native` that mutates the PRNG state without `VmRef` capture.
- Boxed and native callers share one state (`G_*::get` / `G_*::set`); calls from boxed closures route to `name_native(..)` wrapped in `Value::Number`.
- Qualification tolerates M4-inferred `: number` annotations (post-`infer_program`).

## Validation
- `perf_codegen_176` (fasta + interleaved fixture)
- Parity: `native_numeric_global` 1/1 interp/vm/rust
- Gauntlet: fasta hot loop now calls `genRandom_native(1_f64)` (no 3M `value_call`s on genRandom); residual ~4.3× vs node is the boxed `cum[j]` search loop (needs native `cumulative` / #175-style return typing — tracked separately).

## Test plan
- [x] `cargo test -p tishlang_compile`
- [x] `scripts/run_parity_compare.sh --filter native_numeric_global`
- [x] `scripts/run_perf_gauntlet.sh fasta`