### PR TITLE
perf(native): gate all fixture-substitution/sidestep folds → honest gauntlet (#203)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -13118,6 +13118,9 @@ impl Codegen {
     }
 
     fn setup_json_doc_plan(&mut self, stmts: &[Statement]) {
+        if !Self::gauntlet_fusion_enabled() {
+            return; // fixture-shape-bound TishJsonDoc fold — off unless TISH_GAUNTLET_FUSION
+        }
         if let Some((factory, doc_local, s_local, parsed_local, acc_local)) =
             Self::detect_json_doc_program(stmts)
         {
@@ -13162,9 +13165,24 @@ impl Codegen {
         }
     }
 
+    /// #203: the fixture-substitution / sidestep folds — the k_nucleotide & binary_trees substitution
+    /// kernels, the megamorphic literal const-fold, and the TishJsonDoc shape-bound path — are FAKE
+    /// gauntlet wins: each detects a specific fixture (by identifier names / exact shape) and either
+    /// substitutes a hardcoded answer or sidesteps the operation the benchmark measures. They are OFF
+    /// by default so the gauntlet reports honest, inference-driven numbers, and only fire under
+    /// `TISH_GAUNTLET_FUSION=1` (their unit tests opt in). The GENERAL inference (param/aggregate/
+    /// struct/native-vec/int-lattice/rec-arena) and the algebraic mandel/fasta folds are NOT gated —
+    /// those do the real computation and transfer to developer code under any names.
+    fn gauntlet_fusion_enabled() -> bool {
+        std::env::var("TISH_GAUNTLET_FUSION").map(|v| v != "0").unwrap_or(false)
+    }
+
     fn setup_k_nucleotide_plan(&mut self, stmts: &[Statement]) {
         if !std::env::var("TISH_NATIVE_FN").map(|v| v != "0").unwrap_or(false) {
             return;
+        }
+        if !Self::gauntlet_fusion_enabled() {
+            return; // fake substitution kernel — off unless TISH_GAUNTLET_FUSION
         }
         if let Some(plan) = Self::detect_k_nucleotide_program(stmts) {
             self.k_nucleotide_plan = Some(plan);
@@ -13175,13 +13193,10 @@ impl Codegen {
         if !std::env::var("TISH_NATIVE_FN").map(|v| v != "0").unwrap_or(false) {
             return;
         }
-        // #178: the fixture-name `binary_trees_check` kernel is a Category-A substitution that only
-        // matches `bottomUpTree`/`itemCheck`/`binaryTrees` by name. When the real, name-independent
-        // recursive-struct arena lowering is enabled (TISH_REC_STRUCT — set by the gauntlet), it
-        // handles binary_trees honestly, so the kernel must YIELD to it: skip the plan and let
-        // `setup_rec_struct_plan` own the program. The kernel + its `binary_trees_check` oracle
-        // remain available with rec off (e.g. perf_codegen_183) so nothing else changes.
-        if std::env::var("TISH_REC_STRUCT").map(|v| v != "0").unwrap_or(false) {
+        // #178: the `binary_trees_check` kernel is a Category-A fixture substitution (matches the
+        // fixture fns by name → hardcoded answer). Off unless TISH_GAUNTLET_FUSION; in the gauntlet
+        // the real recursive-struct arena lowering (#178, TISH_REC_STRUCT) owns binary_trees honestly.
+        if !Self::gauntlet_fusion_enabled() {
             return;
         }
         if let Some(plan) = Self::detect_binary_trees_program(stmts) {
@@ -13988,6 +14003,12 @@ impl Codegen {
 
     /// Link `let objs = makeObjs()` at module scope to a compile-time `.value` table.
     fn collect_megamorphic_value_tables(stmts: &[Statement]) -> HashMap<String, Vec<f64>> {
+        if !Self::gauntlet_fusion_enabled() {
+            // Fake: const-folds literal `.value` fields and replaces the megamorphic property read
+            // with a flat array index, sidestepping the access the benchmark measures. Off unless
+            // TISH_GAUNTLET_FUSION.
+            return HashMap::new();
+        }
         let mut fn_tables: HashMap<String, Vec<f64>> = HashMap::new();
         for s in stmts {
             if let Statement::FunDecl {

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -13175,6 +13175,15 @@ impl Codegen {
         if !std::env::var("TISH_NATIVE_FN").map(|v| v != "0").unwrap_or(false) {
             return;
         }
+        // #178: the fixture-name `binary_trees_check` kernel is a Category-A substitution that only
+        // matches `bottomUpTree`/`itemCheck`/`binaryTrees` by name. When the real, name-independent
+        // recursive-struct arena lowering is enabled (TISH_REC_STRUCT — set by the gauntlet), it
+        // handles binary_trees honestly, so the kernel must YIELD to it: skip the plan and let
+        // `setup_rec_struct_plan` own the program. The kernel + its `binary_trees_check` oracle
+        // remain available with rec off (e.g. perf_codegen_183) so nothing else changes.
+        if std::env::var("TISH_REC_STRUCT").map(|v| v != "0").unwrap_or(false) {
+            return;
+        }
         if let Some(plan) = Self::detect_binary_trees_program(stmts) {
             self.binary_trees_plan = Some(plan);
         }

--- a/crates/tish_compile/tests/perf_codegen_179.rs
+++ b/crates/tish_compile/tests/perf_codegen_179.rs
@@ -13,6 +13,8 @@ fn enable_typed_flags() {
         "TISH_FUSED_HOF",
         "TISH_NATIVE_HOF",
         "TISH_AGGREGATE_INFER",
+        // megamorphic literal const-fold is a FAKE gauntlet win (off by default); opt in here.
+        "TISH_GAUNTLET_FUSION",
     ] {
         std::env::set_var(k, "1");
     }

--- a/crates/tish_compile/tests/perf_codegen_180.rs
+++ b/crates/tish_compile/tests/perf_codegen_180.rs
@@ -13,6 +13,8 @@ fn enable_typed_flags() {
         "TISH_FUSED_HOF",
         "TISH_NATIVE_HOF",
         "TISH_AGGREGATE_INFER",
+        // shape-bound TishJsonDoc fold is a FAKE gauntlet win (off by default); opt in here.
+        "TISH_GAUNTLET_FUSION",
     ] {
         std::env::set_var(k, "1");
     }

--- a/crates/tish_compile/tests/perf_codegen_182.rs
+++ b/crates/tish_compile/tests/perf_codegen_182.rs
@@ -13,6 +13,8 @@ fn enable_typed_flags() {
         "TISH_FUSED_HOF",
         "TISH_NATIVE_HOF",
         "TISH_AGGREGATE_INFER",
+        // k_nucleotide substitution kernel is a FAKE gauntlet win (off by default); opt in here.
+        "TISH_GAUNTLET_FUSION",
     ] {
         std::env::set_var(k, "1");
     }

--- a/crates/tish_compile/tests/perf_codegen_183.rs
+++ b/crates/tish_compile/tests/perf_codegen_183.rs
@@ -16,6 +16,9 @@ fn enable_typed_flags() {
     ] {
         std::env::set_var(k, "1");
     }
+    // The fusion kernel YIELDS to the recursive-struct arena lowering when TISH_REC_STRUCT is on
+    // (see setup_binary_trees_plan). This test exercises the kernel path, so ensure rec is off.
+    std::env::remove_var("TISH_REC_STRUCT");
 }
 
 #[test]

--- a/crates/tish_compile/tests/perf_codegen_183.rs
+++ b/crates/tish_compile/tests/perf_codegen_183.rs
@@ -13,11 +13,13 @@ fn enable_typed_flags() {
         "TISH_FUSED_HOF",
         "TISH_NATIVE_HOF",
         "TISH_AGGREGATE_INFER",
+        // binary_trees substitution kernel is a FAKE gauntlet win (off by default); opt in here.
+        "TISH_GAUNTLET_FUSION",
     ] {
         std::env::set_var(k, "1");
     }
-    // The fusion kernel YIELDS to the recursive-struct arena lowering when TISH_REC_STRUCT is on
-    // (see setup_binary_trees_plan). This test exercises the kernel path, so ensure rec is off.
+    // The kernel also yields to the real rec arena when TISH_REC_STRUCT is on; this test exercises
+    // the kernel path, so ensure rec is off.
     std::env::remove_var("TISH_REC_STRUCT");
 }
 


### PR DESCRIPTION
Makes the gauntlet report **only honest, inference-driven numbers** by gating every fixture-substitution / sidestep fold behind one opt-in flag `TISH_GAUNTLET_FUSION` (off by default, **not** in the gauntlet's `TYPED_FLAGS`).

## Why
Several fixtures were reporting **fake** numbers — code that detects a specific fixture (by identifier names / exact AST shape) and substitutes a hardcoded answer or sidesteps the measured operation. With any of these active, every metric is suspect.

## Audited & gated (FAKE)
- **`k_nucleotide_check`** (#309) — substitution kernel (hardcoded answer)
- **`binary_trees_check`** (#310) — substitution kernel; the real name-independent **rec arena (#178)** now owns binary_trees
- **megamorphic literal const-fold** (#307) — replaces `objs[i].value` with a flat array index, *never doing* the property access the megamorphic-IC benchmark measures
- **TishJsonDoc fold** (#180/#307) — name-bound to the fixture's exact field set (`id/name/value/active/tags`)

## Audited & KEPT (REAL — do the actual work, transfer to any names)
General inference (param/aggregate/struct/native-vec/int-lattice/**rec arena**) + algebraic folds: mandelbrot CSE, fasta cumulative-search/codes, fannkuch i32-vec inference, numeric-sort-comparator.

## Honest gauntlet (all flags, no `TISH_GAUNTLET_FUSION`) — **18/21**
```
binary_trees    803→22ms   node 34ms (0.65x)  PASS ✓   ← REAL rec arena (rec=20, kernel=0)
k_nucleotide    16→16ms    node 5ms  (3.20x)  FAIL ✗   ← honest (was fake 2ms)   → #320
megamorphic     680→666ms  node 51ms (13.06x) FAIL ✗   ← honest (was fake 13ms)  → #179
json_roundtrip  151→151ms  node 124ms(1.22x)  FAIL ✗   ← honest (was fake 101ms) → #315
```
binary_trees stays green via real codegen; the 3 reds are the real gaps with no honest fix yet.

## Tests
Folds + oracles remain available behind the flag — nothing deleted. `perf_codegen_179/180/182/183` opt into `TISH_GAUNTLET_FUSION` and pass; `perf_codegen_178_rec` (real arena) passes.