### PR TITLE
test(infra): cap the integration compile cache to one generation per fixture

### DIFF
--- a/crates/tish/tests/integration_test.rs
+++ b/crates/tish/tests/integration_test.rs
@@ -52,6 +52,28 @@ fn integration_compile_cache_dir() -> PathBuf {
     target_dir().join("integration_compile_cache")
 }
 
+/// Remove cache entries under `dir` whose name starts with `prefix` but is not part of the current
+/// generation `keep_leaf` (the current artifact may have an extension appended, e.g. `<leaf>.wasm`,
+/// so we keep anything that *starts with* `keep_leaf`). Best-effort: caps the per-fixture compile
+/// cache so a `tish` rebuild doesn't leave the previous generation behind forever. Parallel-safe —
+/// see the call site in `compile_cached`.
+fn prune_stale_cache_generations(dir: &Path, prefix: &str, keep_leaf: &str) {
+    if let Ok(rd) = std::fs::read_dir(dir) {
+        for ent in rd.flatten() {
+            let name = ent.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with(prefix) && !name.starts_with(keep_leaf) {
+                let p = ent.path();
+                if p.is_dir() {
+                    let _ = std::fs::remove_dir_all(&p);
+                } else {
+                    let _ = std::fs::remove_file(&p);
+                }
+            }
+        }
+    }
+}
+
 /// Match `tish build` with no `--feature`: link every capability compiled into this `tish` binary.
 fn native_build_features_for_integration_test() -> Vec<String> {
     let mut v: Vec<String> = tishlang_vm::all_compiled_capabilities()
@@ -169,6 +191,14 @@ fn compile_cached(bin: &Path, path: &Path, backend: &str) -> PathBuf {
     let _ = std::fs::create_dir_all(&cache_base);
     // Include `backend` in the leaf name so nested cargo bin names never collide across backends.
     let leaf = format!("{}__{}__{}", stem, backend, hash8);
+
+    // Cap the cache: `hash8` mixes in the `tish` binary's mtime, so every recompile of `tish`
+    // orphans the previous generation of THIS (stem, backend). Drop those stale siblings now, so the
+    // cache holds ~one generation per fixture instead of growing without bound across rebuilds
+    // (it reached 14 GB in one session and exhausted the disk). Safe under parallel `nextest`: every
+    // live process for this (stem, backend) computes the SAME `hash8`, so only genuinely-stale
+    // generations (a different hash) are removed, never an artifact a concurrent run is using.
+    prune_stale_cache_generations(&cache_base, &format!("{}__{}__", stem, backend), &leaf);
 
     let (artifact_path, compile_args): (PathBuf, Vec<OsString>) = match backend {
         "native" => {
@@ -1416,6 +1446,16 @@ fn test_mvp_programs_native() {
     let combined = combined_mvp_native_inputs_hash(&paths);
     let cache_dir = mvp_native_batch_cache_dir(combined);
     let _ = std::fs::create_dir_all(&cache_dir);
+    // Cap the native batch cache: a new combined hash (a codegen / inference / source change) orphans
+    // the previous `native_many/<hash>` directory, each of which holds a full nested Cargo `target/`
+    // (~GBs). Drop the stale siblings, keeping only the current generation. Only `test_mvp_programs_
+    // native` builds here, so there is no cross-process race.
+    if let (Some(parent), Some(keep)) = (
+        cache_dir.parent(),
+        cache_dir.file_name().map(|n| n.to_string_lossy().into_owned()),
+    ) {
+        prune_stale_cache_generations(parent, "", &keep);
+    }
 
     let ext = if cfg!(target_os = "windows") {
         ".exe"


### PR DESCRIPTION
## Problem
`crates/tish/tests/integration_test.rs` caches each compiled artifact under `target/integration_compile_cache/<backend>/<stem>__<backend>__<hash8>`, where `hash8` mixes in the `tish` binary's mtime. So **every rebuild of `tish` orphans the entire previous generation**, and nothing ever removed them. Across a session of rebuild+test cycles the cache grew to **14 GB** and exhausted the disk — failing native/wasi compiles with `ENOSPC`. The `native_many/<combined-hash>` batch dir is worse: each generation is a full nested Cargo `target/` (GBs).

## Fix
Before writing a new artifact, prune the stale siblings of the current generation:
- `compile_cached`: remove `{stem}__{backend}__*` entries whose hash isn't the current one.
- native batch: remove `native_many/<other-hash>` directories.

A small `prune_stale_cache_generations(dir, prefix, keep_leaf)` helper does the best-effort removal.

## Parallel safety
`nextest` runs a process per test. Every live process for a given `(stem, backend)` computes the **same** `hash8` (same binary + same source), so only genuinely-stale generations (a different hash) are removed — never an artifact a concurrent run is using. Different fixtures use disjoint prefixes. `native_many` is built by a single test (`test_mvp_programs_native`).

## Validation
- Corpus `cargo nextest -p tishlang --test integration_test`: **green** with the guard (all backends, incl. the `native_many` batch).
- Two js-backend runs with a `tish` mtime change in between: cache held at **88 entries** (one per fixture), not 176.
- Full corpus: `integration_compile_cache` held at **~2.8 GB** (one generation) instead of accumulating.