### PR TITLE
fix(native): clone left operand in &&/|| value-lowering — fixes E0382 (#328)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -20115,8 +20115,13 @@ impl Codegen {
             // coerced boolean (`five() && 7` is `7`, not `true`). The right operand sits inside the
             // branch, so its side effects only run when reached. (Typed `bool && bool` uses Rust's
             // own `&&`/`||` above, where returning the bool already IS the operand.)
-            BinOp::And => format!("{{ let __l = {}; if __l.is_truthy() {{ {} }} else {{ __l }} }}", l, r),
-            BinOp::Or => format!("{{ let __l = {}; if __l.is_truthy() {{ __l }} else {{ {} }} }}", l, r),
+            //
+            // #328: bind the left operand by `.clone()`, NOT by move — the right operand commonly reuses
+            // the same local (`aid && out.indexOf(aid)`), and a bare `let __l = aid;` moves the non-`Copy`
+            // `Value` so the reuse is a borrow-after-move (E0382). The left operand is still evaluated
+            // exactly once (its side effects don't double-run); only its value is cloned for the test.
+            BinOp::And => format!("{{ let __l = ({}).clone(); if __l.is_truthy() {{ {} }} else {{ __l }} }}", l, r),
+            BinOp::Or => format!("{{ let __l = ({}).clone(); if __l.is_truthy() {{ __l }} else {{ {} }} }}", l, r),
             BinOp::BitAnd => Self::emit_bitwise_binop(l, r, "&"),
             BinOp::BitOr => Self::emit_bitwise_binop(l, r, "|"),
             BinOp::BitXor => Self::emit_bitwise_binop(l, r, "^"),

--- a/tests/core/shortcircuit_local_reuse.tish
+++ b/tests/core/shortcircuit_local_reuse.tish
@@ -1,0 +1,21 @@
+// Regression (#328): a `let` local used as the LEFT (truthiness) operand of `&&`/`||` and REUSED in
+// the right operand must not be MOVED by the short-circuit lowering — the native rust backend emitted
+// `let __l = aid;` (a move) then borrowed `aid` again (E0382). Valid in tish + node; deterministic.
+function dedupeCount(items) {
+  let out = []
+  let i = 0
+  while (i < items.length) {
+    let aid = items[i]
+    if (aid && out.indexOf(aid) === -1) { out.push(aid) }   // aid reused across the && operands
+    i = i + 1
+  }
+  return out.length
+}
+// `||` form with a reused local too.
+function firstTruthyLen(a, b) {
+  let x = a
+  let pick = (x || b)
+  return ("" + x + pick).length
+}
+console.log("dedupe:" + dedupeCount(["a", "b", "a", "", "b"]))
+console.log("pick:" + firstTruthyLen("hi", "yo"))

--- a/tests/core/shortcircuit_local_reuse.tish.expected
+++ b/tests/core/shortcircuit_local_reuse.tish.expected
@@ -1,0 +1,2 @@
+dedupe:2
+pick:4


### PR DESCRIPTION
Fixes #328.

## Problem
The native `rust` backend lowered value-returning `&&` / `||` as `{ let __l = <left>; if __l.is_truthy() { <right> } else { __l } }` — binding the left operand by **move**. When the right operand reuses the same local (`aid && out.indexOf(aid)`), the non-`Copy` `Value` is borrowed after move → `error[E0382]: borrow of moved value`. Interpreter and `--native-backend cranelift` are correct; only `rust` mis-compiled.

## Fix
Bind the left operand by `.clone()`. Evaluated exactly once (no double side effects); only its value is cloned for the truthiness test, leaving the original local for the right operand. No behavior change.

## Test (TDD)
`tests/core/shortcircuit_local_reuse.tish` (+ `.expected`) exercises a `&&` and a `||` each reusing a local. RED before the fix (E0382 for `aid` and `x`), GREEN after — verified **byte-identical across interpreter / native-rust / cranelift / js / wasi** by the integration parity harness (24 passed, 0 failed).

> Note: an unrelated, pre-existing flaky test (`loop_var_decl_clone_outer_var`) fails on clean `main` in full test runs due to env-var pollution between tests (proven independent of this change); it is not touched here.