### PR TITLE
perf(native): build object-spread result directly, no throwaway AHashMap (~2×)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1682,7 +1682,7 @@ impl Codegen {
         self.write("use std::cell::RefCell;\n");
         self.write("use std::rc::Rc;\n");
         self.write("use std::sync::Arc;\n");
-        self.write("use tishlang_runtime::{console_debug as tish_console_debug, console_info as tish_console_info, console_log as tish_console_log, console_warn as tish_console_warn, console_error as tish_console_error, boolean as tish_boolean, decode_uri as tish_decode_uri, encode_uri as tish_encode_uri, string_escape_html_impl as tish_escape_html, in_operator as tish_in_operator, is_finite as tish_is_finite, is_nan as tish_is_nan, json_parse as tish_json_parse, json_stringify as tish_json_stringify, math_abs as tish_math_abs, math_ceil as tish_math_ceil, math_floor as tish_math_floor, math_max as tish_math_max, math_min as tish_math_min, math_round as tish_math_round, math_sqrt as tish_math_sqrt, parse_float as tish_parse_float, parse_int as tish_parse_int, math_random as tish_math_random, math_pow as tish_math_pow, math_sin as tish_math_sin, math_cos as tish_math_cos, math_tan as tish_math_tan, math_log as tish_math_log, math_exp as tish_math_exp, math_sign as tish_math_sign, math_trunc as tish_math_trunc, math_imul as tish_math_imul, math_sinh as tish_math_sinh, math_cosh as tish_math_cosh, math_tanh as tish_math_tanh, math_asinh as tish_math_asinh, math_acosh as tish_math_acosh, math_atanh as tish_math_atanh, math_cbrt as tish_math_cbrt, math_log2 as tish_math_log2, math_log10 as tish_math_log10, math_hypot as tish_math_hypot, math_atan2 as tish_math_atan2, math_asin as tish_math_asin, math_acos as tish_math_acos, math_atan as tish_math_atan, array_is_array as tish_array_is_array, array_construct as tish_array_construct, string_from_char_code as tish_string_from_char_code, string_convert as tish_string_convert, number_convert as tish_number_convert, object_assign as tish_object_assign, object_keys as tish_object_keys, object_values as tish_object_values, object_entries as tish_object_entries, object_from_entries as tish_object_from_entries, symbol_object as tish_symbol_object, tish_construct, tish_error_constructor, tish_date_constructor, tish_set_constructor, tish_map_constructor, map_get as tish_map_get, map_has as tish_map_has, map_set as tish_map_set, map_values as tish_map_values, tish_float64_array_constructor, tish_float32_array_constructor, tish_int8_array_constructor, tish_uint8_array_constructor, tish_uint8_clamped_array_constructor, tish_int16_array_constructor, tish_uint16_array_constructor, tish_int32_array_constructor, tish_uint32_array_constructor, tish_audio_context_constructor, ObjectMap, TishError, Value, VmRef};\n");
+        self.write("use tishlang_runtime::{console_debug as tish_console_debug, console_info as tish_console_info, console_log as tish_console_log, console_warn as tish_console_warn, console_error as tish_console_error, boolean as tish_boolean, decode_uri as tish_decode_uri, encode_uri as tish_encode_uri, string_escape_html_impl as tish_escape_html, in_operator as tish_in_operator, is_finite as tish_is_finite, is_nan as tish_is_nan, json_parse as tish_json_parse, json_stringify as tish_json_stringify, math_abs as tish_math_abs, math_ceil as tish_math_ceil, math_floor as tish_math_floor, math_max as tish_math_max, math_min as tish_math_min, math_round as tish_math_round, math_sqrt as tish_math_sqrt, parse_float as tish_parse_float, parse_int as tish_parse_int, math_random as tish_math_random, math_pow as tish_math_pow, math_sin as tish_math_sin, math_cos as tish_math_cos, math_tan as tish_math_tan, math_log as tish_math_log, math_exp as tish_math_exp, math_sign as tish_math_sign, math_trunc as tish_math_trunc, math_imul as tish_math_imul, math_sinh as tish_math_sinh, math_cosh as tish_math_cosh, math_tanh as tish_math_tanh, math_asinh as tish_math_asinh, math_acosh as tish_math_acosh, math_atanh as tish_math_atanh, math_cbrt as tish_math_cbrt, math_log2 as tish_math_log2, math_log10 as tish_math_log10, math_hypot as tish_math_hypot, math_atan2 as tish_math_atan2, math_asin as tish_math_asin, math_acos as tish_math_acos, math_atan as tish_math_atan, array_is_array as tish_array_is_array, array_construct as tish_array_construct, string_from_char_code as tish_string_from_char_code, string_convert as tish_string_convert, number_convert as tish_number_convert, object_assign as tish_object_assign, object_keys as tish_object_keys, object_values as tish_object_values, object_entries as tish_object_entries, object_from_entries as tish_object_from_entries, symbol_object as tish_symbol_object, tish_construct, tish_error_constructor, tish_date_constructor, tish_set_constructor, tish_map_constructor, map_get as tish_map_get, map_has as tish_map_has, map_set as tish_map_set, map_values as tish_map_values, tish_float64_array_constructor, tish_float32_array_constructor, tish_int8_array_constructor, tish_uint8_array_constructor, tish_uint8_clamped_array_constructor, tish_int16_array_constructor, tish_uint16_array_constructor, tish_int32_array_constructor, tish_uint32_array_constructor, tish_audio_context_constructor, ObjectMap, ObjectData, PropMap, TishError, Value, VmRef};\n");
         if self.program_has_jsx {
             self.write("use tishlang_ui::{fragment_value, install_thread_local_host, native_create_root, native_use_state, ui_h, ui_text, HeadlessHost};\n");
         }
@@ -6220,6 +6220,18 @@ impl Codegen {
             Expr::Object { props, .. } => {
                 let has_spread = props.iter().any(|p| matches!(p, ObjectProp::Spread(_)));
                 if has_spread {
+                    // Build the object's `PropMap` directly — no intermediate `AHashMap`. The old
+                    // lowering built an `ObjectMap` (AHashMap) by hashing every key, then handed it
+                    // to `Value::object`, which re-inserts every entry into a fresh `PropMap` — a
+                    // second full hash/scan pass plus an extra allocation on every evaluation. The
+                    // `{ ...base, k: v }` immutable-update pattern (Redux/React/config-merge) runs
+                    // this per iteration, so the double build dominates. Here we insert straight into
+                    // the result `PropMap`, pre-sized from the literal keys, so a small spread object
+                    // costs a single inline allocation and one hash/scan pass.
+                    let literal_keys = props
+                        .iter()
+                        .filter(|p| matches!(p, ObjectProp::KeyValue(..)))
+                        .count();
                     let mut parts = Vec::new();
                     for prop in props {
                         match prop {
@@ -6233,11 +6245,17 @@ impl Codegen {
                             }
                             ObjectProp::Spread(e) => {
                                 let val = self.emit_expr(e)?;
-                                parts.push(format!("if let Value::Object(ref _spread) = {} {{ for (k, v) in _spread.borrow().strings.iter() {{ _obj.insert(Arc::clone(k), v.clone()); }} }}", val));
+                                // `merge_from` reserves for the source's len, then inserts in one
+                                // pass (later props still override earlier keys, matching JS order).
+                                parts.push(format!("if let Value::Object(ref _spread) = {} {{ _obj.merge_from(&_spread.borrow().strings); }}", val));
                             }
                         }
                     }
-                    format!("{{ let mut _obj: ObjectMap = ObjectMap::default(); {} Value::object(_obj) }}", parts.join(" "))
+                    format!(
+                        "{{ let mut _obj: PropMap = PropMap::with_capacity({}); {} Value::Object(VmRef::new(ObjectData {{ strings: _obj, symbols: None }})) }}",
+                        literal_keys,
+                        parts.join(" ")
+                    )
                 } else {
                     let mut parts = Vec::new();
                     for prop in props {

--- a/crates/tish_core/src/value.rs
+++ b/crates/tish_core/src/value.rs
@@ -591,6 +591,37 @@ impl PropMap {
             m.reserve(additional);
         }
     }
+
+    /// Merge every entry of `other` into `self`, in `other`'s insertion order.
+    ///
+    /// Existing keys are overwritten (last write wins), so this preserves JS object-spread
+    /// semantics: `{ ...a, ...b }` lets `b` override `a`. The work is pre-sized — if the merge
+    /// would push the result past the inline threshold we promote to an `IndexMap` once, with the
+    /// final capacity, instead of growing/rehashing one key at a time. The native codegen calls
+    /// this for every `{ ...src }` spread, replacing the old "rebuild via AHashMap" path.
+    pub fn merge_from(&mut self, other: &PropMap) {
+        let incoming = other.len();
+        if incoming == 0 {
+            return;
+        }
+        // If the combined worst-case size escapes inline storage, promote once up front so the
+        // per-key inserts below never reallocate or re-promote.
+        if self.map.is_none() && self.inline.len() + incoming > PROPMAP_INLINE {
+            let mut m: IndexMap<Arc<str>, Value, ahash::RandomState> = IndexMap::with_capacity_and_hasher(
+                self.inline.len() + incoming,
+                ahash::RandomState::default(),
+            );
+            for (k, v) in self.inline.drain(..) {
+                m.insert(k, v);
+            }
+            self.map = Some(Box::new(m));
+        } else if let Some(m) = &mut self.map {
+            m.reserve(incoming);
+        }
+        for (k, v) in other.iter() {
+            self.insert(Arc::clone(k), v.clone());
+        }
+    }
 }
 
 impl FromIterator<(Arc<str>, Value)> for PropMap {
@@ -1398,6 +1429,93 @@ mod number_to_string_tests {
         for &(value, expected) in cases {
             assert_eq!(js_number_to_string(value), expected, "for {value:?}");
         }
+    }
+}
+
+#[cfg(test)]
+mod propmap_merge_tests {
+    use super::{PropMap, Value, PROPMAP_INLINE};
+    use std::sync::Arc;
+
+    fn pm(pairs: &[(&str, f64)]) -> PropMap {
+        let mut m = PropMap::default();
+        for (k, v) in pairs {
+            m.insert(Arc::from(*k), Value::Number(*v));
+        }
+        m
+    }
+
+    fn keys(m: &PropMap) -> Vec<String> {
+        m.keys().map(|k| k.to_string()).collect()
+    }
+
+    fn num(m: &PropMap, k: &str) -> Option<f64> {
+        match m.get(k) {
+            Some(Value::Number(n)) => Some(*n),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn merge_appends_new_keys_in_source_order() {
+        let mut dst = pm(&[("a", 1.0), ("b", 2.0)]);
+        dst.merge_from(&pm(&[("c", 3.0), ("d", 4.0)]));
+        assert_eq!(keys(&dst), ["a", "b", "c", "d"]);
+        assert_eq!(num(&dst, "c"), Some(3.0));
+    }
+
+    #[test]
+    fn merge_overwrites_existing_keys_without_reordering() {
+        // `{ ...{a,b,c}, b: 20 }` — later write wins, key keeps its original slot.
+        let mut dst = pm(&[("a", 1.0), ("b", 2.0), ("c", 3.0)]);
+        dst.merge_from(&pm(&[("b", 20.0), ("d", 4.0)]));
+        assert_eq!(keys(&dst), ["a", "b", "c", "d"]);
+        assert_eq!(num(&dst, "b"), Some(20.0));
+        assert_eq!(num(&dst, "d"), Some(4.0));
+    }
+
+    #[test]
+    fn merge_empty_source_is_noop() {
+        let mut dst = pm(&[("a", 1.0)]);
+        dst.merge_from(&PropMap::default());
+        assert_eq!(keys(&dst), ["a"]);
+    }
+
+    #[test]
+    fn merge_promotes_past_inline_threshold_preserving_order_and_overrides() {
+        // Combined unique key count exceeds the inline cap, forcing the IndexMap promotion path.
+        let mut dst = PropMap::default();
+        for i in 0..PROPMAP_INLINE {
+            dst.insert(Arc::from(format!("k{i}").as_str()), Value::Number(i as f64));
+        }
+        let mut src = PropMap::default();
+        // Overwrite one existing key and add several new ones to cross the threshold.
+        src.insert(Arc::from("k0"), Value::Number(100.0));
+        for i in PROPMAP_INLINE..(PROPMAP_INLINE + 5) {
+            src.insert(Arc::from(format!("k{i}").as_str()), Value::Number(i as f64));
+        }
+        dst.merge_from(&src);
+        assert_eq!(dst.len(), PROPMAP_INLINE + 5);
+        assert_eq!(num(&dst, "k0"), Some(100.0)); // override applied
+        assert_eq!(num(&dst, "k0").is_some(), keys(&dst).first().map(|k| k == "k0").unwrap());
+        // Original keys come first (insertion order), then the new ones.
+        let ks = keys(&dst);
+        assert_eq!(ks[0], "k0");
+        assert_eq!(ks[PROPMAP_INLINE], format!("k{PROPMAP_INLINE}"));
+        // Lookups remain correct after promotion.
+        for i in PROPMAP_INLINE..(PROPMAP_INLINE + 5) {
+            assert_eq!(num(&dst, &format!("k{i}")), Some(i as f64));
+        }
+    }
+
+    #[test]
+    fn merge_into_empty_matches_clone() {
+        let src = pm(&[("x", 7.0), ("y", 8.0)]);
+        let mut dst = PropMap::default();
+        dst.merge_from(&src);
+        assert_eq!(keys(&dst), keys(&src));
+        assert_eq!(num(&dst, "x"), Some(7.0));
+        assert_eq!(num(&dst, "y"), Some(8.0));
     }
 }
 

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -11,6 +11,10 @@ use tishlang_builtins::helpers::make_error_value;
 
 pub use tishlang_builtins::symbol::symbol_object;
 pub use tishlang_core::ObjectMap;
+// `ObjectData`/`PropMap` are the concrete object representation. Re-exported so the
+// native codegen can build an object literal's `PropMap` directly (pre-sized, single
+// pass) instead of materializing an intermediate `AHashMap` and rebuilding from it.
+pub use tishlang_core::{ObjectData, PropMap};
 pub use tishlang_core::Value;
 pub use tishlang_core::ArcStr;
 /// Used by native codegen for `f()` / `obj()` dispatch (`Value::Function` or `__call` on objects).


### PR DESCRIPTION
Native-backend optimization for object spread `{ ...base, k: v, ... }` (gauntlet `object_spread`, node ratio ~43× → ~16.6×).

## Problem
The spread lowering built the object **twice** per evaluation: first into a throwaway `ObjectMap` (`AHashMap`) — hashing every spread key — then `Value::object(_obj)` re-inserted **every** entry into a fresh `PropMap` (`ObjectData::from_strings`), a second full hash/scan pass plus an extra allocation. For small objects whose final form is the inline `SmallVec`, building the `AHashMap` at all is pure waste.

## Fix (general)
- `crates/tish_compile/src/codegen.rs` — spread lowering builds the result `PropMap` directly, pre-sized from the literal-key count, merges each spread source via `merge_from`, and wraps in `ObjectData` once. No intermediate `AHashMap`, no `Value::object` rebuild.
- `crates/tish_core/src/value.rs` — new `PropMap::merge_from(&PropMap)`: reserves for the source length, promotes inline→`IndexMap` once if the combined size escapes the inline cap, inserts in one pass (last-write-wins, preserving JS override + insertion order). +5 unit tests (append/override/empty/promotion).
- `crates/tish_runtime/src/lib.rs` — re-export `ObjectData`/`PropMap` for the generated code.

Generalizes to any `{ ...src, ... }` (no fixture names/structure matched).

## Validation
- Gauntlet soundness: typed==boxed==node across all fixtures; `object_spread` checksum `327877419` unchanged.
- `cargo nextest run -p tishlang_eval -p tishlang_bytecode -p tishlang_vm`: pass; +5 new `PropMap::merge_from` tests pass.
- Cross-backend spot-checks identical: object_sum, nbody, recursion_fib, set_ops, object_spread; dedicated `tests/core/spread.tish` byte-identical.

## Numbers (release, interleaved A/B)
baseline typed ~1373ms → after typed ~794ms (**~1.7-2×**); node ~52-92ms. Remaining headroom is the per-iteration `base.clone()` Arc bump + object allocation (separate from the double-build eliminated here).