### PR TITLE
perf(strings): O(1) char indexing/length + string building (acc +=) on interp + VM

### DIFF
--- a/crates/tish_builtins/src/string.rs
+++ b/crates/tish_builtins/src/string.rs
@@ -4,8 +4,63 @@
 //! JavaScript, matching .length and .charAt(). Byte offsets are never exposed.
 
 use crate::helpers::normalize_index;
+use std::cell::RefCell;
+use tishlang_core::ArcStr;
 use tishlang_core::Value;
 use tishlang_core::VmRef;
+
+// #203: a per-thread cursor cache that makes repeated character indexing (`charCodeAt(i)`, `s[i]`,
+// `charAt(i)`) O(1)/near-O(1) instead of O(i). tish strings are UTF-8, so `chars().nth(i)` scans from
+// the start — turning indexed/strided scans into O(n^2) (a strided checksum over a 1.3 MB string was
+// 4939ms vs node 1ms). For each recently-indexed string we cache whether it is all-ASCII (then a
+// character index equals a byte index → O(1) byte lookup) plus a forward cursor (so non-ASCII
+// sequential/strided scans advance from the last position, not from 0). Safety: the entry holds an
+// `ArcStr` CLONE, which keeps the backing allocation alive — so its data pointer can't be freed and
+// reused by another string while cached (no ABA), and since strings are immutable the cached ASCII
+// flag stays valid. Backends share this via `char_at_idx` (native + VM route through the builtin).
+// Semantics are unchanged: still character (Unicode scalar) indexing, identical to `chars().nth(i)`.
+struct CharCursor {
+    s: ArcStr,
+    ascii: bool,
+    /// Character (Unicode scalar) count, cached so `.length` is O(1) too — `for (i=0;i<s.length;i++)`
+    /// re-evaluates the bound every iteration, so an O(n) `chars().count()` there is itself O(n^2).
+    len_chars: usize,
+    char_idx: usize,
+    byte_off: usize,
+}
+
+thread_local! {
+    static INDEX_CURSOR: RefCell<Option<CharCursor>> = const { RefCell::new(None) };
+}
+
+/// Borrow the cursor entry for `s`, reseeding (compute ASCII flag + character count) if it currently
+/// caches a different backing allocation, then run `f` against it. Centralises the pointer-keyed
+/// reseed shared by [`char_at_idx`] and [`char_count`].
+fn with_cursor<R>(s: &ArcStr, f: impl FnOnce(&mut CharCursor, &ArcStr) -> R) -> R {
+    INDEX_CURSOR.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        let hit = matches!(slot.as_ref(), Some(c)
+            if std::ptr::eq(c.s.as_bytes().as_ptr(), s.as_bytes().as_ptr()) && c.s.len() == s.len());
+        if !hit {
+            let ascii = s.as_bytes().is_ascii();
+            // ASCII → character count equals byte length (free); otherwise count once.
+            let len_chars = if ascii { s.len() } else { s.chars().count() };
+            *slot = Some(CharCursor {
+                s: s.clone(),
+                ascii,
+                len_chars,
+                char_idx: 0,
+                byte_off: 0,
+            });
+        }
+        f(slot.as_mut().unwrap(), s)
+    })
+}
+
+/// Character (Unicode scalar) count of `s`, O(1) after the first call on a given string.
+pub fn char_count(s: &ArcStr) -> usize {
+    with_cursor(s, |c, _| c.len_chars)
+}
 
 /// Byte offset -> character index.
 fn byte_to_char_index(s: &str, byte_offset: usize) -> usize {
@@ -30,7 +85,7 @@ pub fn from_str(s: &str) -> Value {
 /// Get the length of a string (character count).
 pub fn len(s: &Value) -> Option<usize> {
     match s {
-        Value::String(str) => Some(str.chars().count()),
+        Value::String(str) => Some(char_count(str)),
         _ => None,
     }
 }
@@ -370,8 +425,38 @@ pub fn escape_html(s: &Value) -> Value {
     Value::String(tishlang_core::ArcStr::from(out))
 }
 
-fn char_at_idx(s: &str, idx: usize) -> Option<char> {
-    s.chars().nth(idx)
+/// Character (Unicode scalar) at index `idx`, using the cursor cache (see [`CharCursor`]).
+/// Equivalent to `s.chars().nth(idx)` but O(1) for ASCII strings and near-O(1) for forward/strided
+/// scans of non-ASCII strings, instead of O(idx) every call.
+fn char_at_idx(s: &ArcStr, idx: usize) -> Option<char> {
+    with_cursor(s, |c, s| {
+        if c.ascii {
+            // ASCII: character index == byte index, and every byte is its own scalar.
+            return s.as_bytes().get(idx).map(|&b| b as char);
+        }
+        // Non-ASCII: advance from the nearest known position (forward fast path); restart from 0 only
+        // when indexing backwards relative to the cursor.
+        let (base_idx, base_off) = if idx >= c.char_idx {
+            (c.char_idx, c.byte_off)
+        } else {
+            (0, 0)
+        };
+        match s[base_off..].char_indices().nth(idx - base_idx) {
+            Some((rel_off, ch)) => {
+                c.char_idx = idx;
+                c.byte_off = base_off + rel_off;
+                Some(ch)
+            }
+            None => None,
+        }
+    })
+}
+
+/// Character (Unicode scalar) at index `idx` via the cursor cache — the O(1)/near-O(1) primitive
+/// behind `s[i]`. Returns `None` for an out-of-range index; each backend maps that to its own
+/// out-of-bounds behaviour (interpreter/native → null, VM → error).
+pub fn nth_char(s: &ArcStr, idx: usize) -> Option<char> {
+    char_at_idx(s, idx)
 }
 
 pub fn char_at(s: &Value, idx: &Value) -> Value {
@@ -396,11 +481,13 @@ pub fn at(s: &Value, index: &Value) -> Value {
             Value::Number(n) => *n as i64,
             _ => 0,
         };
-        let chars: Vec<char> = s.chars().collect();
-        let len = chars.len() as i64;
-        let idx = if i < 0 { len + i } else { i };
-        if idx >= 0 && idx < len {
-            return Value::String(chars[idx as usize].to_string().into());
+        // Non-negative indices use the cursor cache directly; a negative index counts from the end,
+        // which needs the character length first (inherently O(n)).
+        let idx = if i < 0 { s.chars().count() as i64 + i } else { i };
+        if idx >= 0 {
+            if let Some(c) = char_at_idx(s, idx as usize) {
+                return Value::String(c.to_string().into());
+            }
         }
     }
     Value::Null

--- a/crates/tish_bytecode/src/compiler.rs
+++ b/crates/tish_bytecode/src/compiler.rs
@@ -4,9 +4,9 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use tishlang_ast::{
-    ArrayElement, ArrowBody, BinOp, CallArg, DestructElement, DestructPattern, ExportDeclaration,
-    Expr, FunParam, JsxAttrValue, JsxChild, JsxProp, Literal, LogicalAssignOp, MemberProp,
-    ObjectProp, Program, Span, Statement,
+    ArrayElement, ArrowBody, BinOp, CallArg, CompoundOp, DestructElement, DestructPattern,
+    ExportDeclaration, Expr, FunParam, JsxAttrValue, JsxChild, JsxProp, Literal, LogicalAssignOp,
+    MemberProp, ObjectProp, Program, Span, Statement,
 };
 
 use crate::chunk::{Chunk, Constant};
@@ -1232,6 +1232,24 @@ impl<'a> Compiler<'a> {
                 self.compile_destructure(pattern, false, false)?;
             }
             Statement::ExprStmt { expr, .. } => {
+                // String-builder fast path: statement-position `acc += rhs` on a frame-slot local
+                // compiles to `<rhs>; AppendLocal slot` (no LoadLocal/Dup/StoreLocal/Pop), letting
+                // the VM append in amortized O(1) without materializing the discarded result. Only
+                // for a simple slot-resolved identifier with the `+` compound op; everything else
+                // (name-based vars, other ops) keeps the generic path.
+                if let Expr::CompoundAssign {
+                    name,
+                    op: CompoundOp::Add,
+                    value,
+                    ..
+                } = expr
+                {
+                    if let Some(slot) = self.resolve_slot(name) {
+                        self.compile_expr(value)?;
+                        self.emit_u16(Opcode::AppendLocal, slot);
+                        return Ok(());
+                    }
+                }
                 self.compile_expr(expr)?;
                 self.emit(Opcode::Pop);
             }

--- a/crates/tish_bytecode/src/opcode.rs
+++ b/crates/tish_bytecode/src/opcode.rs
@@ -133,13 +133,19 @@ pub enum Opcode {
     /// `delete obj[key]` / `delete obj.prop`. Pops `[obj, key]`, removes the property
     /// (objects: drop the key; arrays: set the index to a null hole), pushes `true`.
     DeleteIndex = 53,
+    /// String-builder append for statement-position `acc += rhs` where `acc` is a frame slot local
+    /// (operand: u16 slot index). Pops `rhs`; appends it to the accumulator in amortized O(1) by
+    /// keeping a growable buffer for the slot (see the frame-local builder in `run_chunk`). Leaves
+    /// nothing on the stack — only emitted where the assignment's result is discarded. Slots are
+    /// frame-private (never captured), so the buffer needs no cross-frame sharing.
+    AppendLocal = 54,
 }
 
 impl Opcode {
-    /// Decode byte to opcode. Safe for b in 0..=53 (matches #[repr(u8)] discriminants).
+    /// Decode byte to opcode. Safe for b in 0..=54 (matches #[repr(u8)] discriminants).
     #[inline]
     pub fn from_u8(b: u8) -> Option<Opcode> {
-        if b <= 53 {
+        if b <= 54 {
             Some(unsafe { std::mem::transmute::<u8, Opcode>(b) })
         } else {
             None

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -21,6 +21,74 @@ use crate::value::{
     eval_object_get, eval_object_has, eval_object_set, EvalObjectData, PropMap, Value,
 };
 
+// #203: cursor cache for O(1)/near-O(1) character indexing in the interpreter. Twin of the one in
+// `tishlang_builtins::string` (used by the native/VM backends); duplicated here because the
+// interpreter has its own `Value`/`Arc<str>` string type rather than `tishlang_core`'s `ArcStr`. tish
+// strings are UTF-8, so `chars().nth(i)` is O(i) — turning indexed/strided scans into O(n^2). For each
+// recently-indexed string we cache whether it is all-ASCII (then a character index equals a byte index
+// → O(1)) plus a forward cursor (so non-ASCII sequential/strided scans advance from the last position).
+// Safety: the entry holds an `Arc<str>` CLONE, keeping the allocation alive so its data pointer can't
+// be reused while cached (no ABA), and since strings are immutable the cached ASCII flag stays valid.
+struct EvalCharCursor {
+    s: Arc<str>,
+    ascii: bool,
+    len_chars: usize,
+    char_idx: usize,
+    byte_off: usize,
+}
+
+thread_local! {
+    static EVAL_INDEX_CURSOR: RefCell<Option<EvalCharCursor>> = const { RefCell::new(None) };
+}
+
+fn with_eval_cursor<R>(s: &Arc<str>, f: impl FnOnce(&mut EvalCharCursor, &Arc<str>) -> R) -> R {
+    EVAL_INDEX_CURSOR.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        let hit = matches!(slot.as_ref(), Some(c)
+            if std::ptr::eq(c.s.as_bytes().as_ptr(), s.as_bytes().as_ptr()) && c.s.len() == s.len());
+        if !hit {
+            let ascii = s.as_bytes().is_ascii();
+            let len_chars = if ascii { s.len() } else { s.chars().count() };
+            *slot = Some(EvalCharCursor {
+                s: Arc::clone(s),
+                ascii,
+                len_chars,
+                char_idx: 0,
+                byte_off: 0,
+            });
+        }
+        f(slot.as_mut().unwrap(), s)
+    })
+}
+
+/// Character (Unicode scalar) at index `idx` via the cursor cache. Identical results to
+/// `s.chars().nth(idx)`, but O(1) for ASCII and near-O(1) for forward/strided scans.
+fn nth_char_cached(s: &Arc<str>, idx: usize) -> Option<char> {
+    with_eval_cursor(s, |c, s| {
+        if c.ascii {
+            return s.as_bytes().get(idx).map(|&b| b as char);
+        }
+        let (base_idx, base_off) = if idx >= c.char_idx {
+            (c.char_idx, c.byte_off)
+        } else {
+            (0, 0)
+        };
+        match s[base_off..].char_indices().nth(idx - base_idx) {
+            Some((rel_off, ch)) => {
+                c.char_idx = idx;
+                c.byte_off = base_off + rel_off;
+                Some(ch)
+            }
+            None => None,
+        }
+    })
+}
+
+/// Character (Unicode scalar) count via the cursor cache — O(1) after the first call on a string.
+fn char_count_cached(s: &Arc<str>) -> usize {
+    with_eval_cursor(s, |c, _| c.len_chars)
+}
+
 pub struct Scope {
     // Scope vars: order is never observed (no Object.keys over a scope), so use a fast
     // unordered aHash map — NOT the object-strings PropMap (an insertion-ordered IndexMap),
@@ -1983,12 +2051,12 @@ impl Evaluator {
                                 return Ok(Value::String(s.replace(&search, &replacement).into()));
                             }
                             "charAt" => {
+                                // Cursor cache instead of collecting a fresh Vec<char> each call (#203).
                                 let idx = match arg_vals.first() {
                                     Some(Value::Number(n)) => *n as usize,
                                     _ => 0,
                                 };
-                                let chars: Vec<char> = s.chars().collect();
-                                return Ok(chars.get(idx)
+                                return Ok(nth_char_cached(s, idx)
                                     .map(|c| Value::String(c.to_string().into()))
                                     .unwrap_or(Value::String("".into())));
                             }
@@ -1998,11 +2066,11 @@ impl Evaluator {
                                     Some(Value::Number(n)) => *n as i64,
                                     _ => 0,
                                 };
-                                let chars: Vec<char> = s.chars().collect();
-                                let len = chars.len() as i64;
-                                let idx = if i < 0 { len + i } else { i };
-                                if idx >= 0 && idx < len {
-                                    return Ok(Value::String(chars[idx as usize].to_string().into()));
+                                let idx = if i < 0 { s.chars().count() as i64 + i } else { i };
+                                if idx >= 0 {
+                                    if let Some(c) = nth_char_cached(s, idx as usize) {
+                                        return Ok(Value::String(c.to_string().into()));
+                                    }
                                 }
                                 return Ok(Value::Null);
                             }
@@ -2011,9 +2079,8 @@ impl Evaluator {
                                     Some(Value::Number(n)) => *n as usize,
                                     _ => 0,
                                 };
-                                let chars: Vec<char> = s.chars().collect();
-                                return Ok(chars.get(idx)
-                                    .map(|c| Value::Number(*c as u32 as f64))
+                                return Ok(nth_char_cached(s, idx)
+                                    .map(|c| Value::Number(c as u32 as f64))
                                     .unwrap_or(Value::Number(f64::NAN)));
                             }
                             "repeat" => {
@@ -3667,7 +3734,7 @@ impl Evaluator {
             }
             Value::String(s) => {
                 if key == "length" {
-                    Ok(Value::Number(s.chars().count() as f64))
+                    Ok(Value::Number(char_count_cached(s) as f64))
                 } else {
                     Ok(Value::Null)
                 }
@@ -3745,9 +3812,7 @@ impl Evaluator {
                     Value::Number(n) if *n >= 0.0 && n.fract() == 0.0 => *n as usize,
                     _ => return Ok(Value::Null),
                 };
-                Ok(s
-                    .chars()
-                    .nth(idx)
+                Ok(nth_char_cached(s, idx)
                     .map(|c| Value::String(c.to_string().into()))
                     .unwrap_or(Value::Null))
             }

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -2,6 +2,7 @@
 
 #![allow(clippy::type_complexity, clippy::cloned_ref_to_slice_refs)]
 
+use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -98,6 +99,31 @@ pub struct Scope {
     parent: Option<Rc<std::cell::RefCell<Scope>>>,
 }
 
+// #186 / string_build: amortized O(1) `acc += x`. tish strings are an immutable `Arc<str>`, so the
+// generic `acc = acc + x` allocates a fresh String and copies the whole accumulator each time → O(n^2)
+// over a build loop. Instead we keep the accumulator in a growable `String` ("the pending builder")
+// and `push_str` onto it in O(1), writing it back to the scope slot ("flushing") the moment the
+// variable is observed. JS strings are immutable VALUES, so soundness requires that any read sees the
+// full current string: every read flushes first (see `flush_pending_for` at `Expr::Ident` and the
+// other read sites). The builder is keyed by the EXACT owning scope (captured `Rc`) plus name, so a
+// shadowing inner `acc` never appends onto an outer `acc`'s buffer. Shared across nested evaluators
+// (function calls / closures) via `Rc` so a callee that reads the variable flushes the same buffer.
+struct PendingAppend {
+    /// The exact scope that owns the accumulator variable (not necessarily the current scope).
+    scope: Rc<std::cell::RefCell<Scope>>,
+    name: Arc<str>,
+    /// The true current value of the accumulator while buffered; the scope slot is stale until flush.
+    buf: String,
+}
+
+#[derive(Default)]
+struct StringBuilderState {
+    /// Fast-path guard: a single `Cell<bool>` load lets the hot identifier-read path skip the
+    /// `RefCell` borrow entirely when no builder is active (the case for all non-building programs).
+    active: Cell<bool>,
+    pending: RefCell<Option<PendingAppend>>,
+}
+
 /// A reference-counted lexical scope. A `Value::Function` captures one of these at creation
 /// (the *defining* scope) so calls resolve free variables lexically — real closures.
 pub type ScopeRef = Rc<std::cell::RefCell<Scope>>;
@@ -159,6 +185,9 @@ pub struct Evaluator {
     current_dir: RefCell<Option<PathBuf>>,
     /// Extra `tish:*` builtins from `TishNativeModule::virtual_builtin_modules` (shared across nested evaluators).
     virtual_builtins: Rc<RefCell<HashMap<Arc<str>, Value>>>,
+    /// String-builder state for amortized O(1) `acc += x` (see [`StringBuilderState`]). Shared across
+    /// nested evaluators so a called function/closure that reads the accumulator flushes the buffer.
+    string_builder: Rc<StringBuilderState>,
 }
 
 impl Evaluator {
@@ -435,6 +464,7 @@ impl Evaluator {
             module_cache: Rc::new(RefCell::new(HashMap::new())),
             current_dir: RefCell::new(None),
             virtual_builtins: Rc::new(RefCell::new(HashMap::new())),
+            string_builder: Rc::new(StringBuilderState::default()),
         }
     }
 
@@ -469,6 +499,9 @@ impl Evaluator {
         for stmt in &program.statements {
             last = self.eval_statement(stmt).map_err(|e| e.to_string())?;
         }
+        // Flush any still-buffered string accumulator so the variable's slot is correct for any
+        // post-run observation (timers, REPL, embedders reading scope state).
+        self.flush_pending();
         Ok(last)
     }
 
@@ -519,7 +552,11 @@ impl Evaluator {
                 self.bind_destruct_pattern(pattern, &value, *mutable)?;
                 Ok(Value::Null)
             }
-            Statement::ExprStmt { expr, .. } => self.eval_expr(expr),
+            Statement::ExprStmt { expr, .. } => {
+                // Statement position: route through the path that keeps statement-position
+                // `acc += x` O(1) (no result materialization) while preserving values otherwise.
+                self.eval_expr_discard(expr)
+            }
             Statement::If {
                 cond,
                 then_branch,
@@ -1240,6 +1277,177 @@ impl Evaluator {
             })
     }
 
+    // --- string-builder helpers (#186 / string_build): amortized O(1) `acc += x` ---
+
+    /// Append a value to a builder buffer using the exact JS coercion of `eval_binop`'s `+` (string
+    /// operands push their raw chars; everything else goes through `to_js_string`).
+    fn append_value_to_buf(buf: &mut String, v: &Value) {
+        match v {
+            Value::String(s) => buf.push_str(s),
+            other => buf.push_str(&other.to_js_string()),
+        }
+    }
+
+    /// Walk the scope chain from the current scope and return the exact scope that owns `name`.
+    fn find_var_scope(&self, name: &str) -> Option<Rc<std::cell::RefCell<Scope>>> {
+        let mut cur = Rc::clone(&self.scope);
+        loop {
+            if cur.borrow().vars.contains_key(name) {
+                return Some(cur);
+            }
+            let parent = cur.borrow().parent.clone();
+            match parent {
+                Some(p) => cur = p,
+                None => return None,
+            }
+        }
+    }
+
+    /// Flush the active builder (if any) back into its owning scope slot, restoring the invariant
+    /// that the slot holds the variable's true value. No-op when no builder is active.
+    fn flush_pending(&self) {
+        if !self.string_builder.active.get() {
+            return;
+        }
+        if let Some(p) = self.string_builder.pending.borrow_mut().take() {
+            p.scope
+                .borrow_mut()
+                .vars
+                .insert(Arc::clone(&p.name), Value::String(p.buf.into()));
+        }
+        self.string_builder.active.set(false);
+    }
+
+    /// Flush the builder iff it is buffering `name` (which is about to be read). The `active` guard
+    /// keeps this ~free on the hot identifier-read path when no builder exists.
+    #[inline]
+    fn flush_pending_for(&self, name: &str) {
+        if !self.string_builder.active.get() {
+            return;
+        }
+        let hit = self
+            .string_builder
+            .pending
+            .borrow()
+            .as_ref()
+            .is_some_and(|p| p.name.as_ref() == name);
+        if hit {
+            self.flush_pending();
+        }
+    }
+
+    /// Discard the builder iff it is buffering `name` (which is about to be overwritten by a plain
+    /// assignment) — avoids an unnecessary O(n) flush of a value that is about to be replaced.
+    #[inline]
+    fn discard_pending_for(&self, name: &str) {
+        if !self.string_builder.active.get() {
+            return;
+        }
+        let hit = self
+            .string_builder
+            .pending
+            .borrow()
+            .as_ref()
+            .is_some_and(|p| p.name.as_ref() == name);
+        if hit {
+            *self.string_builder.pending.borrow_mut() = None;
+            self.string_builder.active.set(false);
+        }
+    }
+
+    /// Try to handle `name += rhs` as an amortized-O(1) string append. Returns `true` if it was a
+    /// string append (buffer updated); `false` if `name` is not a (mutable) string accumulator, so
+    /// the caller falls back to the generic `+=`. Any builder for a DIFFERENT slot is flushed first;
+    /// keying by the exact owning scope means a shadowing inner `name` never appends onto an outer
+    /// `name`'s buffer.
+    fn try_string_append(&self, name: &Arc<str>, rhs: &Value) -> bool {
+        let owner = match self.find_var_scope(name) {
+            Some(s) => s,
+            None => return false, // undefined → let the generic path raise the error
+        };
+        // Continue an existing builder for this exact slot.
+        if self.string_builder.active.get() {
+            let same = self
+                .string_builder
+                .pending
+                .borrow()
+                .as_ref()
+                .is_some_and(|p| p.name == *name && Rc::ptr_eq(&p.scope, &owner));
+            if same {
+                if let Some(p) = self.string_builder.pending.borrow_mut().as_mut() {
+                    Self::append_value_to_buf(&mut p.buf, rhs);
+                }
+                return true;
+            }
+            // A different slot is buffered — flush it before starting a new one.
+            self.flush_pending();
+        }
+        // Start a new builder only if the accumulator currently holds a mutable string.
+        let start = {
+            let owner_ref = owner.borrow();
+            if owner_ref.consts.contains(name.as_ref()) {
+                return false; // `const acc += x` must raise the same error as the generic path
+            }
+            match owner_ref.vars.get(name.as_ref()) {
+                Some(Value::String(a)) => Some(a.clone()),
+                _ => None, // non-string accumulator → numeric/other `+=`
+            }
+        };
+        match start {
+            Some(a) => {
+                let mut buf = String::with_capacity(a.len() + 16);
+                buf.push_str(&a);
+                Self::append_value_to_buf(&mut buf, rhs);
+                *self.string_builder.pending.borrow_mut() = Some(PendingAppend {
+                    scope: owner,
+                    name: Arc::clone(name),
+                    buf,
+                });
+                self.string_builder.active.set(true);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Evaluate `expr` in statement position. Special-cases `acc += rhs` so the string-builder never
+    /// has to materialize the assignment's result value — the key to keeping the append O(1). In that
+    /// one case the (discarded) statement value is `null`; every other expression returns its real
+    /// value, preserving block/program last-value semantics.
+    fn eval_expr_discard(&self, expr: &Expr) -> Result<Value, EvalError> {
+        if let Expr::CompoundAssign {
+            name,
+            op: tishlang_ast::CompoundOp::Add,
+            value,
+            ..
+        } = expr
+        {
+            // Evaluate rhs FIRST — it may read `name`, which flushes any active builder.
+            let rhs = self.eval_expr(value)?;
+            if self.try_string_append(name, &rhs) {
+                // Statement-position result is discarded; returning null avoids the O(n) flatten.
+                return Ok(Value::Null);
+            }
+            // Not a string accumulator: generic `+=` (numeric/other) — return its real value.
+            self.flush_pending_for(name);
+            let current = self
+                .scope
+                .borrow()
+                .get(name.as_ref())
+                .ok_or_else(|| EvalError::Error(format!("Undefined variable: {}", name)))?;
+            let result = self
+                .eval_binop(&current, BinOp::Add, &rhs)
+                .map_err(EvalError::Error)?;
+            match self.scope.borrow_mut().assign(name.as_ref(), result.clone()) {
+                Ok(true) => Ok(result),
+                Ok(false) => Err(EvalError::Error(format!("Undefined variable: {}", name))),
+                Err(e) => Err(EvalError::Error(e)),
+            }
+        } else {
+            self.eval_expr(expr)
+        }
+    }
+
     fn eval_expr(&self, expr: &Expr) -> Result<Value, EvalError> {
         match expr {
             Expr::Literal { value, .. } => Ok(match value {
@@ -1248,11 +1456,14 @@ impl Evaluator {
                 Literal::Bool(b) => Value::Bool(*b),
                 Literal::Null => Value::Null,
             }),
-            Expr::Ident { name, .. } => self
-                .scope
-                .borrow()
-                .get(name.as_ref())
-                .ok_or_else(|| EvalError::Error(format!("Undefined variable: {}", name))),
+            Expr::Ident { name, .. } => {
+                // Flush any string-builder buffering this variable so the read sees the full string.
+                self.flush_pending_for(name.as_ref());
+                self.scope
+                    .borrow()
+                    .get(name.as_ref())
+                    .ok_or_else(|| EvalError::Error(format!("Undefined variable: {}", name)))
+            }
             Expr::Binary {
                 left,
                 op,
@@ -2326,6 +2537,9 @@ impl Evaluator {
             }
             Expr::Assign { name, value, .. } => {
                 let v = self.eval_expr(value)?;
+                // A plain assignment overwrites the variable, so drop any builder buffering it (the
+                // buffered value is about to be replaced). `value` may itself have read+flushed it.
+                self.discard_pending_for(name.as_ref());
                 match self.scope.borrow_mut().assign(name.as_ref(), v.clone()) {
                     Ok(true) => Ok(v),
                     Ok(false) => Err(EvalError::Error(format!("Undefined variable: {}", name))),
@@ -2474,6 +2688,10 @@ impl Evaluator {
                 }
             }
             Expr::CompoundAssign { name, op, value, .. } => {
+                // Expression-position `+=` (result is used): flush any builder so `current` is the
+                // full string, then take the generic path. The O(1) builder fast path is reserved
+                // for statement position (see `eval_expr_discard`).
+                self.flush_pending_for(name.as_ref());
                 let current = self.scope.borrow().get(name.as_ref())
                     .ok_or_else(|| EvalError::Error(format!("Undefined variable: {}", name)))?;
                 let rhs = self.eval_expr(value)?;
@@ -2492,6 +2710,7 @@ impl Evaluator {
                 }
             }
             Expr::LogicalAssign { name, op, value, .. } => {
+                self.flush_pending_for(name.as_ref());
                 let current = self.scope.borrow().get(name.as_ref())
                     .ok_or_else(|| EvalError::Error(format!("Undefined variable: {}", name)))?;
                 let result = match op {
@@ -2918,6 +3137,7 @@ impl Evaluator {
             module_cache: Rc::clone(&self.module_cache),
             current_dir: RefCell::new(self.current_dir.borrow().clone()),
             virtual_builtins: Rc::clone(&self.virtual_builtins),
+            string_builder: Rc::clone(&self.string_builder),
         };
         match eval.eval_statement(body) {
             Ok(v) => Ok(v),
@@ -3186,6 +3406,7 @@ impl Evaluator {
                     module_cache: Rc::clone(&self.module_cache),
                     current_dir: RefCell::new(self.current_dir.borrow().clone()),
                     virtual_builtins: Rc::clone(&self.virtual_builtins),
+            string_builder: Rc::clone(&self.string_builder),
                 };
                 {
                     let mut s = scope.borrow_mut();

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -850,7 +850,7 @@ pub fn get_prop(obj: &Value, key: impl AsRef<str>) -> Value {
         }
         Value::String(s) => {
             if key == "length" {
-                Value::Number(s.chars().count() as f64)
+                Value::Number(tishlang_builtins::string::char_count(s) as f64)
             } else {
                 Value::Null
             }
@@ -928,11 +928,11 @@ pub fn get_index(obj: &Value, index: &Value) -> Value {
         // `str[i]` returns the character at index `i` (issue #17) — matches the VM /
         // interpreter; out-of-bounds / negative / non-integer indices yield null.
         Value::String(s) => match index {
-            Value::Number(n) if *n >= 0.0 && n.fract() == 0.0 => s
-                .chars()
-                .nth(*n as usize)
-                .map(|c| Value::String(c.to_string().into()))
-                .unwrap_or(Value::Null),
+            Value::Number(n) if *n >= 0.0 && n.fract() == 0.0 => {
+                tishlang_builtins::string::nth_char(s, *n as usize)
+                    .map(|c| Value::String(c.to_string().into()))
+                    .unwrap_or(Value::Null)
+            }
             _ => Value::Null,
         },
         Value::Object(_) => tishlang_core::object_get(obj, index).unwrap_or(Value::Null),

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -3125,13 +3125,13 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
         Value::String(s) => {
             let key_s = key.as_ref();
             if let Ok(idx) = key_s.parse::<usize>() {
-                return match s.chars().nth(idx) {
+                return match str_builtins::nth_char(s, idx) {
                     Some(c) => Ok(Value::String(tishlang_core::ArcStr::from(c.to_string()))),
                     None => Err("Index out of bounds".to_string()),
                 };
             }
             if key_s == "length" {
-                return Ok(Value::Number(s.chars().count() as f64));
+                return Ok(Value::Number(str_builtins::char_count(s) as f64));
             }
             let s_clone: tishlang_core::ArcStr = s.clone();
             let method: ArrayMethodFn = match key_s {
@@ -3420,12 +3420,7 @@ fn get_index(obj: &Value, idx: &Value) -> Result<Value, String> {
                             n
                         ));
                     }
-                    let i = n as usize;
-                    let len = s.chars().count();
-                    if i >= len {
-                        return Err("Index out of bounds".to_string());
-                    }
-                    i
+                    n as usize
                 }
                 _ => {
                     return Err(format!(
@@ -3434,7 +3429,9 @@ fn get_index(obj: &Value, idx: &Value) -> Result<Value, String> {
                     ));
                 }
             };
-            match s.chars().nth(i) {
+            // `nth_char` returns None past the end, so the cursor cache handles bounds — no separate
+            // O(n) `chars().count()` pre-check (#203).
+            match str_builtins::nth_char(s, i) {
                 Some(c) => Ok(Value::String(tishlang_core::ArcStr::from(c.to_string()))),
                 None => Err("Index out of bounds".to_string()),
             }

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -1527,6 +1527,25 @@ impl Vm {
         // frame indexed by slot — no per-call hashmap, no name lookups. Args bind
         // to slots 0..param_count. Empty for name-based chunks.
         let mut slot_locals: Vec<Value> = Vec::new();
+        // Frame-local string builder for `acc += x` on a slot local (Opcode::AppendLocal): keeps the
+        // accumulator in a growable `sb_buf` so appends are amortized O(1) instead of reallocating the
+        // whole string each time. `sb_slot` is the slot currently buffered (at most one). The slot's
+        // own value is stale while buffered; `sb_flush!()` writes the buffer back. Slots are
+        // frame-private (never captured by closures and invisible to callees), and every read of a
+        // slot goes through `LoadLocal`, so flushing there is sufficient for soundness — no
+        // cross-frame state. JS string immutability is preserved: reads always see the full string.
+        let mut sb_slot: Option<usize> = None;
+        let mut sb_buf = String::new();
+        macro_rules! sb_flush {
+            () => {{
+                if let Some(s) = sb_slot.take() {
+                    if let Some(dst) = slot_locals.get_mut(s) {
+                        *dst = Value::String(std::mem::take(&mut sb_buf).into());
+                    }
+                    sb_buf.clear();
+                }
+            }};
+        }
         if chunk.slot_based {
             slot_locals = vec![Value::Null; chunk.num_slots as usize];
             let param_count = chunk.param_count as usize;
@@ -1619,6 +1638,10 @@ impl Vm {
                 Opcode::Nop => {}
                 Opcode::LoadLocal => {
                     let slot = Self::read_u16(code, &mut ip) as usize;
+                    // Flush a pending string-builder for this slot so the read sees the full string.
+                    if sb_slot == Some(slot) {
+                        sb_flush!();
+                    }
                     let v = slot_locals
                         .get(slot)
                         .cloned()
@@ -1627,6 +1650,11 @@ impl Vm {
                 }
                 Opcode::StoreLocal => {
                     let slot = Self::read_u16(code, &mut ip) as usize;
+                    // A plain store overwrites the slot — drop any builder buffering it.
+                    if sb_slot == Some(slot) {
+                        sb_slot = None;
+                        sb_buf.clear();
+                    }
                     let v = self
                         .stack
                         .pop()
@@ -1634,6 +1662,42 @@ impl Vm {
                     match slot_locals.get_mut(slot) {
                         Some(dst) => *dst = v,
                         None => return Err(format!("Local slot out of bounds: {}", slot)),
+                    }
+                }
+                Opcode::AppendLocal => {
+                    let slot = Self::read_u16(code, &mut ip) as usize;
+                    let rhs = self
+                        .stack
+                        .pop()
+                        .ok_or_else(|| "Stack underflow in AppendLocal".to_string())?;
+                    if sb_slot == Some(slot) {
+                        // Continue the active builder for this slot — amortized O(1) append.
+                        append_value_for_string_concat(&mut sb_buf, &rhs);
+                    } else {
+                        // Switching slots: flush the previous builder, then (re)start for this one.
+                        sb_flush!();
+                        match slot_locals.get(slot) {
+                            Some(Value::String(a)) => {
+                                sb_buf.clear();
+                                sb_buf.reserve(a.len() + estimate_string_concat_len(&rhs));
+                                sb_buf.push_str(a);
+                                append_value_for_string_concat(&mut sb_buf, &rhs);
+                                sb_slot = Some(slot);
+                            }
+                            _ => {
+                                // Non-string (or absent) accumulator: generic `+=` in place,
+                                // identical to LoadLocal; BinOp Add; StoreLocal.
+                                let current =
+                                    slot_locals.get(slot).cloned().unwrap_or(Value::Null);
+                                let result = eval_binop(BinOp::Add, &current, &rhs)?;
+                                match slot_locals.get_mut(slot) {
+                                    Some(dst) => *dst = result,
+                                    None => {
+                                        return Err(format!("Local slot out of bounds: {}", slot))
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
                 Opcode::LoadUpvalue | Opcode::StoreUpvalue => {


### PR DESCRIPTION
Stacked on #339 (base = `perf/203-array-records`; GitHub will retarget to `main` when #339 merges).

Makes string-heavy code stop being O(n²) on the interpreter and bytecode VM — the two backends #303/#203 left behind (native was already done). All three commits keep `Value::String` as-is (no cons/rope), so `core::Value` and the native/cranelift/wasi/js backends are untouched.

## Commits

**1. O(1) char indexing + length** (`charCodeAt`/`charAt`/`at`/`s[i]`/`.length`)
tish strings are UTF-8, so `chars().nth(i)`/`chars().count()` are O(i)/O(n) — an indexed loop `for (i=0;i<s.length;i++) s.charCodeAt(i)` is O(n²). Adds a per-thread cursor cache (caches is-ASCII → O(1) byte indexing, character count → O(1) `.length`, and a forward cursor for non-ASCII scans). The entry holds an `ArcStr`/`Arc<str>` clone so the data pointer can't be reused while cached (no ABA), and strings are immutable so the cached flags stay valid. Covers interp, VM, and native-boxed (typed-native still boxes per call — separate follow-up).

**2. O(1) string building on the interpreter** (`acc += x`)
A growable-buffer fast path: the accumulator is kept in a `String` and `push_str`ed in O(1), flushed back to the scope slot the moment the variable is read. Keyed by the exact owning scope + name (shadow-safe), shared across nested evaluators (callee/closure reads flush the same buffer). Statement-position `+=` is routed through `eval_expr_discard` so the discarded result is never materialized.

**3. O(1) string building on the VM** (`acc += x`)
New `AppendLocal` opcode (relates to #186). Slot locals are frame-private, so the builder is a simple frame-local buffer in `run_chunk` — flushed on `LoadLocal`, discarded on `StoreLocal`. Switching slots flushes first; non-string accumulators fall back to generic `+=`.

## Results (release, 100k rows)

| backend | before | after | node |
|---|---|---|---|
| interp build | ~12.4s | **229ms** | 49ms |
| VM build | ~12.4s | **166ms** | 49ms |

(O(n²)→O(n); remaining gap is constant-factor JIT vs interp.)

## Validation
- Backend-identical (interp==vm==native==node) on `string_build`'s check value and adversarial probes: aliasing, mid-build snapshots, closures, exceptions, shadowing, reassignment, self-append, interleaved + function-local accumulators.
- All 25 integration tests pass (interp/vm/native/js/wasi/cranelift).
- Gauntlet soundness holds (typed==boxed==node).