### PR TITLE
fix(lexer/parser): support regex literals /pattern/flags (#299)

### DIFF
--- a/crates/tish_lexer/src/lib.rs
+++ b/crates/tish_lexer/src/lib.rs
@@ -878,10 +878,15 @@ impl<'a> Lexer<'a> {
                     self.advance();
                     self.skip_block_comment()?;
                     return self.next_token();
-                } else if !self.prev_ends_value() && !self.jsx_in_opening_tag {
+                } else if !self.prev_ends_value()
+                    && !self.jsx_in_opening_tag
+                    && !self.jsx_in_closing_tag
+                {
                     // #299: regex literal — the previous token does not end a value, so `/` starts a
                     // regex (`let re = /\d+/g`, `f(/x/)`, `return /x/`), not division. `//` and `/*`
-                    // (handled above) stay comments even here. Desugared to `new RegExp(...)` by the parser.
+                    // (handled above) stay comments even here. JSX tag contexts keep `/` as a tag
+                    // slash, not a regex: `<div />` (jsx_in_opening_tag) and `</div>` (the `<` sets
+                    // jsx_in_closing_tag). Desugared to `new RegExp(...)` by the parser.
                     let (pat, flags) = self.read_regex()?;
                     let end = self.span_start();
                     let lit = format!("{}\u{0}{}", pat, flags);

--- a/crates/tish_lexer/src/lib.rs
+++ b/crates/tish_lexer/src/lib.rs
@@ -125,6 +125,65 @@ impl<'a> Lexer<'a> {
         )
     }
 
+    /// #299 — true when the previous significant token ends a value, so a following `/` is DIVISION,
+    /// not the start of a regex literal. Superset of `last_is_value` (adds postfix `++`/`--` and
+    /// template-end tokens, which also end a value). When false, `/` begins a regex.
+    fn prev_ends_value(&self) -> bool {
+        self.last_is_value()
+            || matches!(
+                self.last_significant_kind,
+                Some(
+                    TokenKind::PlusPlus
+                        | TokenKind::MinusMinus
+                        | TokenKind::TemplateNoSub
+                        | TokenKind::TemplateTail
+                )
+            )
+    }
+
+    /// #299 — scan a regex literal body. The opening `/` is already consumed. Reads the pattern
+    /// VERBATIM (no escape processing — `\d` must stay `\d`), honoring `\`-escapes (`\/` is literal)
+    /// and `[...]` character classes (a `/` inside a class is literal), until the closing `/`, then
+    /// the trailing ascii-alpha flags. A newline inside the body or EOF is an unterminated-regex error.
+    fn read_regex(&mut self) -> Result<(String, String), String> {
+        let mut pat = String::with_capacity(16);
+        let mut in_class = false;
+        loop {
+            match self.advance() {
+                None | Some('\n') => return Err("Unterminated regex literal".to_string()),
+                Some('\\') => {
+                    pat.push('\\');
+                    match self.advance() {
+                        None | Some('\n') => {
+                            return Err("Unterminated regex literal".to_string())
+                        }
+                        Some(c) => pat.push(c),
+                    }
+                }
+                Some('[') => {
+                    in_class = true;
+                    pat.push('[');
+                }
+                Some(']') => {
+                    in_class = false;
+                    pat.push(']');
+                }
+                Some('/') if !in_class => break,
+                Some(c) => pat.push(c),
+            }
+        }
+        let mut flags = String::new();
+        while let Some(c) = self.peek() {
+            if c.is_ascii_alphabetic() {
+                flags.push(c);
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        Ok((pat, flags))
+    }
+
     #[inline]
     fn jsx_sync_in_opening_tag(&mut self) {
         self.jsx_in_opening_tag = self.jsx_stack.last().map(|e| e.in_opener).unwrap_or(false);
@@ -819,6 +878,18 @@ impl<'a> Lexer<'a> {
                     self.advance();
                     self.skip_block_comment()?;
                     return self.next_token();
+                } else if !self.prev_ends_value() && !self.jsx_in_opening_tag {
+                    // #299: regex literal — the previous token does not end a value, so `/` starts a
+                    // regex (`let re = /\d+/g`, `f(/x/)`, `return /x/`), not division. `//` and `/*`
+                    // (handled above) stay comments even here. Desugared to `new RegExp(...)` by the parser.
+                    let (pat, flags) = self.read_regex()?;
+                    let end = self.span_start();
+                    let lit = format!("{}\u{0}{}", pat, flags);
+                    return Ok(Some(Token {
+                        kind: TokenKind::Regex,
+                        span: Span { start, end },
+                        literal: Some(lit.into()),
+                    }));
                 } else if self.peek() == Some('=') {
                     self.advance();
                     TokenKind::SlashAssign

--- a/crates/tish_lexer/src/token.rs
+++ b/crates/tish_lexer/src/token.rs
@@ -123,6 +123,10 @@ pub enum TokenKind {
     TemplateMiddle, // }text${  (middle part)
     TemplateTail,   // }text`   (end part)
 
+    /// Regex literal `/pattern/flags` (#299). The token's `literal` carries `pattern\0flags`
+    /// (NUL-separated); the parser desugars it to `new RegExp(pattern, flags)`.
+    Regex,
+
     JsxText, // Raw text in JSX children (emojis, etc.); only {}<> are special
 }
 

--- a/crates/tish_parser/src/parser.rs
+++ b/crates/tish_parser/src/parser.rs
@@ -2102,6 +2102,33 @@ impl<'a> Parser<'a> {
                     span,
                 })
             }
+            TokenKind::Regex => {
+                // #299: `/pattern/flags` desugars to `new RegExp("pattern", "flags")`. Every backend
+                // already lowers `new RegExp(str, str)`, so no codegen change is needed. The lexer
+                // encodes the literal as `pattern\0flags`; the pattern is kept verbatim (e.g. `\d+`).
+                let lit = t.literal.clone().ok_or("Expected regex literal")?;
+                let (pat, flags) = match lit.split_once('\u{0}') {
+                    Some((p, f)) => (Arc::from(p), Arc::from(f)),
+                    None => (Arc::clone(&lit), Arc::from("")),
+                };
+                Ok(Expr::New {
+                    callee: Box::new(Expr::Ident {
+                        name: Arc::from("RegExp"),
+                        span,
+                    }),
+                    args: vec![
+                        CallArg::Expr(Expr::Literal {
+                            value: Literal::String(pat),
+                            span,
+                        }),
+                        CallArg::Expr(Expr::Literal {
+                            value: Literal::String(flags),
+                            span,
+                        }),
+                    ],
+                    span,
+                })
+            }
             TokenKind::True => Ok(Expr::Literal {
                 value: Literal::Bool(true),
                 span,

--- a/tests/core/regex_literal.tish
+++ b/tests/core/regex_literal.tish
@@ -1,0 +1,11 @@
+// #299: regex literals /pattern/flags — lexed context-sensitively, desugared to new RegExp(...).
+let re = /ab+c/i
+console.log(re.test("xABBBCx"))                       // true (i flag)
+console.log(re.test("xyz"))                           // false
+let d = /\d+/
+console.log(d.test("a1b"))                            // true (\d kept verbatim)
+console.log("foo123bar".replace(/\d+/g, "#"))         // foo#bar
+console.log("a,b;c".split(/[,;]/).join("|"))          // a|b|c  ([...] class with / not needed, but ; , )
+let x = 10
+let y = 2
+console.log(x / y)                                    // 5  (division still works after a value)

--- a/tests/core/regex_literal.tish.expected
+++ b/tests/core/regex_literal.tish.expected
@@ -1,0 +1,6 @@
+true
+false
+true
+foo#bar
+a|b|c
+5


### PR DESCRIPTION
Fixes #299.

## Problem
The lexer only produced `Slash`/`SlashAssign` for `/`, so `/ab+c/i` was a parse error ("Unexpected token: Slash").

## Fix (lexer + parser, no backend codegen)
- **Lexer**: context-sensitive scan — when the previous significant token doesn't end a value (after `=`, `(`, `,`, `return`, an operator, or statement start) `/` begins a regex; after a value (`a / b`, `(x)/2`, `arr[0]/2`) it stays division. Pattern scanned **verbatim** (`\d+` preserved), honoring `\` escapes and `[...]` classes, then flags. `//`/`/*` stay comments.
- **Parser**: the `Regex` token desugars to `new RegExp("pattern", "flags")` — every backend already lowers that, so **zero codegen change**.

## Test (TDD)
`tests/core/regex_literal.tish` (+ `.expected`): RED ("Unexpected token: Slash") → GREEN. `.test`/`.replace`/`.split` + a trailing division, identical across **interpreter / native / cranelift / js(node)**; CI cross-backend parity covers vm + wasi. Scanned all tests/core + tests/perf locally: **zero parse regressions**.