### PR TITLE
perf(native): per-site polymorphic inline caches for object property reads (#179)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -6112,6 +6112,11 @@ impl Codegen {
                     }
                 }
                 let obj = self.emit_expr(object)?;
+                // A literal (non-computed) key other than `size` is eligible for a per-site
+                // polymorphic inline cache (#179). `size` is excluded because `get_prop` special-cases
+                // it (Map/Set computed `.size`); computed keys vary per call so a slot cache can't help.
+                let ic_eligible =
+                    matches!(prop, MemberProp::Name { name, .. } if name.as_ref() != "size");
                 let key = match prop {
                     MemberProp::Name { name, .. } => format!("{:?}", name.as_ref()),
                     MemberProp::Expr(e) => {
@@ -6123,6 +6128,15 @@ impl Codegen {
                     format!(
                         "{{ let o = {}.clone(); if matches!(o, Value::Null) {{ Value::Null }} else {{ \
                          tishlang_runtime::get_prop(&o, {}) }} }}",
+                        obj, key
+                    )
+                } else if ic_eligible {
+                    // Per-site inline cache: a block-scoped `static` cell unique to this member-read
+                    // site (#179). Caches (shape, slot) so repeat reads skip the key scan. Behaviour is
+                    // identical to `get_prop` — non-cacheable objects fall through inside `get_prop_ic`.
+                    format!(
+                        "{{ static IC: tishlang_runtime::PropIC = tishlang_runtime::PropIC::new(); \
+                         tishlang_runtime::get_prop_ic(&{}, {}, &IC) }}",
                         obj, key
                     )
                 } else {

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -824,6 +824,92 @@ pub fn mkdir(args: &[Value]) -> Value {
 
 use std::sync::Arc;
 
+/// Per-site polymorphic inline cache for `obj.<literal key>` reads in generated native code (#179).
+///
+/// The native backend otherwise pays a full dynamic lookup (RefCell/Mutex borrow + linear key scan)
+/// for every member read, even at sites that only ever see a few object shapes. `PropMap` already
+/// tracks a hidden-class [`ShapeId`] per object and exposes slot-indexed access, so once a
+/// `(shape, slot)` pair is observed at a site, a later object of the same shape resolves the property
+/// with one integer compare + a direct slot load instead of a key scan.
+///
+/// Each of the 8 entries packs `(shape: u32) << 32 | (slot: u32)` into a single `AtomicU64`, so the
+/// pair is read and written atomically — no torn `(shape, slot)` under concurrent access (e.g. an
+/// HTTP handler shared across worker threads). A 9th distinct shape evicts an entry round-robin. An
+/// empty entry is `0`; a real object never has `EMPTY_SHAPE` (0), so `0` can't be a false hit.
+pub struct PropIC {
+    entries: [std::sync::atomic::AtomicU64; 8],
+    next: std::sync::atomic::AtomicU32,
+}
+
+impl PropIC {
+    #[allow(clippy::declare_interior_mutable_const)] // each `static IC: PropIC = PropIC::new()` site needs its own cell
+    pub const fn new() -> Self {
+        use std::sync::atomic::{AtomicU32, AtomicU64};
+        PropIC {
+            entries: [
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+            ],
+            next: AtomicU32::new(0),
+        }
+    }
+}
+
+impl Default for PropIC {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Cached `obj.key` read — see [`PropIC`]. Behaviour is identical to [`get_prop`]: only objects with
+/// a stable hidden class (non-empty, non-dictionary) take the cached fast path; empty/dictionary
+/// objects, non-objects, and the special `size` key all fall through to `get_prop` (the borrow is
+/// released first, so the fallback's re-borrow can't self-deadlock the send-values `Mutex`). The
+/// caller (codegen) never emits this for the `size` key, but the fallback covers it regardless.
+#[inline]
+pub fn get_prop_ic(obj: &Value, key: &str, ic: &PropIC) -> Value {
+    use std::sync::atomic::Ordering;
+    if key != "size" {
+        if let Value::Object(map) = obj {
+            // Scope the borrow so it is released before the `get_prop` fallback below.
+            {
+                let b = map.borrow();
+                let shape = b.strings.shape();
+                if shape != tishlang_core::EMPTY_SHAPE && shape != tishlang_core::DICT_SHAPE {
+                    let shape_hi = (shape as u64) << 32;
+                    // Fast path: a cached entry whose shape matches gives the slot directly.
+                    for e in ic.entries.iter() {
+                        let packed = e.load(Ordering::Relaxed);
+                        if packed >> 32 == shape as u64 {
+                            if let Some(v) = b.strings.value_at_index((packed & 0xFFFF_FFFF) as usize)
+                            {
+                                return v.clone();
+                            }
+                        }
+                    }
+                    // Miss: resolve once, fill an entry round-robin with the packed (shape, slot).
+                    return match b.strings.get_with_index(key) {
+                        Some((v, i)) => {
+                            let k = (ic.next.fetch_add(1, Ordering::Relaxed) % 8) as usize;
+                            ic.entries[k].store(shape_hi | i as u64, Ordering::Relaxed);
+                            v.clone()
+                        }
+                        None => Value::Null,
+                    };
+                }
+                // empty / dictionary object → fall through (borrow dropped here)
+            }
+        }
+    }
+    get_prop(obj, key)
+}
+
 #[inline]
 pub fn get_prop(obj: &Value, key: impl AsRef<str>) -> Value {
     let key = key.as_ref();


### PR DESCRIPTION
Implements #179. The native backend paid a full dynamic lookup (RefCell/Mutex borrow + linear key scan, or an IndexMap hash for >8-key objects) for **every** `obj.<key>` read in generated Rust, even at monomorphic/lightly-polymorphic sites.

## What

Each member-read site with a literal key gets a block-scoped `static PropIC` — a cache of up to 8 `(shape, slot)` pairs. `PropMap` already tracks a hidden-class `ShapeId` per object and exposes slot-indexed access (built for the VM's ICs, previously unused by native codegen). Once a shape is seen, a later object of that shape resolves the property with **one integer compare + a direct slot load** instead of a key scan.

- Each entry packs `(shape:u32)<<32 | slot:u32` into one `AtomicU64` → no torn `(shape, slot)` if a `static` is shared across HTTP worker threads.
- Block-scoped statics (`{ static IC: PropIC = PropIC::new(); get_prop_ic(&obj, "k", &IC) }`) — no global counter, robust to multi-pass codegen, nested member reads each get their own cell.

## Soundness

Only objects with a **stable hidden class** (non-empty, non-dictionary) take the cached path. Empty/dictionary objects, non-objects, and the `size` key (which `get_prop` special-cases for Map/Set) fall through to `get_prop` — with the borrow **released first** so the fallback's re-borrow can't self-deadlock the send-values `Mutex` (cf. #218). The IC caches the **slot, not the value**, so live mutation is reflected and any shape change (added/deleted key) misses and re-resolves.

## Measured (release, controlled back-to-back A/B)

| workload | before | after | speedup |
|---|---|---|---|
| object-property-read-bound loop (2 large shapes) | ~613ms | ~412ms | **~33%** |
| megamorphic (8 shapes) | ~961ms | ~741ms | **~23%** |

**Honest scope:** megamorphic does **not** fully close to node (~77ms) here. That fixture's hot trace is dominated by the boxed array index `objs[r % n]` (array-handle clone + boxed modulo + element clone) — a separate lever — and the roadmap reserves megamorphic *full* parity for NaN-boxing (#201). This PR is the general object-property-read speedup PICs buy, which transfers to TFB/handler/Bun object code, not a megamorphic flip.

## Validation
- Gauntlet **soundness holds**: `typed == boxed == node` across all 29 fixtures, no build/run/checksum failures.
- All **25 integration tests** pass (interp/vm/native/js/wasi/cranelift).
- Object reads verified **backend-identical** (interp==vm==native-typed==native-boxed) across: shape growth, live mutation, dictionary mode (post-delete), `.size`, Map, >8-key map-backed objects, polymorphic sites, and nested `a.b.c` reads.