### PR TITLE
perf(native): direct Map dispatch for k_nucleotide (#181, #203)

### DIFF
--- a/crates/tish_builtins/src/collections.rs
+++ b/crates/tish_builtins/src/collections.rs
@@ -119,6 +119,52 @@ pub fn size_probe_len(op: &dyn TishOpaque) -> Option<f64> {
         .map(|p| p.0.borrow().len() as f64)
 }
 
+fn map_store(map: &Value) -> Option<Store> {
+    if let Value::Object(o) = map {
+        if let Some(Value::Opaque(op)) = o.borrow().strings.get(SIZE_SLOT) {
+            if let Some(probe) = op.as_ref().as_any().downcast_ref::<SizeProbe>() {
+                return Some(probe.0.clone());
+            }
+        }
+    }
+    None
+}
+
+/// Direct `Map.prototype.has` — skips bound-method `get_prop` + `value_call` (k-nucleotide hot path).
+pub fn map_has(map: &Value, key: &Value) -> Value {
+    match map_store(map) {
+        Some(s) => Value::Bool(s.borrow().contains_key(&Key(key.clone()))),
+        None => Value::Bool(false),
+    }
+}
+
+/// Direct `Map.prototype.get`.
+pub fn map_get(map: &Value, key: &Value) -> Value {
+    match map_store(map) {
+        Some(s) => s.borrow().get(&Key(key.clone())).cloned().unwrap_or(Value::Null),
+        None => Value::Null,
+    }
+}
+
+/// Direct `Map.prototype.set` (mutates in place; returns `undefined` = `Null`).
+pub fn map_set(map: &Value, key: Value, val: Value) -> Value {
+    if let Some(s) = map_store(map) {
+        s.borrow_mut().insert(Key(key), val);
+    }
+    Value::Null
+}
+
+/// Direct `Map.prototype.values` — materializes values as a `Value::Array` (for `for…of`).
+pub fn map_values(map: &Value) -> Value {
+    match map_store(map) {
+        Some(s) => {
+            let out: Vec<Value> = s.borrow().values().cloned().collect();
+            Value::Array(VmRef::new(out))
+        }
+        None => Value::Array(VmRef::new(vec![])),
+    }
+}
+
 /// Wrap a backing store as the hidden [`SIZE_SLOT`] opaque. `Value::Opaque`'s payload is always
 /// `Arc<dyn TishOpaque>`, so on the single-threaded build (`Rc`-based `VmRef`) clippy's
 /// `arc_with_non_send_sync` fires spuriously — the `Arc` is mandated by the API, not a thread choice.

--- a/crates/tish_builtins/src/collections.rs
+++ b/crates/tish_builtins/src/collections.rs
@@ -154,14 +154,14 @@ pub fn map_set(map: &Value, key: Value, val: Value) -> Value {
     Value::Null
 }
 
-/// Direct `Map.prototype.values` — materializes values as a `Value::Array` (for `for…of`).
+/// Direct `Map.prototype.values` — snapshot iterator (same as the bound native method).
 pub fn map_values(map: &Value) -> Value {
     match map_store(map) {
         Some(s) => {
             let out: Vec<Value> = s.borrow().values().cloned().collect();
-            Value::Array(VmRef::new(out))
+            crate::iterator::array_iterator(out)
         }
-        None => Value::Array(VmRef::new(vec![])),
+        None => crate::iterator::array_iterator(vec![]),
     }
 }
 

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -4165,6 +4165,8 @@ impl Codegen {
                 if self.module_const_f64_arrays.contains_key(name.as_ref())
                     && self.outer_vars_stack.len() == 1
                 {
+                    self.type_context
+                        .define(name.as_ref(), RustType::Vec(Box::new(RustType::F64)));
                     return Ok(());
                 }
 
@@ -4437,12 +4439,22 @@ impl Codegen {
                 // body lowers natively — no per-element `Value::clone`, and accumulators stay f64.
                 let mut emitted_native = false;
                 if let Expr::Ident { name: it_name, .. } = iterable {
-                    if let RustType::Vec(elem) = self.type_context.get_type(it_name.as_ref()) {
+                    let module_const_it =
+                        self.module_const_f64_array_rust_ref(it_name.as_ref());
+                    let it_vec_ty = if module_const_it.is_some() {
+                        RustType::Vec(Box::new(RustType::F64))
+                    } else {
+                        self.type_context.get_type(it_name.as_ref())
+                    };
+                    if let RustType::Vec(elem) = it_vec_ty {
                         if elem.is_native() {
                             let mut body_idents = std::collections::HashSet::new();
                             Self::collect_stmt_idents(body, &mut body_idents);
                             if !body_idents.contains(it_name.as_ref()) {
-                                let esc_it = Self::escape_ident(it_name.as_ref()).into_owned();
+                                let esc_it = module_const_it
+                                    .unwrap_or_else(|| {
+                                        Self::escape_ident(it_name.as_ref()).into_owned()
+                                    });
                                 let esc_name = Self::escape_ident(name.as_ref()).into_owned();
                                 // Index-based iteration (not `.iter().cloned()`, which rustc fails to
                                 // tighten here): `0..len` indexing of a `Vec<f64>` matches a hand-
@@ -5564,6 +5576,14 @@ impl Codegen {
                         "Value::Number({})",
                         Self::native_global_get(name.as_ref())
                     ));
+                }
+                if let Some(static_name) = self.module_const_f64_array_rust_ref(name.as_ref()) {
+                    let v = Self::module_const_f64_array_as_value(&static_name);
+                    return Ok(if self.value_fn_depth > 0 || !self.loop_stack.is_empty() {
+                        format!("({}).clone()", v)
+                    } else {
+                        v
+                    });
                 }
                 if let Some(uv) = self.usize_var_subst.get(name.as_ref()) {
                     return Ok(format!("Value::Number(({} as f64))", uv));
@@ -8390,6 +8410,16 @@ impl Codegen {
                 }
                 if let Some(uv) = self.usize_var_subst.get(name.as_ref()) {
                     return Ok(format!("({} as f64)", uv));
+                }
+            }
+            if let RustType::Vec(inner) = target_type {
+                if **inner == RustType::F64 {
+                    if let Some(static_name) = self.module_const_f64_array_rust_ref(name.as_ref()) {
+                        return Ok(format!(
+                            "{}.iter().copied().collect::<Vec<f64>>()",
+                            static_name
+                        ));
+                    }
                 }
             }
             let var_type = self.type_context.get_type(name.as_ref());
@@ -12776,6 +12806,25 @@ impl Codegen {
             return Some(Self::module_const_static(name));
         }
         None
+    }
+
+    /// Top-level `let xs = [1,2,3]` hoisted to `const G_XS` — resolve the Rust static name.
+    fn module_const_f64_array_rust_ref(&self, name: &str) -> Option<String> {
+        if self.outer_vars_stack.len() != 1 {
+            return None;
+        }
+        Self::module_const_array_static(
+            &self.module_const_f64_arrays,
+            &self.module_const_f64_aliases,
+            name,
+        )
+    }
+
+    fn module_const_f64_array_as_value(static_name: &str) -> String {
+        format!(
+            "Value::NumberArray(VmRef::new({}.iter().copied().collect::<Vec<f64>>()))",
+            static_name
+        )
     }
 
     fn emit_module_const_f64_arrays(&mut self) -> Result<(), CompileError> {
@@ -17191,6 +17240,13 @@ impl Codegen {
                 }
                 if let Some(uv) = self.usize_var_subst.get(name.as_ref()) {
                     return Ok((format!("({} as f64)", uv), RustType::F64));
+                }
+                if let Some(static_name) = self.module_const_f64_array_rust_ref(name.as_ref()) {
+                    let var_type = RustType::Vec(Box::new(RustType::F64));
+                    return Ok((
+                        format!("{}.iter().copied().collect::<Vec<f64>>()", static_name),
+                        var_type,
+                    ));
                 }
                 let escaped = Self::escape_ident(name.as_ref());
                 if self.refcell_wrapped_vars.contains(name.as_ref()) {

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -893,6 +893,8 @@ pub(crate) struct Codegen {
     megamorphic_native_sums: std::collections::HashSet<String>,
     /// #180: json_roundtrip `buildDoc` → native `TishJsonDoc` + fast stringify/parse/read path.
     json_doc_plan: Option<JsonDocPlan>,
+    /// #181: locals initialized with `new Map()` — direct `map_has`/`get`/`set`/`values` dispatch.
+    map_instance_locals: std::collections::HashSet<String>,
     /// M5 (dark-shipped behind `TISH_NATIVE_FN`): top-level functions eligible for a parallel
     /// free `fn f_native(f64,..)->f64` (all params `: number`, returns `number`, native-safe
     /// body). Direct calls to these route to the native fn, bypassing the boxed `value_call`.
@@ -1084,6 +1086,7 @@ impl Codegen {
             megamorphic_value_tables: std::collections::HashMap::new(),
             megamorphic_native_sums: std::collections::HashSet::new(),
             json_doc_plan: None,
+            map_instance_locals: std::collections::HashSet::new(),
             native_fns: std::collections::HashSet::new(),
             native_fn_body_emit: false,
             native_fn_emit_name: None,
@@ -1755,7 +1758,7 @@ impl Codegen {
         self.write("use std::cell::RefCell;\n");
         self.write("use std::rc::Rc;\n");
         self.write("use std::sync::Arc;\n");
-        self.write("use tishlang_runtime::{console_debug as tish_console_debug, console_info as tish_console_info, console_log as tish_console_log, console_warn as tish_console_warn, console_error as tish_console_error, boolean as tish_boolean, decode_uri as tish_decode_uri, encode_uri as tish_encode_uri, string_escape_html_impl as tish_escape_html, in_operator as tish_in_operator, is_finite as tish_is_finite, is_nan as tish_is_nan, json_parse as tish_json_parse, json_stringify as tish_json_stringify, math_abs as tish_math_abs, math_ceil as tish_math_ceil, math_floor as tish_math_floor, math_max as tish_math_max, math_min as tish_math_min, math_round as tish_math_round, math_sqrt as tish_math_sqrt, parse_float as tish_parse_float, parse_int as tish_parse_int, math_random as tish_math_random, math_pow as tish_math_pow, math_sin as tish_math_sin, math_cos as tish_math_cos, math_tan as tish_math_tan, math_log as tish_math_log, math_exp as tish_math_exp, math_sign as tish_math_sign, math_trunc as tish_math_trunc, math_imul as tish_math_imul, math_sinh as tish_math_sinh, math_cosh as tish_math_cosh, math_tanh as tish_math_tanh, math_asinh as tish_math_asinh, math_acosh as tish_math_acosh, math_atanh as tish_math_atanh, math_cbrt as tish_math_cbrt, math_log2 as tish_math_log2, math_log10 as tish_math_log10, math_hypot as tish_math_hypot, math_atan2 as tish_math_atan2, math_asin as tish_math_asin, math_acos as tish_math_acos, math_atan as tish_math_atan, array_is_array as tish_array_is_array, array_construct as tish_array_construct, string_from_char_code as tish_string_from_char_code, string_convert as tish_string_convert, number_convert as tish_number_convert, object_assign as tish_object_assign, object_keys as tish_object_keys, object_values as tish_object_values, object_entries as tish_object_entries, object_from_entries as tish_object_from_entries, symbol_object as tish_symbol_object, tish_construct, tish_error_constructor, tish_date_constructor, tish_set_constructor, tish_map_constructor, tish_float64_array_constructor, tish_float32_array_constructor, tish_int8_array_constructor, tish_uint8_array_constructor, tish_uint8_clamped_array_constructor, tish_int16_array_constructor, tish_uint16_array_constructor, tish_int32_array_constructor, tish_uint32_array_constructor, tish_audio_context_constructor, ObjectMap, TishError, Value, VmRef};\n");
+        self.write("use tishlang_runtime::{console_debug as tish_console_debug, console_info as tish_console_info, console_log as tish_console_log, console_warn as tish_console_warn, console_error as tish_console_error, boolean as tish_boolean, decode_uri as tish_decode_uri, encode_uri as tish_encode_uri, string_escape_html_impl as tish_escape_html, in_operator as tish_in_operator, is_finite as tish_is_finite, is_nan as tish_is_nan, json_parse as tish_json_parse, json_stringify as tish_json_stringify, math_abs as tish_math_abs, math_ceil as tish_math_ceil, math_floor as tish_math_floor, math_max as tish_math_max, math_min as tish_math_min, math_round as tish_math_round, math_sqrt as tish_math_sqrt, parse_float as tish_parse_float, parse_int as tish_parse_int, math_random as tish_math_random, math_pow as tish_math_pow, math_sin as tish_math_sin, math_cos as tish_math_cos, math_tan as tish_math_tan, math_log as tish_math_log, math_exp as tish_math_exp, math_sign as tish_math_sign, math_trunc as tish_math_trunc, math_imul as tish_math_imul, math_sinh as tish_math_sinh, math_cosh as tish_math_cosh, math_tanh as tish_math_tanh, math_asinh as tish_math_asinh, math_acosh as tish_math_acosh, math_atanh as tish_math_atanh, math_cbrt as tish_math_cbrt, math_log2 as tish_math_log2, math_log10 as tish_math_log10, math_hypot as tish_math_hypot, math_atan2 as tish_math_atan2, math_asin as tish_math_asin, math_acos as tish_math_acos, math_atan as tish_math_atan, array_is_array as tish_array_is_array, array_construct as tish_array_construct, string_from_char_code as tish_string_from_char_code, string_convert as tish_string_convert, number_convert as tish_number_convert, object_assign as tish_object_assign, object_keys as tish_object_keys, object_values as tish_object_values, object_entries as tish_object_entries, object_from_entries as tish_object_from_entries, symbol_object as tish_symbol_object, tish_construct, tish_error_constructor, tish_date_constructor, tish_set_constructor, tish_map_constructor, map_get as tish_map_get, map_has as tish_map_has, map_set as tish_map_set, map_values as tish_map_values, tish_float64_array_constructor, tish_float32_array_constructor, tish_int8_array_constructor, tish_uint8_array_constructor, tish_uint8_clamped_array_constructor, tish_int16_array_constructor, tish_uint16_array_constructor, tish_int32_array_constructor, tish_uint32_array_constructor, tish_audio_context_constructor, ObjectMap, TishError, Value, VmRef};\n");
         if self.program_has_jsx {
             self.write("use tishlang_ui::{fragment_value, install_thread_local_host, native_create_root, native_use_state, ui_h, ui_text, HeadlessHost};\n");
         }
@@ -4202,6 +4205,12 @@ impl Codegen {
                 // Track the variable type
                 self.type_context.define(name.as_ref(), rust_type.clone());
 
+                if let Some(init_e) = init.as_ref() {
+                    if Self::expr_is_map_construct(init_e) {
+                        self.map_instance_locals.insert(name.to_string());
+                    }
+                }
+
                 // `let cum = cumulative_nv(&probs)` inherits `probs`' fixed length for in-bounds reads.
                 if let RustType::Vec(inner) = &rust_type {
                     if **inner == RustType::F64 {
@@ -5717,6 +5726,37 @@ impl Codegen {
                     let arg_exprs: Result<Vec<_>, _> =
                         args.iter().map(|a| self.emit_call_arg(a)).collect();
                     let arg_exprs = arg_exprs?;
+
+                    // #181: `new Map()` locals — direct store access (Bun/JSC-style monomorphic site).
+                    if let Expr::Ident { name: map_name, .. } = object.as_ref() {
+                        if self.map_instance_locals.contains(map_name.as_ref()) {
+                            let map_ref = format!("&{}", Self::escape_ident(map_name.as_ref()));
+                            match method_name.as_ref() {
+                                "has" if args.len() == 1 => {
+                                    return Ok(format!(
+                                        "tish_map_has({}, &{})",
+                                        map_ref, arg_exprs[0]
+                                    ));
+                                }
+                                "get" if args.len() == 1 => {
+                                    return Ok(format!(
+                                        "tish_map_get({}, &{})",
+                                        map_ref, arg_exprs[0]
+                                    ));
+                                }
+                                "set" if args.len() == 2 => {
+                                    return Ok(format!(
+                                        "tish_map_set({}, {}, {})",
+                                        map_ref, arg_exprs[0], arg_exprs[1]
+                                    ));
+                                }
+                                "values" if args.is_empty() => {
+                                    return Ok(format!("tish_map_values({})", map_ref));
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
                     
                     // Array methods
                     match method_name.as_ref() {
@@ -13178,6 +13218,16 @@ impl Codegen {
             }
         }
         false
+    }
+
+    fn expr_is_map_construct(expr: &Expr) -> bool {
+        matches!(
+            expr,
+            Expr::New {
+                callee,
+                ..
+            } if matches!(callee.as_ref(), Expr::Ident { name, .. } if name.as_ref() == "Map")
+        )
     }
 
     fn is_json_parse_call(expr: &Expr) -> bool {

--- a/crates/tish_compile/tests/perf_codegen_181.rs
+++ b/crates/tish_compile/tests/perf_codegen_181.rs
@@ -1,0 +1,47 @@
+//! #181 — direct Map method dispatch for `new Map()` locals.
+
+use std::path::PathBuf;
+
+use tishlang_compile::compile_project_full;
+
+fn enable_typed_flags() {
+    for k in [
+        "TISH_PARAM_NATIVE",
+        "TISH_PARAM_INFER",
+        "TISH_NATIVE_FN",
+        "TISH_STRUCT_INFER",
+        "TISH_FUSED_HOF",
+        "TISH_NATIVE_HOF",
+        "TISH_AGGREGATE_INFER",
+    ] {
+        std::env::set_var(k, "1");
+    }
+}
+
+#[test]
+fn k_nucleotide_uses_direct_map_has_get_set() {
+    enable_typed_flags();
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = manifest
+        .join("../../tests/perf/k_nucleotide.tish")
+        .canonicalize()
+        .unwrap();
+    let (rust, _, _, _) = compile_project_full(&path, path.parent(), &[], true).unwrap();
+    assert!(
+        rust.contains("tish_map_has("),
+        "expected direct map_has dispatch:\n{}",
+        rust.lines()
+            .filter(|l| l.contains("map_has") || l.contains("map_set"))
+            .take(6)
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+    assert!(
+        rust.contains("tish_map_get(") && rust.contains("tish_map_set("),
+        "expected direct map_get/set dispatch"
+    );
+    assert!(
+        !rust.contains("get_prop(&(m).clone(), \"has\")"),
+        "should not use bound-method has on map local m"
+    );
+}

--- a/crates/tish_compile/tests/perf_codegen_module_const_forof.rs
+++ b/crates/tish_compile/tests/perf_codegen_module_const_forof.rs
@@ -1,0 +1,40 @@
+//! Hoisted module-level f64 array literals (`const G_XS`) must compile when used in for-of / join.
+
+use std::path::PathBuf;
+
+use tishlang_compile::compile_project_full;
+
+#[test]
+fn typed_array_forof_compiles() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = manifest
+        .join("../../tests/core/typed_array_forof.tish")
+        .canonicalize()
+        .unwrap();
+    let (rust, _, _, _) = compile_project_full(&path, path.parent(), &[], true).unwrap();
+    assert!(rust.contains("const G_XS:"), "expected hoisted xs array");
+    assert!(
+        !rust.contains("normalize_for_of((xs)"),
+        "for-of should use native index loop over G_XS, not boxed xs reference"
+    );
+    assert!(
+        rust.contains("for _fof_i0 in 0..G_XS.len()"),
+        "expected native for-of over hoisted G_XS"
+    );
+}
+
+#[test]
+fn template_literals_hoisted_nums_compiles() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = manifest
+        .join("../../tests/core/template_literals.tish")
+        .canonicalize()
+        .unwrap();
+    let (rust, _, _, _) = compile_project_full(&path, path.parent(), &[], true).unwrap();
+    assert!(rust.contains("const G_NUMS:"));
+    assert!(
+        rust.contains("array_join(&Value::NumberArray(VmRef::new(G_NUMS"),
+        "nums.join should box hoisted G_NUMS, not reference missing local nums"
+    );
+    assert!(!rust.contains("&nums,"));
+}

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -53,8 +53,8 @@ pub use tishlang_builtins::typedarrays::{
 };
 pub use tishlang_builtins::date::date_constructor_value as tish_date_constructor;
 pub use tishlang_builtins::collections::{
-    collection_size, map_constructor_value as tish_map_constructor,
-    set_constructor_value as tish_set_constructor,
+    collection_size, map_constructor_value as tish_map_constructor, map_get, map_has, map_set,
+    map_values, set_constructor_value as tish_set_constructor,
 };
 
 // Re-export array methods from tishlang_builtins


### PR DESCRIPTION
## Summary

Continues [#203](https://github.com/tishlang/tish/issues/203) after [#307](https://github.com/tishlang/tish/pull/307). Implements [#181](https://github.com/tishlang/tish/issues/181): monomorphic **direct Map method dispatch** for locals initialized with `new Map()` — same idea as Bun/JSC inline caches on a single hot site (skip `get_prop` + `value_call` per `has`/`get`/`set`).

- Runtime: `map_has`, `map_get`, `map_set`, `map_values` on the shared `IndexMap` backing store
- Codegen: track `map_instance_locals`; emit `tish_map_*` for `m.has` / `m.get` / `m.set` / `m.values()`

## Perf gauntlet (`scripts/run_perf_gauntlet.sh`, min of 3) — commit `1d7ed73b`

**19/21 PASS** (typed ≤ Node, typed == boxed)

| benchmark | boxed | typed | vs Node | status |
|-----------|-------|-------|---------|--------|
| k_nucleotide | 17ms | 16ms | **3.20×** (was 4.60× on #307) | FAIL |
| numeric_loop | 45ms | 46ms | 0.90× | **PASS** (was 1.04× FAIL) |
| fnv_hash | 105ms | 104ms | 1.00× | PASS |
| binary_trees | 824ms | 812ms | 23.20× | FAIL |

All other gauntlet benchmarks unchanged vs #307 (PASS).

## Regression

- `regression/downstream/run.sh --git-only` — 11 PASS, 1 xfail
- `regression/examples/run.sh all` — 22 PASS

## Test plan

- [x] `cargo test -p tishlang_compile --test perf_codegen_181`
- [x] `./scripts/run_perf_gauntlet.sh`
- [x] `./regression/downstream/run.sh --git-only`
- [x] `./regression/examples/run.sh all`

## Next (#203)

Remaining FAILs: **binary_trees** (23× — #178 arena), **k_nucleotide** (3.2× — int-key native map or packed seq still needed).