### PR TITLE
fix(native): make `throw` from a called fn catchable across all frame kinds (#303)

### DIFF
--- a/crates/tish_builtins/src/array.rs
+++ b/crates/tish_builtins/src/array.rs
@@ -309,12 +309,14 @@ pub fn map(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
         let mut nums: Vec<f64> = Vec::with_capacity(data.len());
         for (i, &n) in data.iter().enumerate() {
+            if tishlang_core::has_pending_throw() { return packed_or_empty(nums); } // #303
             match cb.call(&[Value::Number(n), Value::Number(i as f64)]) {
                 Value::Number(r) => nums.push(r),
                 other => {
                     let mut boxed: Vec<Value> = nums.into_iter().map(Value::Number).collect();
                     boxed.push(other);
                     for (j, &m) in data.iter().enumerate().skip(i + 1) {
+                        if tishlang_core::has_pending_throw() { break; } // #303
                         boxed.push(cb.call(&[Value::Number(m), Value::Number(j as f64)]));
                     }
                     return Value::Array(VmRef::new(boxed));
@@ -326,11 +328,12 @@ pub fn map(arr: &Value, callback: &Value) -> Value {
     let arr = as_boxed_array(arr); let arr = &*arr;
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow();
-        let result: Vec<Value> = arr_borrow
-            .iter()
-            .enumerate()
-            .map(|(i, v)| cb.call(&[v.clone(), Value::Number(i as f64)]))
-            .collect();
+        // #303: stop on a pending throw from the callback (don't map the rest of the array).
+        let mut result: Vec<Value> = Vec::with_capacity(arr_borrow.len());
+        for (i, v) in arr_borrow.iter().enumerate() {
+            if tishlang_core::has_pending_throw() { break; }
+            result.push(cb.call(&[v.clone(), Value::Number(i as f64)]));
+        }
         Value::Array(VmRef::new(result))
     } else {
         Value::Null
@@ -343,6 +346,7 @@ pub fn filter(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
         let mut out: Vec<f64> = Vec::new();
         for (i, &n) in data.iter().enumerate() {
+            if tishlang_core::has_pending_throw() { break; } // #303
             if cb.call(&[Value::Number(n), Value::Number(i as f64)]).is_truthy() {
                 out.push(n);
             }
@@ -352,18 +356,14 @@ pub fn filter(arr: &Value, callback: &Value) -> Value {
     let arr = as_boxed_array(arr); let arr = &*arr;
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow();
-        let result: Vec<Value> = arr_borrow
-            .iter()
-            .enumerate()
-            .filter_map(|(i, v)| {
-                let keep = cb.call(&[v.clone(), Value::Number(i as f64)]);
-                if keep.is_truthy() {
-                    Some(v.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
+        // #303: stop on a pending throw from the predicate (don't test the rest of the array).
+        let mut result: Vec<Value> = Vec::new();
+        for (i, v) in arr_borrow.iter().enumerate() {
+            if tishlang_core::has_pending_throw() { break; }
+            if cb.call(&[v.clone(), Value::Number(i as f64)]).is_truthy() {
+                result.push(v.clone());
+            }
+        }
         Value::Array(VmRef::new(result))
     } else {
         Value::Null
@@ -381,6 +381,7 @@ pub fn reduce(arr: &Value, callback: &Value, initial: &Value) -> Value {
         };
         // `skip(start_idx)` preserves the true element index for the callback's 3rd arg.
         for (i, &x) in data.iter().enumerate().skip(start_idx) {
+            if tishlang_core::has_pending_throw() { return acc; } // #303
             acc = cb.call(&[acc, Value::Number(x), Value::Number(i as f64)]);
         }
         return acc;
@@ -396,6 +397,7 @@ pub fn reduce(arr: &Value, callback: &Value, initial: &Value) -> Value {
             (0, initial.clone())
         };
         for i in start_idx..len {
+            if tishlang_core::has_pending_throw() { return acc; } // #303
             let v = arr_borrow[i].clone();
             acc = cb.call(&[acc, v.clone(), Value::Number(i as f64)]);
         }
@@ -408,6 +410,7 @@ pub fn reduce(arr: &Value, callback: &Value, initial: &Value) -> Value {
 pub fn for_each(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
         for (i, &n) in data.iter().enumerate() {
+            if tishlang_core::has_pending_throw() { return Value::Null; } // #303
             cb.call(&[Value::Number(n), Value::Number(i as f64)]);
         }
         return Value::Null;
@@ -416,6 +419,7 @@ pub fn for_each(arr: &Value, callback: &Value) -> Value {
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow();
         for (i, v) in arr_borrow.iter().enumerate() {
+            if tishlang_core::has_pending_throw() { break; } // #303
             cb.call(&[v.clone(), Value::Number(i as f64)]);
         }
     }
@@ -425,6 +429,7 @@ pub fn for_each(arr: &Value, callback: &Value) -> Value {
 pub fn find(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
         for (i, &n) in data.iter().enumerate() {
+            if tishlang_core::has_pending_throw() { break; } // #303
             if cb.call(&[Value::Number(n), Value::Number(i as f64)]).is_truthy() {
                 return Value::Number(n);
             }
@@ -435,6 +440,7 @@ pub fn find(arr: &Value, callback: &Value) -> Value {
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow();
         for (i, v) in arr_borrow.iter().enumerate() {
+            if tishlang_core::has_pending_throw() { break; } // #303
             let result = cb.call(&[v.clone(), Value::Number(i as f64)]);
             if result.is_truthy() {
                 return v.clone();
@@ -447,6 +453,7 @@ pub fn find(arr: &Value, callback: &Value) -> Value {
 pub fn find_index(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
         for (i, &n) in data.iter().enumerate() {
+            if tishlang_core::has_pending_throw() { break; } // #303
             if cb.call(&[Value::Number(n), Value::Number(i as f64)]).is_truthy() {
                 return Value::Number(i as f64);
             }
@@ -457,6 +464,7 @@ pub fn find_index(arr: &Value, callback: &Value) -> Value {
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow();
         for (i, v) in arr_borrow.iter().enumerate() {
+            if tishlang_core::has_pending_throw() { break; } // #303
             let result = cb.call(&[v.clone(), Value::Number(i as f64)]);
             if result.is_truthy() {
                 return Value::Number(i as f64);
@@ -471,6 +479,7 @@ pub fn find_index(arr: &Value, callback: &Value) -> Value {
 pub fn find_last(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
         for i in (0..data.len()).rev() {
+            if tishlang_core::has_pending_throw() { break; } // #303
             if cb
                 .call(&[Value::Number(data[i]), Value::Number(i as f64)])
                 .is_truthy()
@@ -485,6 +494,7 @@ pub fn find_last(arr: &Value, callback: &Value) -> Value {
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow();
         for i in (0..arr_borrow.len()).rev() {
+            if tishlang_core::has_pending_throw() { break; } // #303
             let v = &arr_borrow[i];
             if cb.call(&[v.clone(), Value::Number(i as f64)]).is_truthy() {
                 return v.clone();
@@ -498,6 +508,7 @@ pub fn find_last(arr: &Value, callback: &Value) -> Value {
 pub fn find_last_index(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
         for i in (0..data.len()).rev() {
+            if tishlang_core::has_pending_throw() { break; } // #303
             if cb
                 .call(&[Value::Number(data[i]), Value::Number(i as f64)])
                 .is_truthy()
@@ -512,6 +523,7 @@ pub fn find_last_index(arr: &Value, callback: &Value) -> Value {
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow();
         for i in (0..arr_borrow.len()).rev() {
+            if tishlang_core::has_pending_throw() { break; } // #303
             if cb
                 .call(&[arr_borrow[i].clone(), Value::Number(i as f64)])
                 .is_truthy()
@@ -546,6 +558,7 @@ pub fn at(arr: &Value, index: &Value) -> Value {
 pub fn some(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
         for (i, &n) in data.iter().enumerate() {
+            if tishlang_core::has_pending_throw() { break; } // #303
             if cb.call(&[Value::Number(n), Value::Number(i as f64)]).is_truthy() {
                 return Value::Bool(true);
             }
@@ -556,6 +569,7 @@ pub fn some(arr: &Value, callback: &Value) -> Value {
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow();
         for (i, v) in arr_borrow.iter().enumerate() {
+            if tishlang_core::has_pending_throw() { break; } // #303
             let result = cb.call(&[v.clone(), Value::Number(i as f64)]);
             if result.is_truthy() {
                 return Value::Bool(true);
@@ -568,6 +582,7 @@ pub fn some(arr: &Value, callback: &Value) -> Value {
 pub fn every(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
         for (i, &n) in data.iter().enumerate() {
+            if tishlang_core::has_pending_throw() { break; } // #303
             if !cb.call(&[Value::Number(n), Value::Number(i as f64)]).is_truthy() {
                 return Value::Bool(false);
             }
@@ -578,6 +593,7 @@ pub fn every(arr: &Value, callback: &Value) -> Value {
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow();
         for (i, v) in arr_borrow.iter().enumerate() {
+            if tishlang_core::has_pending_throw() { break; } // #303
             let result = cb.call(&[v.clone(), Value::Number(i as f64)]);
             if !result.is_truthy() {
                 return Value::Bool(false);
@@ -595,6 +611,7 @@ pub fn flat_map(arr: &Value, callback: &Value) -> Value {
         let arr_borrow = arr.borrow();
         let mut result: Vec<Value> = Vec::new();
         for (i, v) in arr_borrow.iter().enumerate() {
+            if tishlang_core::has_pending_throw() { break; } // #303
             let mapped = cb.call(&[v.clone(), Value::Number(i as f64)]);
             if let Value::Array(inner) = mapped {
                 result.extend(inner.borrow().iter().cloned());
@@ -635,6 +652,11 @@ pub fn sort_with_comparator(arr: &Value, comparator: &Value) -> Value {
         let mut args_buf: [Value; 2] = [Value::Null, Value::Null];
 
         indices.sort_by(|&a, &b| {
+            // #303: once the comparator has thrown, stop invoking it — return Equal so the sort can
+            // unwind. Avoids extra comparator calls (and their side effects) after the throw.
+            if tishlang_core::has_pending_throw() {
+                return std::cmp::Ordering::Equal;
+            }
             args_buf[0] = elements[a].clone();
             args_buf[1] = elements[b].clone();
             match cmp_fn.call(&args_buf) {
@@ -644,10 +666,16 @@ pub fn sort_with_comparator(arr: &Value, comparator: &Value) -> Value {
             }
         });
 
-        *arr_mut = indices
-            .into_iter()
-            .map(|i| std::mem::replace(&mut elements[i], Value::Null))
-            .collect();
+        if tishlang_core::has_pending_throw() {
+            // #303: the comparator threw — do NOT write the partial/bogus reordering back. Restore the
+            // original element order (leave the array unmodified) and let the caller re-raise the throw.
+            *arr_mut = elements;
+        } else {
+            *arr_mut = indices
+                .into_iter()
+                .map(|i| std::mem::replace(&mut elements[i], Value::Null))
+                .collect();
+        }
         drop(arr_mut);
         Value::Array(arr.clone())
     } else {
@@ -880,5 +908,72 @@ mod packed_hof_tests {
         let n = na(&[1.0, 2.0]);
         assert!(matches!(map(&n, &Value::Number(1.0)), Value::Null));
         assert!(matches!(filter(&n, &Value::Null), Value::Null));
+    }
+
+    #[test]
+    fn for_each_stops_on_pending_throw() {
+        use std::sync::{Arc, Mutex};
+        // #303: once the callback parks a throw, for_each must stop invoking it (no extra iterations).
+        let _ = tishlang_core::take_pending_throw(); // start with a clean slot
+        let arr = from_vec(vec![
+            Value::Number(1.0),
+            Value::Number(2.0),
+            Value::Number(3.0),
+            Value::Number(4.0),
+        ]);
+        let calls = Arc::new(Mutex::new(0usize));
+        let c2 = calls.clone();
+        let cb = Value::native(move |a: &[Value]| {
+            *c2.lock().unwrap() += 1;
+            if a[0].as_number() == Some(2.0) {
+                tishlang_core::set_pending_throw(Value::Null);
+            }
+            Value::Null
+        });
+        for_each(&arr, &cb);
+        assert_eq!(
+            *calls.lock().unwrap(),
+            2,
+            "for_each should stop after the throwing element, not run all 4"
+        );
+        let _ = tishlang_core::take_pending_throw(); // drain so it doesn't leak into other tests
+    }
+
+    #[test]
+    fn sort_with_comparator_throw_restores_original_order() {
+        // #303: a comparator that throws must NOT corrupt the array — sort_with_comparator restores the
+        // original order and leaves the throw parked for the caller to re-raise.
+        let _ = tishlang_core::take_pending_throw();
+        let arr = from_vec(vec![
+            Value::Number(5.0),
+            Value::Number(4.0),
+            Value::Number(3.0),
+            Value::Number(2.0),
+            Value::Number(1.0),
+        ]);
+        // Park a throw on the first comparison and return a dummy ordering value.
+        let cmp = Value::native(|_a: &[Value]| {
+            tishlang_core::set_pending_throw(Value::String("cmp".into()));
+            Value::Null
+        });
+        let _ = sort_with_comparator(&arr, &cmp);
+        if let Value::Array(a) = &arr {
+            let got: Vec<f64> = a
+                .borrow()
+                .iter()
+                .map(|v| v.as_number().unwrap_or(f64::NAN))
+                .collect();
+            assert_eq!(
+                got,
+                vec![5.0, 4.0, 3.0, 2.0, 1.0],
+                "array must be left in its original order after a comparator throw"
+            );
+        } else {
+            panic!("expected a boxed array");
+        }
+        assert!(
+            tishlang_core::take_pending_throw().is_some(),
+            "the parked throw must survive for the caller to re-raise"
+        );
     }
 }

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -14349,6 +14349,14 @@ impl Codegen {
     /// disqualify a caller). M5 / #177 fns are auto-excluded — M5 has no array params, and the param
     /// classifier rejects struct-element arrays (`p[i].field`), which is the aggregate path's shape.
     fn body_uses_local_vec_ops(body: &Statement) -> bool {
+        // Only a `.push` onto a var DECLARED LOCALLY in this body counts: the `_nv` lowering emits
+        // such a var as an owned `Vec`. A `.push` onto a CAPTURED outer var (e.g. a top-level
+        // `let seen = []` closed over by `function dbl(x){ seen.push(x); return x*2 }`) is NOT a
+        // local vec op — the free `fn dbl_nv(..)` has no closure environment, so emitting it would
+        // reference an unbound `seen` and fail to compile. Such a fn must stay a boxed closure
+        // (which captures correctly). Array *params* are handled separately via `has_array_param`.
+        let mut locals = std::collections::HashSet::new();
+        Self::collect_local_var_names(body, &mut locals);
         let mut found = false;
         Self::for_each_stmt_expr(body, &mut |e| {
             if let Expr::Call { callee, .. } = e {
@@ -14358,10 +14366,12 @@ impl Codegen {
                     ..
                 } = callee.as_ref()
                 {
-                    if method.as_ref() == "push"
-                        && matches!(object.as_ref(), Expr::Ident { .. })
-                    {
-                        found = true;
+                    if method.as_ref() == "push" {
+                        if let Expr::Ident { name, .. } = object.as_ref() {
+                            if locals.contains(name.as_ref()) {
+                                found = true;
+                            }
+                        }
                     }
                 }
             }

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -4566,18 +4566,38 @@ impl Codegen {
             }
             Statement::Throw { value, .. } => {
                 let v = self.emit_expr(value)?;
-                if self.try_closure_depth > 0 || self.value_fn_depth == 0 {
-                    // Inside a try-body closure (so `catch`/`finally` can see it) or at top level
-                    // (run() returns a Result): a catchable error completion.
+                if self.try_closure_depth > 0 {
+                    // Inside a try-body closure (so `catch`/`finally` can see it): a catchable error
+                    // completion. A try-closure returns `Result` even when nested in a native-typed
+                    // fn, so this stays well-typed.
+                    self.writeln(&format!(
+                        "return Err(Box::new(tishlang_runtime::TishError::Throw({})) as Box<dyn std::error::Error>);",
+                        v
+                    ));
+                } else if self.in_native_typed_frame() {
+                    // #303: native-typed frame (`-> f64`/`-> Vec<..>`/`-> ()`) with no enclosing try.
+                    // There is no `Value` or `Result` channel here, so neither the dummy-`Value`
+                    // escape nor a `return Err(..)` would type-check. Fall back to the pre-#303 abort
+                    // (a native numeric kernel hitting an uncaught throw is already a degenerate path;
+                    // `panic!` coerces to any return type via `!`).
+                    self.writeln(&format!(
+                        "{{ let _th = {}; panic!(\"uncaught throw: {{}}\", _th.to_display_string()); }}",
+                        v
+                    ));
+                } else if self.value_fn_depth == 0 {
+                    // Top level (run() returns a Result): a catchable error completion.
                     self.writeln(&format!(
                         "return Err(Box::new(tishlang_runtime::TishError::Throw({})) as Box<dyn std::error::Error>);",
                         v
                     ));
                 } else {
-                    // Top of a value-fn body with no enclosing try: there is no error channel
-                    // across the native-fn ABI, so an uncaught throw aborts (matches prior behavior).
+                    // #303: value-fn body with no enclosing try — the native-fn ABI (`-> Value`) has
+                    // no error channel, so store the throw in the pending slot and escape with a dummy
+                    // `Value`. The caller's post-call pending-throw check (emitted after each call)
+                    // propagates it: re-raised as `TishError::Throw` in a try-closure / at top level,
+                    // or escaped again to climb past another value-fn.
                     self.writeln(&format!(
-                        "{{ let _th = {}; panic!(\"uncaught throw: {{}}\", _th.to_display_string()); }}",
+                        "{{ tishlang_runtime::set_pending_throw({}); return Value::Null; }}",
                         v
                     ));
                 }
@@ -4907,6 +4927,13 @@ impl Codegen {
                 }
                 self.writeln("Value::native(move |args: &[Value]| {");
                 self.value_fn_depth += 1;
+                // #303: a nested value-fn is its own `-> Value` frame; the enclosing `try`'s
+                // `Result` channel is NOT reachable via `return Err` from inside it (a throw here
+                // returns to the fn's caller, not the outer try). Reset the try-closure depth so
+                // throws / `emit_pending_throw_check` inside this body use the pending-throw slot,
+                // not a mis-typed `return Err`. Restored at every exit below.
+                let saved_try_depth = self.try_closure_depth;
+                self.try_closure_depth = 0;
                 self.indent += 1;
                 // Mutable outer vars: capture the RefCell so assignments use borrow_mut
                 for outer_var in &mutable_outer_vars {
@@ -5177,6 +5204,7 @@ impl Codegen {
                 self.type_context.pop_scope();
                 if let Err(e) = fun_body_res {
                     self.value_fn_depth = self.value_fn_depth.saturating_sub(1);
+                    self.try_closure_depth = saved_try_depth;
                     return Err(e);
                 }
 
@@ -5184,6 +5212,7 @@ impl Codegen {
                 self.indent -= 1;
                 self.writeln("})");
                 self.value_fn_depth = self.value_fn_depth.saturating_sub(1);
+                self.try_closure_depth = saved_try_depth;
                 self.indent -= 1;
                 self.writeln("};");
                 // Update the cell with the actual function value
@@ -8022,6 +8051,10 @@ impl Codegen {
 
         code.push_str("    Value::native(move |args: &[Value]| {\n");
         self.value_fn_depth += 1;
+        // #303: like the FunDecl closure above, a nested arrow is its own `-> Value` frame, so the
+        // enclosing `try`'s `Result` channel must not leak in. Reset + restore at every exit.
+        let saved_try_depth = self.try_closure_depth;
+        self.try_closure_depth = 0;
 
         // Make captured outer params available as plain Values (from _ref RefCells)
         for outer_param in &outer_params {
@@ -8170,10 +8203,12 @@ impl Codegen {
         self.type_context.pop_scope();
         if let Err(e) = arrow_body_res {
             self.value_fn_depth = self.value_fn_depth.saturating_sub(1);
+            self.try_closure_depth = saved_try_depth;
             return Err(e);
         }
 
         self.value_fn_depth = self.value_fn_depth.saturating_sub(1);
+        self.try_closure_depth = saved_try_depth;
 
         // Restore state
         self.refcell_wrapped_vars = saved_refcell_vars;
@@ -12239,6 +12274,54 @@ impl Codegen {
         }
     }
 
+    /// #303 — does `stmt` contain a call (so it may set the pending-throw slot)? Conservative: any
+    /// `Call`/`New` anywhere in the statement's expressions.
+    fn stmt_may_throw(stmt: &Statement) -> bool {
+        let mut found = false;
+        Self::for_each_stmt_expr(stmt, &mut |e| {
+            Self::walk_subexprs(e, &mut |x| {
+                if matches!(x, Expr::Call { .. } | Expr::New { .. }) {
+                    found = true;
+                }
+            });
+        });
+        found
+    }
+
+    /// #303 — a statement that already transfers control, so a pending-throw check after it would be
+    /// dead code (the throw propagates via the dummy-return + the caller's own check instead).
+    fn is_terminator_stmt(stmt: &Statement) -> bool {
+        matches!(
+            stmt,
+            Statement::Return { .. }
+                | Statement::Throw { .. }
+                | Statement::Break { .. }
+                | Statement::Continue { .. }
+        )
+    }
+
+    /// #303 — emit the post-call pending-throw check in the form the current frame expects: a
+    /// `Result`-returning frame (a `try`-closure, or `run()` at top level) re-raises it as
+    /// `TishError::Throw`; a value-fn frame escapes with a dummy `Value`, leaving the slot set so the
+    /// throw keeps climbing the call chain.
+    fn emit_pending_throw_check(&mut self) {
+        if self.try_closure_depth > 0 || self.value_fn_depth == 0 {
+            self.writeln("if tishlang_runtime::has_pending_throw() { return Err(Box::new(tishlang_runtime::TishError::Throw(tishlang_runtime::take_pending_throw().unwrap_or(Value::Null))) as Box<dyn std::error::Error>); }");
+        } else {
+            self.writeln("if tishlang_runtime::has_pending_throw() { return Value::Null; }");
+        }
+    }
+
+    /// #303 — are we emitting the body of a native-typed fn (`fn name_native(..) -> f64` /
+    /// `fn name_nv(..) -> Vec<..> | ()`)? Such a frame has no `Value`/`Result` return channel, so the
+    /// pending-throw check (which returns `Err`/`Value::Null`) cannot be typed there and must be
+    /// suppressed — the throw still propagates: it stays in the slot and surfaces at the first
+    /// `Value`/`Result` frame up the call chain. `native_fn_emit_name` is `Some` for the whole body
+    /// of both native emitters and `None` everywhere else.
+    fn in_native_typed_frame(&self) -> bool {
+        self.native_fn_emit_name.is_some() || self.native_vec_ret.is_some()
+    }
+
     fn emit_statements_with_folds(&mut self, statements: &[Statement]) -> Result<(), CompileError> {
         let mut i = 0;
         while i < statements.len() {
@@ -12268,6 +12351,12 @@ impl Codegen {
                 self.emit_native_fn_body(&statements[i])?;
             } else {
                 self.emit_statement(&statements[i])?;
+                if Self::stmt_may_throw(&statements[i])
+                    && !Self::is_terminator_stmt(&statements[i])
+                    && (self.try_closure_depth > 0 || !self.in_native_typed_frame())
+                {
+                    self.emit_pending_throw_check();
+                }
             }
             if let Some((lv, rv)) = promote_strict_lt {
                 self.strict_lt_bounds.push((lv.clone(), rv.clone()));
@@ -12282,6 +12371,9 @@ impl Codegen {
                         self.emit_native_fn_body(&statements[i])?;
                     } else {
                         self.emit_statement(&statements[i])?;
+                        if Self::stmt_may_throw(&statements[i]) && !Self::is_terminator_stmt(&statements[i]) {
+                            self.emit_pending_throw_check();
+                        }
                     }
                     i += 1;
                 }

--- a/crates/tish_core/src/lib.rs
+++ b/crates/tish_core/src/lib.rs
@@ -40,3 +40,40 @@ pub fn process_argv() -> Vec<String> {
         None => std::env::args().collect(),
     }
 }
+
+/// #303 — a thrown JS value parked while it unwinds across a boundary that can't carry a `Result`.
+///
+/// The native value-fn ABI is `Fn(&[Value]) -> Value`, and `Callable::call` likewise returns a bare
+/// `Value`, so a `throw` crossing such a boundary can't ride a `Result`. It is parked here and picked
+/// up at the next checkpoint: native codegen checks it after each call; the VM checks it after each
+/// `Callable::call`; and the shared array builtins (`forEach`/`map`/`sort`/…) check it between
+/// elements so they stop iterating promptly instead of running the callback for the rest of the
+/// array. The slot lives in `tishlang_core` (rather than `tishlang_runtime`) so `tishlang_builtins`
+/// can poll it without a `builtins -> runtime` dependency cycle; `tishlang_runtime` and `tishlang_vm`
+/// share this one slot. First-throw-wins; drained exactly once by [`take_pending_throw`] at the frame
+/// that converts it back into a `Result`.
+thread_local! {
+    static PENDING_THROW: std::cell::RefCell<Option<Value>> = const { std::cell::RefCell::new(None) };
+}
+
+/// Park a thrown value to propagate across a non-`Result` boundary. First-throw-wins: if one is
+/// already pending (an erroneous continuation reached a second throw before the slot was drained),
+/// keep the first — that is the throw JS would have raised.
+pub fn set_pending_throw(v: Value) {
+    PENDING_THROW.with(|c| {
+        let mut slot = c.borrow_mut();
+        if slot.is_none() {
+            *slot = Some(v);
+        }
+    });
+}
+
+/// Is a thrown value waiting to propagate?
+pub fn has_pending_throw() -> bool {
+    PENDING_THROW.with(|c| c.borrow().is_some())
+}
+
+/// Take the parked thrown value, clearing the slot (drains it exactly once).
+pub fn take_pending_throw() -> Option<Value> {
+    PENDING_THROW.with(|c| c.borrow_mut().take())
+}

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -1313,27 +1313,45 @@ impl Evaluator {
                                         let len = arr_mut.len();
                                         let mut indices: Vec<usize> = (0..len).collect();
                                         let arr_values: Vec<Value> = std::mem::take(&mut *arr_mut);
+                                        // A `throw` from the comparator must propagate (be catchable) and
+                                        // must NOT corrupt the array. Previously the `_ => Equal` arm
+                                        // swallowed the `Err` and wrote a bogus reordering back; now we
+                                        // capture the throw, stop comparing, and restore the original order
+                                        // — matching the vm/native backends and node.
+                                        let mut pending: Option<EvalError> = None;
 
                                         if let Some((scope, params, body)) = self.create_callback_scope(&cmp_fn) {
                                             indices.sort_by(|&i, &j| {
-                                                let result = self.call_with_scope(&scope, &params, &body, &[arr_values[i].clone(), arr_values[j].clone()]);
-                                                match result {
+                                                if pending.is_some() {
+                                                    return std::cmp::Ordering::Equal;
+                                                }
+                                                match self.call_with_scope(&scope, &params, &body, &[arr_values[i].clone(), arr_values[j].clone()]) {
                                                     Ok(Value::Number(n)) if n < 0.0 => std::cmp::Ordering::Less,
                                                     Ok(Value::Number(n)) if n > 0.0 => std::cmp::Ordering::Greater,
-                                                    _ => std::cmp::Ordering::Equal,
+                                                    Ok(_) => std::cmp::Ordering::Equal,
+                                                    Err(e) => { pending = Some(e); std::cmp::Ordering::Equal }
                                                 }
                                             });
                                         } else {
                                             indices.sort_by(|&i, &j| {
-                                                let result = self.call_func(&cmp_fn, &[arr_values[i].clone(), arr_values[j].clone()]);
-                                                match result {
+                                                if pending.is_some() {
+                                                    return std::cmp::Ordering::Equal;
+                                                }
+                                                match self.call_func(&cmp_fn, &[arr_values[i].clone(), arr_values[j].clone()]) {
                                                     Ok(Value::Number(n)) if n < 0.0 => std::cmp::Ordering::Less,
                                                     Ok(Value::Number(n)) if n > 0.0 => std::cmp::Ordering::Greater,
-                                                    _ => std::cmp::Ordering::Equal,
+                                                    Ok(_) => std::cmp::Ordering::Equal,
+                                                    Err(e) => { pending = Some(e); std::cmp::Ordering::Equal }
                                                 }
                                             });
                                         }
 
+                                        if let Some(e) = pending {
+                                            // Comparator threw: leave the array untouched and re-raise.
+                                            *arr_mut = arr_values;
+                                            drop(arr_mut);
+                                            return Err(e);
+                                        }
                                         *arr_mut = indices.into_iter().map(|i| arr_values[i].clone()).collect();
                                     }
                                 } else {
@@ -1441,6 +1459,32 @@ impl Evaluator {
                                     for (i, v) in arr_borrow.iter().enumerate() {
                                         let mapped = self.call_func(&callback, &[v.clone(), Value::Number(i as f64)])?;
                                         result.push(mapped);
+                                    }
+                                }
+                                return Ok(Value::Array(Rc::new(RefCell::new(result))));
+                            }
+                            "flatMap" => {
+                                // map + flatten one level (Array.prototype.flatMap). A callback `throw`
+                                // propagates via `?` (catchable), matching vm/native/node — previously
+                                // interp lacked flatMap entirely ("Not a function").
+                                let callback = arg_vals.first().cloned().unwrap_or(Value::Null);
+                                let arr_borrow = arr.borrow();
+                                let mut result: Vec<Value> = Vec::with_capacity(arr_borrow.len());
+                                if let Some((scope, params, body)) = self.create_callback_scope(&callback) {
+                                    for (i, v) in arr_borrow.iter().enumerate() {
+                                        let mapped = self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64)])?;
+                                        match mapped {
+                                            Value::Array(inner) => result.extend(inner.borrow().iter().cloned()),
+                                            other => result.push(other),
+                                        }
+                                    }
+                                } else {
+                                    for (i, v) in arr_borrow.iter().enumerate() {
+                                        let mapped = self.call_func(&callback, &[v.clone(), Value::Number(i as f64)])?;
+                                        match mapped {
+                                            Value::Array(inner) => result.extend(inner.borrow().iter().cloned()),
+                                            other => result.push(other),
+                                        }
                                     }
                                 }
                                 return Ok(Value::Array(Rc::new(RefCell::new(result))));

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -439,14 +439,53 @@ impl fmt::Display for TishError {
 
 impl std::error::Error for TishError {}
 
+thread_local! {
+    /// #303 — a pending JS `throw` that escaped a value-returning native fn. The native fn ABI is
+    /// `Fn(&[Value]) -> Value` with no error channel, so a `throw` inside a CALLED fn cannot be
+    /// returned as a `Result`. Instead the throw codegen stores the thrown value here and escapes the
+    /// closure with a dummy `Value`; every call site checks this slot immediately after the call and
+    /// either re-raises it as `TishError::Throw` (in a `try`-closure or at `run()` top level) or
+    /// escapes the current value-fn with a dummy (leaving the slot set so it keeps propagating up the
+    /// call chain). Drained exactly once, at the frame that converts it back into a `Result`.
+    static PENDING_THROW: std::cell::RefCell<Option<Value>> = const { std::cell::RefCell::new(None) };
+}
+
+/// #303 — record a thrown value that must propagate across a value-fn call boundary. First-throw-
+/// wins: if a throw is already pending (an erroneous continuation reached a second throw before the
+/// slot was drained — e.g. a braceless loop body that re-fires), keep the FIRST one, since that is
+/// the throw JS would have propagated. The slot is drained by `take_pending_throw` at the frame that
+/// converts it back into a `Result`.
+pub fn set_pending_throw(v: Value) {
+    PENDING_THROW.with(|c| {
+        let mut slot = c.borrow_mut();
+        if slot.is_none() {
+            *slot = Some(v);
+        }
+    });
+}
+
+/// #303 — is a thrown value waiting to propagate? (Checked after every native fn call.)
+pub fn has_pending_throw() -> bool {
+    PENDING_THROW.with(|c| c.borrow().is_some())
+}
+
+/// #303 — take the pending thrown value, clearing the slot (drains it exactly once).
+pub fn take_pending_throw() -> Option<Value> {
+    PENDING_THROW.with(|c| c.borrow_mut().take())
+}
+
 /// Function-boundary unwind: convert a completion that escaped a function body's `Result`-closure
-/// back into the function's `Value`. A `return v` yields `v`; an uncaught `throw` panics (matching
-/// the behavior of a throw with no enclosing `try`); any other error panics.
+/// back into the function's `Value`. A `return v` yields `v`; an uncaught `throw` is stored in the
+/// pending-throw slot and the fn escapes with a dummy `Value` so the throw keeps propagating to the
+/// caller's post-call check (#303); any other error panics.
 pub fn fn_unwind(e: Box<dyn std::error::Error>) -> Value {
     match e.downcast::<TishError>() {
         Ok(te) => match *te {
             TishError::Return(v) => v,
-            TishError::Throw(v) => panic!("uncaught throw: {}", v.to_display_string()),
+            TishError::Throw(v) => {
+                set_pending_throw(v);
+                Value::Null
+            }
         },
         Err(orig) => panic!("error in native Tish: {:?}", orig),
     }

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -439,40 +439,11 @@ impl fmt::Display for TishError {
 
 impl std::error::Error for TishError {}
 
-thread_local! {
-    /// #303 — a pending JS `throw` that escaped a value-returning native fn. The native fn ABI is
-    /// `Fn(&[Value]) -> Value` with no error channel, so a `throw` inside a CALLED fn cannot be
-    /// returned as a `Result`. Instead the throw codegen stores the thrown value here and escapes the
-    /// closure with a dummy `Value`; every call site checks this slot immediately after the call and
-    /// either re-raises it as `TishError::Throw` (in a `try`-closure or at `run()` top level) or
-    /// escapes the current value-fn with a dummy (leaving the slot set so it keeps propagating up the
-    /// call chain). Drained exactly once, at the frame that converts it back into a `Result`.
-    static PENDING_THROW: std::cell::RefCell<Option<Value>> = const { std::cell::RefCell::new(None) };
-}
-
-/// #303 — record a thrown value that must propagate across a value-fn call boundary. First-throw-
-/// wins: if a throw is already pending (an erroneous continuation reached a second throw before the
-/// slot was drained — e.g. a braceless loop body that re-fires), keep the FIRST one, since that is
-/// the throw JS would have propagated. The slot is drained by `take_pending_throw` at the frame that
-/// converts it back into a `Result`.
-pub fn set_pending_throw(v: Value) {
-    PENDING_THROW.with(|c| {
-        let mut slot = c.borrow_mut();
-        if slot.is_none() {
-            *slot = Some(v);
-        }
-    });
-}
-
-/// #303 — is a thrown value waiting to propagate? (Checked after every native fn call.)
-pub fn has_pending_throw() -> bool {
-    PENDING_THROW.with(|c| c.borrow().is_some())
-}
-
-/// #303 — take the pending thrown value, clearing the slot (drains it exactly once).
-pub fn take_pending_throw() -> Option<Value> {
-    PENDING_THROW.with(|c| c.borrow_mut().take())
-}
+// #303 — the pending-throw slot lives in `tishlang_core` so the shared array builtins
+// (`tishlang_builtins::array`) can poll it without a `builtins -> runtime` dependency cycle, and so
+// the VM shares the same slot. Re-export the accessors so the Rust emitted by `tishlang_compile`
+// keeps calling `tishlang_runtime::{set,has,take}_pending_throw`. See `tishlang_core` for the docs.
+pub use tishlang_core::{has_pending_throw, set_pending_throw, take_pending_throw};
 
 /// Function-boundary unwind: convert a completion that escaped a function body's `Result`-closure
 /// back into the function's `Value`. A `return v` yields `v`; an uncaught `throw` is stored in the

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -27,19 +27,18 @@ use tishlang_core::{
 /// instead and is picked up at the next call site (or the top-level boundary).
 const PENDING_THROW_SENTINEL: &str = "\u{1}__tish_pending_throw__";
 
-thread_local! {
-    static VM_PENDING_THROW: std::cell::RefCell<Option<Value>> =
-        const { std::cell::RefCell::new(None) };
-}
-
+// #303 — the VM shares the one pending-throw slot defined in `tishlang_core`, so the array builtins
+// it calls (`tishlang_builtins::array`) can poll the same slot and so native + VM agree. These thin
+// wrappers keep every VM call site unchanged. `core::set_pending_throw` is first-throw-wins, but the
+// VM only sets (one site) after draining at a try boundary, so behavior is unchanged.
 fn set_pending_throw(v: Value) {
-    VM_PENDING_THROW.with(|c| *c.borrow_mut() = Some(v));
+    tishlang_core::set_pending_throw(v);
 }
 fn take_pending_throw() -> Option<Value> {
-    VM_PENDING_THROW.with(|c| c.borrow_mut().take())
+    tishlang_core::take_pending_throw()
 }
 fn pending_throw_is_set() -> bool {
-    VM_PENDING_THROW.with(|c| c.borrow().is_some())
+    tishlang_core::has_pending_throw()
 }
 
 /// Append the source location of the instruction at `off` to a runtime-error message, e.g.

--- a/tests/core/captured_array_in_numeric_fn.tish
+++ b/tests/core/captured_array_in_numeric_fn.tish
@@ -1,0 +1,11 @@
+// native codegen: a NAMED numeric-returning fn that CAPTURES an outer array must stay a boxed closure
+// (capturing it correctly) — it must NOT be lowered to a free native `_nv`/`-> f64` fn, which has no
+// closure environment and would reference the captured var unbound. Backend-identical; deterministic.
+let seen = []
+function dbl(x) { seen.push(x); return x * 2 }      // captures `seen`, returns numeric
+let doubled = [10, 20, 30].map(dbl)
+console.log("seen:" + seen.join(","))
+console.log("doubled:" + doubled.join(","))
+function inc(x) { return x + 1 }                     // non-capturing numeric fn still fine
+console.log("inc:" + [5, 6].map(inc).join(","))
+console.log("done")

--- a/tests/core/captured_array_in_numeric_fn.tish.expected
+++ b/tests/core/captured_array_in_numeric_fn.tish.expected
@@ -1,0 +1,4 @@
+seen:10,20,30
+doubled:20,40,60
+inc:6,7
+done

--- a/tests/core/throw_from_called_fn.tish
+++ b/tests/core/throw_from_called_fn.tish
@@ -1,0 +1,22 @@
+// #303: a `throw` from a CALLED function must be catchable by an enclosing try/catch on the native
+// backend (it used to panic instead of propagating). Backend-identical; deterministic.
+function boom() { throw "kaboom" }
+try { boom() } catch (e) { console.log("caught:" + e) }
+function inner() { throw "deep" }
+function outer() { inner() }                 // throw propagates across two call frames
+try { outer() } catch (e) { console.log("caught2:" + e) }
+function fail(n) { if (n > 0) { throw "n=" + n } return 0 }
+let r = "ok"
+try { fail(5) } catch (e) { r = e }          // thrown value bound in catch
+console.log(r)
+function safe(n) { if (n < 0) { throw "neg" } return n + 1 }
+console.log("safe:" + safe(9))               // non-throwing path still works
+// #303: a throw from a value-fn/arrow defined INSIDE a try is catchable too — the nested closure is
+// its own `-> Value` frame, so its body (incl. the call below) must use the pending-throw slot, not
+// a `return Err` into the outer try (which used to mis-compile / panic).
+function helper(x) { return x + 1 }
+try {
+  let f = () => { console.log("inside-arrow:" + helper(9)); throw "arrow" }
+  f()
+} catch (e) { console.log("a:" + e) }
+console.log("after")

--- a/tests/core/throw_from_called_fn.tish.expected
+++ b/tests/core/throw_from_called_fn.tish.expected
@@ -1,0 +1,7 @@
+caught:kaboom
+caught2:deep
+n=5
+safe:10
+inside-arrow:10
+a:arrow
+after

--- a/tests/core/throw_in_sort_comparator.tish
+++ b/tests/core/throw_in_sort_comparator.tish
@@ -1,0 +1,13 @@
+// #303 follow-up: a `throw` from an Array.sort comparator must be catchable on every backend (it
+// used to be swallowed by the interpreter, and corrupted the array on native/vm). We assert only the
+// catch + that the array is intact (length preserved) — the exact element order after a throwing
+// comparator is implementation-defined in JS, so the deterministic "original order is restored"
+// guarantee is covered by a Rust unit test (tish_builtins::array) instead. Backend-identical.
+let arr = [5, 4, 3, 2, 1]
+let caught = "no"
+try {
+  arr.sort((a, b) => { if (a === 3 || b === 3) { throw "cmp" } return a - b })
+} catch (e) { caught = e }
+console.log("caught:" + caught)
+console.log("len:" + arr.length)
+console.log("done")

--- a/tests/core/throw_in_sort_comparator.tish.expected
+++ b/tests/core/throw_in_sort_comparator.tish.expected
@@ -1,0 +1,3 @@
+caught:cmp
+len:5
+done

--- a/tests/core/throw_stops_array_iteration.tish
+++ b/tests/core/throw_stops_array_iteration.tish
@@ -1,0 +1,35 @@
+// #303 follow-up: a `throw` from an array-iteration callback must be catchable AND must stop the
+// iteration immediately — the shared builtins poll the pending-throw slot between elements instead
+// of running the callback for the rest of the array. Each tracker shows how far the callback ran;
+// it must stop at the throwing element. Backend-identical; deterministic.
+let fe = []
+try { [1, 2, 3, 4].forEach(x => { fe.push(x); if (x === 2) { throw "s" } }) } catch (e) {}
+console.log("forEach:" + fe.join(","))
+let mp = []
+try { [1, 2, 3, 4].map(x => { mp.push(x); if (x === 2) { throw "s" } return x * 2 }) } catch (e) {}
+console.log("map:" + mp.join(","))
+let fl = []
+try { [1, 2, 3, 4].filter(x => { fl.push(x); if (x === 2) { throw "s" } return true }) } catch (e) {}
+console.log("filter:" + fl.join(","))
+let rd = []
+try { [1, 2, 3, 4].reduce((a, x) => { rd.push(x); if (x === 2) { throw "s" } return a + x }, 0) } catch (e) {}
+console.log("reduce:" + rd.join(","))
+let fd = []
+try { [1, 2, 3, 4].find(x => { fd.push(x); if (x === 2) { throw "s" } return false }) } catch (e) {}
+console.log("find:" + fd.join(","))
+let fi = []
+try { [1, 2, 3, 4].findIndex(x => { fi.push(x); if (x === 2) { throw "s" } return false }) } catch (e) {}
+console.log("findIndex:" + fi.join(","))
+let sm = []
+try { [1, 2, 3, 4].some(x => { sm.push(x); if (x === 2) { throw "s" } return false }) } catch (e) {}
+console.log("some:" + sm.join(","))
+let ev = []
+try { [1, 2, 3, 4].every(x => { ev.push(x); if (x === 2) { throw "s" } return true }) } catch (e) {}
+console.log("every:" + ev.join(","))
+let fL = []
+try { [1, 2, 3, 4].findLast(x => { fL.push(x); if (x === 3) { throw "s" } return false }) } catch (e) {}
+console.log("findLast:" + fL.join(","))
+let fX = []
+try { [1, 2, 3, 4].findLastIndex(x => { fX.push(x); if (x === 3) { throw "s" } return false }) } catch (e) {}
+console.log("findLastIndex:" + fX.join(","))
+console.log("done")

--- a/tests/core/throw_stops_array_iteration.tish
+++ b/tests/core/throw_stops_array_iteration.tish
@@ -32,4 +32,7 @@ console.log("findLast:" + fL.join(","))
 let fX = []
 try { [1, 2, 3, 4].findLastIndex(x => { fX.push(x); if (x === 3) { throw "s" } return false }) } catch (e) {}
 console.log("findLastIndex:" + fX.join(","))
+let fm = []
+try { [1, 2, 3, 4].flatMap(x => { fm.push(x); if (x === 2) { throw "s" } return [x] }) } catch (e) {}
+console.log("flatMap:" + fm.join(","))
 console.log("done")

--- a/tests/core/throw_stops_array_iteration.tish.expected
+++ b/tests/core/throw_stops_array_iteration.tish.expected
@@ -1,0 +1,11 @@
+forEach:1,2
+map:1,2
+filter:1,2
+reduce:1,2
+find:1,2
+findIndex:1,2
+some:1,2
+every:1,2
+findLast:4,3
+findLastIndex:4,3
+done

--- a/tests/core/throw_stops_array_iteration.tish.expected
+++ b/tests/core/throw_stops_array_iteration.tish.expected
@@ -8,4 +8,5 @@ some:1,2
 every:1,2
 findLast:4,3
 findLastIndex:4,3
+flatMap:1,2
 done


### PR DESCRIPTION
Fixes #303.

Makes a `throw` from a **called** function fully catchable on every backend, and makes a thrown value from an **array-callback** behave identically across interp / vm / native / cranelift / wasi / js (matching node).

## Commits
1. **`throw` from a called fn catchable across all frame kinds** — the native value-fn ABI (`Fn(&[Value]) -> Value`) has no error channel, so `fn_unwind` used to `panic!` on an uncaught throw. A thread-local pending-throw slot stores the thrown value; the throw codegen escapes with a dummy `Value` and each call site re-raises it (try-closure / `run()` top level) or re-escapes (value-fn). Handles all three Rust frame kinds — `Value`, `Result`, and **native-typed** (`-> f64`/`-> Vec`/`-> ()`, where the check is suppressed and a direct throw falls back to abort, since neither `return Err` nor `return Value::Null` type-checks). Also resets `try_closure_depth` entering a nested value-fn/arrow (so `try { arr.forEach(x => …) }` compiles), and first-throw-wins in the slot.
2. **Array-iteration builtins + `Array.sort` stop on a thrown callback** — `forEach`/`map`/`filter`/`reduce`/`find`/`findIndex`/`findLast`/`findLastIndex`/`some`/`every`/`flatMap` and `sort` used to keep running the callback after a throw (extra side effects; `sort` silently wrote a bogus reordering back). The pending-throw slot moved to `tishlang_core` (to avoid a `builtins → runtime` dependency cycle), re-exported from `tishlang_runtime` and shared by the VM; the builtins now poll it between elements and stop, and `sort` restores the original order.
3. **Native: a numeric fn that captures an outer array stays a boxed closure** — `function dbl(x){ seen.push(x); return x*2 }` used as a callback was mis-lowered to a free native-vec fn that referenced the captured `seen` unbound (`E0425`). The native-vec eligibility now only counts `.push` on **body-local** vars, not captures.
4. **interp: propagate `Array.sort` comparator throws + add `Array.flatMap`** — the interpreter swallowed a comparator `Err` (and corrupted the array); now it propagates + leaves the array intact. `flatMap` was missing entirely ("Not a function"); added (map + flatten one level, throw-propagating).

## Tests (tests/core, backend-identical across all six backends)
- `throw_from_called_fn.tish` — throw across frames, value-in-catch, throw-from-arrow-in-try
- `throw_stops_array_iteration.tish` — all 11 iteration builtins stop at the throw
- `throw_in_sort_comparator.tish` — comparator throw is catchable, array intact
- `captured_array_in_numeric_fn.tish` — numeric fn capturing an outer array compiles + runs
- `tish_builtins::array` unit tests — `for_each` stops on a pending throw; `sort` leaves the array in its original order on a comparator throw

## Validation
- Corpus `cargo nextest -p tishlang --test integration_test`: **24/24** (interp/vm/native/cranelift/wasi/js)
- Workspace unit tests: **455/455**
- Gauntlet soundness validated; the array polls are no-ops when no throw is pending, and the native-capture change only excludes fns that previously failed to compile — both perf/soundness-neutral by construction (CI gauntlet job is the authoritative check).