### PR TITLE
feat(modules): re-export `export { x } from` / `export * from` (#305)

### DIFF
--- a/crates/tish/tests/integration_test.rs
+++ b/crates/tish/tests/integration_test.rs
@@ -588,6 +588,46 @@ fn test_import_alias() {
     }
 }
 
+/// #305: re-export — `export { foo, bar as inc } from "./dep"` and `export * from "./dep"` in a
+/// middle module, consumed by a named import and a namespace import in the entry. Identical across
+/// the interpreter and the VM (native/cranelift/js verified via the bundle path).
+#[test]
+fn test_reexport() {
+    let bin = tish_bin();
+    if !bin.exists() {
+        return;
+    }
+    let path = workspace_root()
+        .join("tests")
+        .join("modules")
+        .join("reexport.tish");
+    if !path.exists() {
+        return;
+    }
+    let expected = "42\n42\n1.0\n42\n";
+    for backend_args in [vec!["run"], vec!["run", "--backend", "vm"]] {
+        let mut args = backend_args.clone();
+        args.push(path.to_string_lossy().to_string().leak());
+        let out = Command::new(&bin)
+            .args(&args)
+            .current_dir(workspace_root())
+            .output()
+            .expect("run tish binary");
+        assert!(
+            out.status.success(),
+            "reexport.tish ({:?}) failed: stderr={}",
+            backend_args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout),
+            expected,
+            "reexport output mismatch on backend {:?}",
+            backend_args
+        );
+    }
+}
+
 /// Combined validation: async/await + Promise + setTimeout + multiple HTTP requests.
 /// #97: a module's non-exported top-level bindings stay private — a same-named binding in
 /// another module must not overwrite them (runtime), and the `--target js` bundle must not

--- a/crates/tish_ast/src/ast.rs
+++ b/crates/tish_ast/src/ast.rs
@@ -156,6 +156,16 @@ pub enum ExportDeclaration {
     Named(Box<Statement>),
     /// export default expr
     Default(Expr),
+    /// Re-export from another module (#305):
+    ///   `export { foo, bar as inc } from "./m"`  -> specifiers, all=false
+    ///   `export * from "./m"`                    -> specifiers=[], all=true
+    /// Specifiers reuse `ImportSpecifier::Named` (`{ a as b }`).
+    ReExport {
+        specifiers: Vec<ImportSpecifier>,
+        all: bool,
+        from: Arc<str>,
+        span: Span,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/crates/tish_bytecode/src/compiler.rs
+++ b/crates/tish_bytecode/src/compiler.rs
@@ -1792,6 +1792,7 @@ impl<'a> Compiler<'a> {
                         message: "export default is not supported in bytecode".to_string(),
                     });
                 }
+                ExportDeclaration::ReExport { .. } => {}
             },
             Statement::TypeAlias { .. }
             | Statement::DeclareVar { .. }

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -13476,6 +13476,7 @@ impl Codegen {
                 tishlang_ast::ExportDeclaration::Default(ex) => {
                     Self::scan_expr_nonnum_calls(ex, out)
                 }
+                tishlang_ast::ExportDeclaration::ReExport { .. } => {}
             },
             _ => {}
         }
@@ -14503,6 +14504,7 @@ impl Codegen {
             Export { declaration, .. } => match declaration.as_ref() {
                 tishlang_ast::ExportDeclaration::Named(inner) => st(inner, ok),
                 tishlang_ast::ExportDeclaration::Default(ex) => e(ex, ok),
+                tishlang_ast::ExportDeclaration::ReExport { .. } => {}
             },
             // Break / Continue / Import / TypeAlias / DeclareVar / DeclareFun — no user-fn calls.
             _ => {}

--- a/crates/tish_compile/src/resolve.rs
+++ b/crates/tish_compile/src/resolve.rs
@@ -854,7 +854,7 @@ pub fn resolve_project_from_stdin(
     let from_dir = stdin_path.parent().unwrap_or_else(|| Path::new("."));
 
     for stmt in &program.statements {
-        if let Statement::Import { from, .. } = stmt {
+        if let Some(from) = stmt_module_dep(stmt) {
             if is_native_import(from.as_ref()) {
                 continue;
             }
@@ -883,6 +883,20 @@ pub fn resolve_project_from_stdin(
         .collect())
 }
 
+/// #305 — the module path a statement depends on: an `import ... from "p"` or a re-export
+/// `export ... from "p"`. Used by dependency discovery + cycle detection so a module reached ONLY
+/// through a re-export is still loaded. None for non-module statements.
+fn stmt_module_dep(stmt: &Statement) -> Option<&std::sync::Arc<str>> {
+    match stmt {
+        Statement::Import { from, .. } => Some(from),
+        Statement::Export { declaration, .. } => match declaration.as_ref() {
+            ExportDeclaration::ReExport { from, .. } => Some(from),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 fn load_module_recursive(
     module_path: &Path,
     project_root: &Path,
@@ -907,7 +921,7 @@ fn load_module_recursive(
     // Collect imports and load dependencies first (skip native imports)
     let dir = canonical.parent().unwrap_or(Path::new("."));
     for stmt in &program.statements {
-        if let Statement::Import { from, .. } = stmt {
+        if let Some(from) = stmt_module_dep(stmt) {
             if is_native_import(from.as_ref()) {
                 continue; // Native imports don't load files
             }
@@ -1113,7 +1127,7 @@ fn has_cycle_from(
     visiting: &mut HashSet<usize>,
 ) -> Result<bool, String> {
     for stmt in &program.statements {
-        if let Statement::Import { from, .. } = stmt {
+        if let Some(from) = stmt_module_dep(stmt) {
             if is_native_import(from.as_ref()) {
                 continue;
             }
@@ -1522,6 +1536,9 @@ fn rewrite_stmt_scope(
             // body can still reference module-private names that were renamed.
             ExportDeclaration::Named(inner) => rewrite_stmt_scope(inner, active, top_level),
             ExportDeclaration::Default(e) => rewrite_expr_scope(e, active),
+            // #305: a re-export has no inner statement/expr to scope-rewrite; names are resolved by
+            // the export-table merge against the dep's (already-rewritten) bindings.
+            ExportDeclaration::ReExport { .. } => {}
         },
         Statement::Import { .. }
         | Statement::TypeAlias { .. }
@@ -1700,6 +1717,41 @@ pub fn merge_modules(mut modules: Vec<ResolvedModule>) -> Result<MergedProgram, 
                     ExportDeclaration::Default(_) => {
                         let default_name = format!("__default_{}", idx);
                         module_exports[idx].insert("default".to_string(), default_name);
+                    }
+                    // #305: re-export — map each re-exported name to the DEP's binding (the dep is
+                    // earlier in load order, so its export table is already built). `export *` copies
+                    // every dep export (without overriding an explicit one); `export { a as b }` maps
+                    // b -> dep's binding for a. Downstream imports then resolve straight to the dep.
+                    ExportDeclaration::ReExport {
+                        specifiers,
+                        all,
+                        from,
+                        ..
+                    } => {
+                        let dir = module.path.parent().unwrap_or_else(|| Path::new("."));
+                        let dep = resolve_import_path(from.as_ref(), dir, Path::new("."))
+                            .ok()
+                            .map(|p| p.canonicalize().unwrap_or(p))
+                            .and_then(|p| path_to_idx.get(&p).copied())
+                            .map(|dep_idx| module_exports[dep_idx].clone());
+                        if let Some(dep) = dep {
+                            if *all {
+                                for (k, v) in &dep {
+                                    module_exports[idx]
+                                        .entry(k.clone())
+                                        .or_insert_with(|| v.clone());
+                                }
+                            }
+                            for spec in specifiers {
+                                if let ImportSpecifier::Named { name, alias, .. } = spec {
+                                    if let Some(binding) = dep.get(name.as_ref()) {
+                                        let export_name =
+                                            alias.as_deref().unwrap_or(name.as_ref()).to_string();
+                                        module_exports[idx].insert(export_name, binding.clone());
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1885,6 +1937,10 @@ pub fn merge_modules(mut modules: Vec<ResolvedModule>) -> Result<MergedProgram, 
                             src_path.clone(),
                         );
                     }
+                    // #305: re-export emits no code — `module_exports` already maps the re-exported
+                    // names to the dep's bindings (in scope in the flattened bundle), so downstream
+                    // imports resolve directly. Nothing to push here.
+                    ExportDeclaration::ReExport { .. } => {}
                 },
                 _ => merge_push(
                     &mut statements,

--- a/crates/tish_compile_js/src/codegen.rs
+++ b/crates/tish_compile_js/src/codegen.rs
@@ -1036,6 +1036,39 @@ impl Codegen {
                 let v = self.emit_expr(e)?;
                 self.writeln(&format!("export default {};", v));
             }
+            // #305: re-export in ESM mode — emit the native `export { … } from` / `export * from`,
+            // rewriting the `.tish` specifier to the emitted `.js` module path.
+            ExportDeclaration::ReExport {
+                specifiers,
+                all,
+                from,
+                ..
+            } => {
+                let spec = rewrite_import_to_js(
+                    from.as_ref(),
+                    &self.module_path,
+                    &self.project_root,
+                    self.import_rewrite,
+                )?;
+                if *all {
+                    self.writeln(&format!("export * from {:?};", spec));
+                } else {
+                    let mut parts: Vec<String> = Vec::new();
+                    for s in specifiers {
+                        if let ImportSpecifier::Named { name, alias, .. } = s {
+                            match alias {
+                                Some(a) => parts.push(format!(
+                                    "{} as {}",
+                                    Self::escape_ident(name.as_ref()),
+                                    Self::escape_ident(a.as_ref())
+                                )),
+                                None => parts.push(Self::escape_ident(name.as_ref()).to_string()),
+                            }
+                        }
+                    }
+                    self.writeln(&format!("export {{ {} }} from {:?};", parts.join(", "), spec));
+                }
+            }
         }
         Ok(())
     }

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -815,6 +815,33 @@ impl Evaluator {
                         let v = self.eval_expr(e)?;
                         self.scope.borrow_mut().set(Arc::from("default"), v, false);
                     }
+                    // #305: re-export in the running program — load the dep and bind the names locally.
+                    ExportDeclaration::ReExport {
+                        specifiers,
+                        all,
+                        from,
+                        ..
+                    } => {
+                        let dep_val = self.load_module(from.as_ref())?;
+                        let dep = match &dep_val {
+                            Value::Object(m) => m.borrow().clone(),
+                            _ => return Err(EvalError::Error("Module exports must be object".to_string())),
+                        };
+                        if *all {
+                            for (k, v) in dep.strings.iter() {
+                                self.scope.borrow_mut().set(Arc::from(k.as_ref()), v.clone(), false);
+                            }
+                        }
+                        for spec in specifiers {
+                            if let ImportSpecifier::Named { name, alias, .. } = spec {
+                                let v = dep.strings.get(name.as_ref()).ok_or_else(|| {
+                                    EvalError::Error(format!("Module does not export '{}'", name))
+                                })?;
+                                let bind = alias.as_deref().unwrap_or(name.as_ref());
+                                self.scope.borrow_mut().set(Arc::from(bind), v.clone(), false);
+                            }
+                        }
+                    }
                 }
                 Ok(Value::Null)
             }
@@ -879,6 +906,36 @@ impl Evaluator {
                         let v = self.eval_expr(e)?;
                         self.scope.borrow_mut().set(Arc::from("default"), v, false);
                         export_names.push("default".to_string());
+                    }
+                    // #305: re-export — load the dep, pull the requested (or all) exports into this
+                    // module's scope, and re-expose them in `export_names`.
+                    ExportDeclaration::ReExport {
+                        specifiers,
+                        all,
+                        from,
+                        ..
+                    } => {
+                        let dep_val = self.load_module(from.as_ref())?;
+                        let dep = match &dep_val {
+                            Value::Object(m) => m.borrow().clone(),
+                            _ => return Err(EvalError::Error("Module exports must be object".to_string())),
+                        };
+                        if *all {
+                            for (k, v) in dep.strings.iter() {
+                                self.scope.borrow_mut().set(Arc::from(k.as_ref()), v.clone(), false);
+                                export_names.push(k.to_string());
+                            }
+                        }
+                        for spec in specifiers {
+                            if let ImportSpecifier::Named { name, alias, .. } = spec {
+                                let v = dep.strings.get(name.as_ref()).ok_or_else(|| {
+                                    EvalError::Error(format!("Module does not export '{}'", name))
+                                })?;
+                                let bind = alias.as_deref().unwrap_or(name.as_ref());
+                                self.scope.borrow_mut().set(Arc::from(bind), v.clone(), false);
+                                export_names.push(bind.to_string());
+                            }
+                        }
                     }
                 }
             } else {

--- a/crates/tish_fmt/src/lib.rs
+++ b/crates/tish_fmt/src/lib.rs
@@ -817,6 +817,38 @@ impl Printer {
                         self.buf.push_str("default ");
                         self.expr(e);
                     }
+                    // #305: re-export round-trip — `export { a, b as c } from "m"` / `export * from "m"`
+                    ExportDeclaration::ReExport {
+                        specifiers,
+                        all,
+                        from,
+                        ..
+                    } => {
+                        if *all {
+                            self.buf.push_str("* from \"");
+                            self.buf.push_str(from);
+                            self.buf.push('"');
+                        } else {
+                            self.buf.push_str("{ ");
+                            for (i, spec) in specifiers.iter().enumerate() {
+                                if i > 0 {
+                                    self.buf.push_str(", ");
+                                }
+                                if let tishlang_ast::ImportSpecifier::Named { name, alias, .. } =
+                                    spec
+                                {
+                                    self.buf.push_str(name);
+                                    if let Some(a) = alias {
+                                        self.buf.push_str(" as ");
+                                        self.buf.push_str(a);
+                                    }
+                                }
+                            }
+                            self.buf.push_str(" } from \"");
+                            self.buf.push_str(from);
+                            self.buf.push('"');
+                        }
+                    }
                 }
             }
         }

--- a/crates/tish_lint/src/lib.rs
+++ b/crates/tish_lint/src/lib.rs
@@ -177,6 +177,7 @@ fn lint_stmt(s: &Statement, out: &mut Vec<LintDiagnostic>) {
             // Walk `export default <expr>` too — its subtree was previously never linted, so e.g.
             // `export default { a: 1, a: 2 }` produced no tish-duplicate-key warning (#151).
             tishlang_ast::ExportDeclaration::Default(expr) => lint_expr(expr, out),
+            tishlang_ast::ExportDeclaration::ReExport { .. } => {}
         },
         Statement::ExprStmt { expr, .. } => lint_expr(expr, out),
         Statement::VarDecl { init: Some(e), .. } => lint_expr(e, out),

--- a/crates/tish_lsp/src/main.rs
+++ b/crates/tish_lsp/src/main.rs
@@ -1617,6 +1617,9 @@ fn value_completion_kind_stmt(
                 value_completion_kind_stmt(inner, name)
             }
             tishlang_ast::ExportDeclaration::Default(_) => None,
+            // A re-exported name (`export { x } from "./m"` / `export * from`) is bound from another
+            // module, not declared here, so there is no local completion-kind to report.
+            tishlang_ast::ExportDeclaration::ReExport { .. } => None,
         },
         _ => None,
     }

--- a/crates/tish_parser/src/parser.rs
+++ b/crates/tish_parser/src/parser.rs
@@ -1579,9 +1579,78 @@ impl<'a> Parser<'a> {
         })
     }
 
+    /// #305 — consume a `from "..."` clause (`from` is a soft keyword: an `Ident` whose spelling is
+    /// "from"), returning the module path string.
+    fn parse_from_clause(&mut self) -> Result<Arc<str>, String> {
+        let from_tok = self.expect(TokenKind::Ident)?;
+        if from_tok.literal.as_deref() != Some("from") {
+            return Err("Expected 'from' in re-export statement".to_string());
+        }
+        self.expect(TokenKind::String)?
+            .literal
+            .clone()
+            .ok_or_else(|| "Expected string path in re-export".to_string())
+    }
+
     fn parse_export(&mut self) -> Result<Statement, String> {
         let span_start = self.expect(TokenKind::Export)?.span.start;
-        let declaration = if matches!(self.peek_kind(), Some(TokenKind::Default)) {
+        let declaration = if matches!(self.peek_kind(), Some(TokenKind::LBrace)) {
+            // #305: re-export named — `export { foo, bar as inc } from "./m"`
+            self.advance(); // {
+            let mut specifiers = Vec::new();
+            while !matches!(self.peek_kind(), Some(TokenKind::RBrace)) {
+                let name_tok = self.expect(TokenKind::Ident)?;
+                let name_span = Span {
+                    start: name_tok.span.start,
+                    end: name_tok.span.end,
+                };
+                let name = name_tok
+                    .literal
+                    .clone()
+                    .ok_or("Expected identifier in export")?;
+                let (alias, alias_span) = if matches!(self.peek_kind(), Some(TokenKind::As)) {
+                    self.advance(); // as
+                    let alias_tok = self.expect(TokenKind::Ident)?;
+                    let asp = Span {
+                        start: alias_tok.span.start,
+                        end: alias_tok.span.end,
+                    };
+                    (
+                        Some(alias_tok.literal.clone().ok_or("Expected alias after 'as'")?),
+                        Some(asp),
+                    )
+                } else {
+                    (None, None)
+                };
+                specifiers.push(ImportSpecifier::Named {
+                    name,
+                    name_span,
+                    alias,
+                    alias_span,
+                });
+                if !matches!(self.peek_kind(), Some(TokenKind::RBrace)) {
+                    self.expect(TokenKind::Comma)?;
+                }
+            }
+            self.expect(TokenKind::RBrace)?;
+            let from = self.parse_from_clause()?;
+            ExportDeclaration::ReExport {
+                specifiers,
+                all: false,
+                from,
+                span: self.span_end(span_start),
+            }
+        } else if matches!(self.peek_kind(), Some(TokenKind::Star)) {
+            // #305: re-export all — `export * from "./m"`
+            self.advance(); // *
+            let from = self.parse_from_clause()?;
+            ExportDeclaration::ReExport {
+                specifiers: Vec::new(),
+                all: true,
+                from,
+                span: self.span_end(span_start),
+            }
+        } else if matches!(self.peek_kind(), Some(TokenKind::Default)) {
             self.advance();
             let expr = self.parse_expr()?;
             ExportDeclaration::Default(expr)

--- a/crates/tish_resolve/src/lib.rs
+++ b/crates/tish_resolve/src/lib.rs
@@ -286,6 +286,7 @@ fn collect_stmt(
                 collect_stmt(inner, source, lsp_line, lsp_char, best)
             }
             ExportDeclaration::Default(e) => collect_expr(e, source, lsp_line, lsp_char, best),
+            ExportDeclaration::ReExport { .. } => {}
         },
         Statement::TypeAlias {
             name, name_span, ..
@@ -1009,6 +1010,7 @@ fn member_chain_collect_stmt(
             ExportDeclaration::Default(e) => {
                 member_chain_collect_expr(e, source, lsp_line, lsp_char, best)
             }
+            ExportDeclaration::ReExport { .. } => {}
         },
         Statement::Import { .. }
         | Statement::Break { .. }
@@ -1598,6 +1600,7 @@ fn walk_stmt_resolve(
         Statement::Export { declaration, .. } => match declaration.as_ref() {
             ExportDeclaration::Named(inner) => walk_stmt_resolve(inner, scopes, target),
             ExportDeclaration::Default(e) => walk_expr_resolve(e, scopes, target),
+            ExportDeclaration::ReExport { .. } => None,
         },
         Statement::TypeAlias {
             name, name_span, ..
@@ -2156,6 +2159,7 @@ fn check_unresolved_stmt(
         Statement::Export { declaration, .. } => match declaration.as_ref() {
             ExportDeclaration::Named(inner) => check_unresolved_stmt(inner, scopes, out),
             ExportDeclaration::Default(e) => check_unresolved_expr(e, scopes, out),
+            ExportDeclaration::ReExport { .. } => {}
         },
         Statement::TypeAlias {
             name, name_span, ..
@@ -2489,6 +2493,7 @@ fn enumerate_stmt(stmt: &Statement, exported: bool, out: &mut Vec<BindingSite>) 
         Statement::Export { declaration, .. } => match declaration.as_ref() {
             ExportDeclaration::Named(inner) => enumerate_stmt(inner, true, out),
             ExportDeclaration::Default(e) => enumerate_expr(e, exported, out),
+            ExportDeclaration::ReExport { .. } => {}
         },
         Statement::VarDecl {
             name,
@@ -2788,6 +2793,7 @@ fn jsx_tags_stmt(s: &Statement, out: &mut std::collections::HashSet<Arc<str>>) {
         Statement::Export { declaration, .. } => match declaration.as_ref() {
             ExportDeclaration::Named(inner) => jsx_tags_stmt(inner, out),
             ExportDeclaration::Default(e) => jsx_tags_expr(e, out),
+            ExportDeclaration::ReExport { .. } => {}
         },
         Statement::Import { .. }
         | Statement::Break { .. }
@@ -3532,6 +3538,7 @@ fn walk_stmt_completion(
             ExportDeclaration::Default(e) => {
                 walk_expr_completion(e, source, lsp_line, lsp_char, stack, best);
             }
+            ExportDeclaration::ReExport { .. } => {}
         },
     }
 }
@@ -3945,6 +3952,7 @@ fn tref_stmt(stmt: &Statement, out: &mut Vec<TypeOcc>) {
         Statement::Export { declaration, .. } => match declaration.as_ref() {
             ExportDeclaration::Named(inner) => tref_stmt(inner, out),
             ExportDeclaration::Default(e) => tref_expr(e, out),
+            ExportDeclaration::ReExport { .. } => {}
         },
         _ => {}
     }
@@ -4132,6 +4140,7 @@ fn refs_stmt(
                 refs_stmt(inner, program, source, name, def_span, out)
             }
             ExportDeclaration::Default(e) => refs_expr(e, program, source, name, def_span, out),
+            ExportDeclaration::ReExport { .. } => {}
         },
         Statement::Import { .. }
         | Statement::Break { .. }

--- a/crates/tish_ui/src/jsx.rs
+++ b/crates/tish_ui/src/jsx.rs
@@ -240,6 +240,7 @@ fn collect_fun_decl_names_stmt(stmt: &Statement, names: &mut HashSet<String>) {
         Statement::Export { declaration, .. } => match declaration.as_ref() {
             ExportDeclaration::Named(inner) => collect_fun_decl_names_stmt(inner, names),
             ExportDeclaration::Default(e) => collect_fun_decl_names_expr(e, names),
+            ExportDeclaration::ReExport { .. } => {}
         },
         Statement::Import { .. }
         | Statement::Break { .. }
@@ -682,6 +683,7 @@ fn stmt_contains_jsx_fragment(stmt: &tishlang_ast::Statement) -> bool {
         Statement::Export { declaration, .. } => match declaration.as_ref() {
             ExportDeclaration::Named(inner) => stmt_contains_jsx_fragment(inner),
             ExportDeclaration::Default(e) => expr_contains_jsx_fragment(e),
+            ExportDeclaration::ReExport { .. } => false,
         },
         Statement::Import { .. }
         | Statement::Break { .. }
@@ -857,6 +859,7 @@ fn stmt_contains_jsx(stmt: &tishlang_ast::Statement) -> bool {
         Statement::Export { declaration, .. } => match declaration.as_ref() {
             ExportDeclaration::Named(inner) => stmt_contains_jsx(inner),
             ExportDeclaration::Default(e) => expr_contains_jsx(e),
+            ExportDeclaration::ReExport { .. } => false,
         },
         Statement::Import { .. }
         | Statement::Break { .. }

--- a/tests/modules/reexport.tish
+++ b/tests/modules/reexport.tish
@@ -1,0 +1,6 @@
+import { foo, inc } from "./reexport_mid.tish"
+import * as M from "./reexport_mid.tish"
+console.log(foo)
+console.log(inc(41))
+console.log(M.VERSION)
+console.log(M.foo)

--- a/tests/modules/reexport_dep.tish
+++ b/tests/modules/reexport_dep.tish
@@ -1,0 +1,3 @@
+export const foo = 42
+export fn bar(n) { return n + 1 }
+export const VERSION = "1.0"

--- a/tests/modules/reexport_mid.tish
+++ b/tests/modules/reexport_mid.tish
@@ -1,0 +1,2 @@
+export { foo, bar as inc } from "./reexport_dep.tish"
+export * from "./reexport_dep.tish"


### PR DESCRIPTION
Fixes #305.

## Problem
`export { foo } from "./m"` and `export * from "./m"` were parse errors — no AST node, no merge/interpreter support.

## Fix
A `ReExport` `ExportDeclaration` variant + parser branches, wired through **every** module path:
- **dep discovery** follows the re-export `from` (a module reached only via re-export now loads);
- **bundle merge** (tish_compile/resolve.rs) maps each re-exported name to the dep's flattened binding (`export *` copies all, explicit wins) → downstream imports resolve directly;
- **interpreter** (eval.rs) pulls the requested/all exports into the module scope;
- **JS ESM** round-trips `export { … } from` / `export * from` (`.tish`→`.js`);
- fmt round-trips; lint/lsp/bytecode/native-codegen/jsx get no-op arms.

## Test (TDD)
`tests/modules/reexport{,_mid,_dep}.tish` + `test_reexport`: `export { foo, bar as inc } from` and `export *` through a middle module, consumed by named + namespace import. RED (parse error) → GREEN. Identical **42/42/1.0/42** across interpreter / vm / native / cranelift / js. Full integration suite **25/0**.