### PR TITLE
perf(native): integer fast path in js_number_to_string + zero-clone Map key lookup

### DIFF
--- a/crates/tish_builtins/src/collections.rs
+++ b/crates/tish_builtins/src/collections.rs
@@ -54,38 +54,65 @@ impl PartialEq for Key {
 }
 impl Eq for Key {}
 
+/// The single source of truth for hashing a key `Value`. Both [`Key`] (owned, the stored key) and
+/// [`KeyRef`] (borrowed, the lookup probe) delegate here so an owned key and a borrowed probe of an
+/// equal value hash identically — the invariant that makes the zero-clone borrow lookup sound.
+#[inline]
+fn hash_key_value<H: Hasher>(v: &Value, state: &mut H) {
+    match v {
+        Value::Number(n) => {
+            0u8.hash(state);
+            // Canonicalize so `Eq` partners hash together: `+0` and `-0` share a key, and every
+            // NaN is one key.
+            let bits = if *n == 0.0 {
+                0u64
+            } else if n.is_nan() {
+                0x7ff8_0000_0000_0000
+            } else {
+                n.to_bits()
+            };
+            bits.hash(state);
+        }
+        Value::String(s) => {
+            1u8.hash(state);
+            s.as_str().hash(state);
+        }
+        Value::Bool(b) => {
+            2u8.hash(state);
+            b.hash(state);
+        }
+        Value::Null => 3u8.hash(state),
+        // Reference / identity values: per-variant tag only; `ptr_eq` in `Eq` does the rest.
+        Value::Symbol(_) => 4u8.hash(state),
+        Value::Array(_) => 5u8.hash(state),
+        Value::NumberArray(_) => 6u8.hash(state),
+        Value::Object(_) => 7u8.hash(state),
+        _ => 8u8.hash(state),
+    }
+}
+
 impl Hash for Key {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        match &self.0 {
-            Value::Number(n) => {
-                0u8.hash(state);
-                // Canonicalize so `Eq` partners hash together: `+0` and `-0` share a key, and every
-                // NaN is one key.
-                let bits = if *n == 0.0 {
-                    0u64
-                } else if n.is_nan() {
-                    0x7ff8_0000_0000_0000
-                } else {
-                    n.to_bits()
-                };
-                bits.hash(state);
-            }
-            Value::String(s) => {
-                1u8.hash(state);
-                s.as_str().hash(state);
-            }
-            Value::Bool(b) => {
-                2u8.hash(state);
-                b.hash(state);
-            }
-            Value::Null => 3u8.hash(state),
-            // Reference / identity values: per-variant tag only; `ptr_eq` in `Eq` does the rest.
-            Value::Symbol(_) => 4u8.hash(state),
-            Value::Array(_) => 5u8.hash(state),
-            Value::NumberArray(_) => 6u8.hash(state),
-            Value::Object(_) => 7u8.hash(state),
-            _ => 8u8.hash(state),
-        }
+        hash_key_value(&self.0, state);
+    }
+}
+
+/// Borrowed look-up probe for [`Key`]: wraps `&Value` so `get`/`contains_key`/`shift_remove` can
+/// query the store **without cloning the key into an owned `Key`** (no `Value` clone, no `Arc` bump).
+/// It hashes via [`hash_key_value`] (identical to `Key`) and compares via [`same_value_zero`]
+/// (identical to `Key`'s `Eq`), so it is `Equivalent<Key>` — the lookup is a drop-in for `&Key`.
+/// Only `set`/`add` (which must *store* the key) still build an owned `Key`.
+struct KeyRef<'a>(&'a Value);
+
+impl Hash for KeyRef<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        hash_key_value(self.0, state);
+    }
+}
+
+impl indexmap::Equivalent<Key> for KeyRef<'_> {
+    fn equivalent(&self, key: &Key) -> bool {
+        same_value_zero(self.0, &key.0)
     }
 }
 
@@ -131,17 +158,18 @@ fn map_store(map: &Value) -> Option<Store> {
 }
 
 /// Direct `Map.prototype.has` — skips bound-method `get_prop` + `value_call` (k-nucleotide hot path).
+/// Looks up via a borrowed [`KeyRef`]: no key clone, no owned `Key` allocation.
 pub fn map_has(map: &Value, key: &Value) -> Value {
     match map_store(map) {
-        Some(s) => Value::Bool(s.borrow().contains_key(&Key(key.clone()))),
+        Some(s) => Value::Bool(s.borrow().contains_key(&KeyRef(key))),
         None => Value::Bool(false),
     }
 }
 
-/// Direct `Map.prototype.get`.
+/// Direct `Map.prototype.get`. Looks up via a borrowed [`KeyRef`] (no key clone / no owned `Key`).
 pub fn map_get(map: &Value, key: &Value) -> Value {
     match map_store(map) {
-        Some(s) => s.borrow().get(&Key(key.clone())).cloned().unwrap_or(Value::Null),
+        Some(s) => s.borrow().get(&KeyRef(key)).cloned().unwrap_or(Value::Null),
         None => Value::Null,
     }
 }
@@ -242,8 +270,8 @@ pub fn set_instance(initial: &[Value]) -> Value {
         m.insert(
             Arc::from("has"),
             Value::native(move |args: &[Value]| {
-                let v = args.first().cloned().unwrap_or(Value::Null);
-                Value::Bool(s.borrow().contains_key(&Key(v)))
+                let v = args.first().unwrap_or(&Value::Null);
+                Value::Bool(s.borrow().contains_key(&KeyRef(v)))
             }),
         );
     }
@@ -252,9 +280,9 @@ pub fn set_instance(initial: &[Value]) -> Value {
         m.insert(
             Arc::from("delete"),
             Value::native(move |args: &[Value]| {
-                let v = args.first().cloned().unwrap_or(Value::Null);
+                let v = args.first().unwrap_or(&Value::Null);
                 // `shift_remove` preserves iteration order (vs `swap_remove`).
-                Value::Bool(s.borrow_mut().shift_remove(&Key(v)).is_some())
+                Value::Bool(s.borrow_mut().shift_remove(&KeyRef(v)).is_some())
             }),
         );
     }
@@ -345,8 +373,8 @@ pub fn map_instance(pairs: &[Value]) -> Value {
         m.insert(
             Arc::from("get"),
             Value::native(move |args: &[Value]| {
-                let key = args.first().cloned().unwrap_or(Value::Null);
-                s.borrow().get(&Key(key)).cloned().unwrap_or(Value::Null)
+                let key = args.first().unwrap_or(&Value::Null);
+                s.borrow().get(&KeyRef(key)).cloned().unwrap_or(Value::Null)
             }),
         );
     }
@@ -355,8 +383,8 @@ pub fn map_instance(pairs: &[Value]) -> Value {
         m.insert(
             Arc::from("has"),
             Value::native(move |args: &[Value]| {
-                let key = args.first().cloned().unwrap_or(Value::Null);
-                Value::Bool(s.borrow().contains_key(&Key(key)))
+                let key = args.first().unwrap_or(&Value::Null);
+                Value::Bool(s.borrow().contains_key(&KeyRef(key)))
             }),
         );
     }
@@ -365,8 +393,8 @@ pub fn map_instance(pairs: &[Value]) -> Value {
         m.insert(
             Arc::from("delete"),
             Value::native(move |args: &[Value]| {
-                let key = args.first().cloned().unwrap_or(Value::Null);
-                Value::Bool(s.borrow_mut().shift_remove(&Key(key)).is_some())
+                let key = args.first().unwrap_or(&Value::Null);
+                Value::Bool(s.borrow_mut().shift_remove(&KeyRef(key)).is_some())
             }),
         );
     }

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -5545,6 +5545,33 @@ impl Codegen {
         self.emit_expr(e)
     }
 
+    /// Emit a `&Value` expression for a read-only (borrow-only) call argument, avoiding the
+    /// by-value `.clone()` that `emit_expr` adds for loop-carried locals. Used by `Map.has`/`Map.get`
+    /// whose runtime entry points take `&Value` and only read the key — a loop-carried key shouldn't
+    /// be re-cloned every iteration just to be looked up. A plain `Value`-typed local lowers to a
+    /// borrow of the place (`&name`); anything else borrows the (possibly temporary) emitted value
+    /// (`&(<expr>)`), which is still a no-op refcount-wise for the duration of the call.
+    fn emit_borrowed_arg(&mut self, arg: &CallArg) -> Result<String, CompileError> {
+        let e = match arg {
+            CallArg::Expr(e) | CallArg::Spread(e) => e,
+        };
+        // Only a plain `Value`-typed, non-refcell local can be borrowed as a place without a clone;
+        // native-typed (f64/…) and refcell-wrapped idents must go through `emit_expr` (which builds a
+        // fresh `Value`), so we borrow that temporary instead.
+        if let Expr::Ident { name, .. } = e {
+            let n = name.as_ref();
+            let is_plain_value = !self.refcell_wrapped_vars.contains(n)
+                && !self.native_numeric_globals.contains_key(n)
+                && self.module_const_f64_array_rust_ref(n).is_none()
+                && !self.usize_var_subst.contains_key(n)
+                && !self.type_context.get_type(n).is_native();
+            if is_plain_value {
+                return Ok(format!("&{}", Self::escape_ident(n)));
+            }
+        }
+        Ok(format!("&({})", self.emit_expr(e)?))
+    }
+
     /// #317: if `expr` lowers to a native Rust `String` (`RustType::String`), return a borrowed
     /// `&str` expression (`(<code>).as_str()`) so string char/index/length ops can BORROW it rather
     /// than deep-clone it into a fresh `Value::String` per call. Returns `None` for any other type
@@ -6190,16 +6217,15 @@ impl Codegen {
                             let map_ref = format!("&{}", Self::escape_ident(map_name.as_ref()));
                             match method_name.as_ref() {
                                 "has" if args.len() == 1 => {
-                                    return Ok(format!(
-                                        "tish_map_has({}, &{})",
-                                        map_ref, arg_exprs[0]
-                                    ));
+                                    // `map_has` borrows the key (`&Value`) — pass a borrow of the
+                                    // place rather than `&(key).clone()`, so a loop-carried key isn't
+                                    // re-cloned every iteration just to be read.
+                                    let key_ref = self.emit_borrowed_arg(&args[0])?;
+                                    return Ok(format!("tish_map_has({}, {})", map_ref, key_ref));
                                 }
                                 "get" if args.len() == 1 => {
-                                    return Ok(format!(
-                                        "tish_map_get({}, &{})",
-                                        map_ref, arg_exprs[0]
-                                    ));
+                                    let key_ref = self.emit_borrowed_arg(&args[0])?;
+                                    return Ok(format!("tish_map_get({}, {})", map_ref, key_ref));
                                 }
                                 "set" if args.len() == 2 => {
                                     return Ok(format!(
@@ -19558,6 +19584,25 @@ impl Codegen {
         }
     }
 
+    /// Box a typed operand back into a `Value` for a runtime call (`ops::add` etc.), avoiding the
+    /// generic `to_value_expr` round-trip when the operand is a constant. A string literal lowers to
+    /// `Value::String("w".into())` — a single `ArcStr` allocation — instead of
+    /// `Value::String("w".to_string().clone().into())`, which allocates a `String`, clones it, and
+    /// then converts to `ArcStr` (three allocations) on every evaluation. In a hot loop (e.g.
+    /// `key = "w" + (seed % 1000)`), the literal is re-evaluated each iteration, so this is the
+    /// difference between three allocations per iteration and one. Numeric literals stay
+    /// `Value::Number(..)` (no allocation either way). Everything else falls back to `to_value_expr`.
+    fn box_operand_for_runtime(orig: &Expr, native_code: &str, ty: &RustType) -> String {
+        if let Expr::Literal { value: Literal::String(s), .. } = orig {
+            return format!("Value::String({:?}.into())", s.as_ref());
+        }
+        if ty.is_native() {
+            ty.to_value_expr(native_code)
+        } else {
+            native_code.to_string()
+        }
+    }
+
     fn emit_typed_expr(&mut self, expr: &Expr) -> Result<(String, RustType), CompileError> {
         match expr {
             // ── literals ─────────────────────────────────────────────────────────
@@ -19769,16 +19814,8 @@ impl Codegen {
                 }
 
                 // Fall back: convert both sides to Value and use the runtime.
-                let lv = if lt.is_native() {
-                    lt.to_value_expr(&l)
-                } else {
-                    l
-                };
-                let rv = if rt.is_native() {
-                    rt.to_value_expr(&r)
-                } else {
-                    r
-                };
+                let lv = Self::box_operand_for_runtime(left, &l, &lt);
+                let rv = Self::box_operand_for_runtime(right, &r, &rt);
                 let result = self.emit_binop(&lv, *op, &rv, *span)?;
                 Ok((result, RustType::Value))
             }

--- a/crates/tish_core/src/value.rs
+++ b/crates/tish_core/src/value.rs
@@ -998,6 +998,22 @@ pub fn js_number_to_string_into(out: &mut String, value: f64) {
         return;
     }
 
+    // Fast path for exact integers within ±2^53 (the f64 "safe integer" range). ECMAScript ToString
+    // renders any such integer in plain decimal (no sign-exponent — magnitude < 1e21 ⇒ `point <= 21`
+    // in the general algorithm below), which `itoa` emits directly, bypassing the `format!("{:e}")`
+    // round-trip + intermediate `String`/`char`-filter/`"0".repeat()`. This is the dominant case for
+    // tally/counter/index loops (e.g. map keys like `"w" + (n % 1000)`). Bit-identical to the general
+    // path for every integer it accepts: each such value is exactly representable in both f64 and i64,
+    // so `value as i64` is exact (no saturation — `±2^53` is well inside i64), and the decimal form is
+    // the same digits the general path would emit. Larger integers (where f64 can't represent
+    // consecutive values) fall through to the general path unchanged.
+    const MAX_SAFE_INT: f64 = 9_007_199_254_740_992.0; // 2^53
+    if value.fract() == 0.0 && value.abs() <= MAX_SAFE_INT {
+        let mut buf = itoa::Buffer::new();
+        out.push_str(buf.format(value as i64));
+        return;
+    }
+
     let negative = value < 0.0;
     // Shortest round-trip digits + base-10 exponent, e.g. "6.022e23" → ("6022", 23).
     let sci = format!("{:e}", value.abs());
@@ -1402,6 +1418,14 @@ mod number_to_string_tests {
             (0.5, "0.5"),
             (-123.456, "-123.456"),
             (100000.0, "100000"),
+            (-1000.0, "-1000"),
+            // Integer fast-path boundary (±2^53): the largest safe integer takes the itoa path; the
+            // next decade up (still an exact f64 integer, but > 2^53) takes the general path. Both must
+            // match Node's `String(value)`.
+            (9007199254740992.0, "9007199254740992"), // 2^53
+            (9007199254740991.0, "9007199254740991"), // 2^53 - 1 (Number.MAX_SAFE_INTEGER)
+            (-9007199254740992.0, "-9007199254740992"),
+            (1e16, "10000000000000000"), // > 2^53, exact f64 integer → general path
             // Decimal/exponential boundary on the large side: 1e21 flips to exponential.
             (1e20, "100000000000000000000"),
             (1e21, "1e+21"),


### PR DESCRIPTION
Native-backend optimization for string-keyed Map workloads (gauntlet `map_string_keys`: **FAIL → PASS**, now beats node), with a general number→string speedup that helps every backend.

## The surprise: it wasn't the Map
Profiling with isolation probes showed the `m.has/get/set` calls were a minority cost. The dominant cost was building the key `"w" + (seed % 1000)` — specifically `js_number_to_string`, which routed **every integer** through `format!("{:e}", …)` scientific-notation formatting + an intermediate `String` + a `char`-filter `collect()` + `"0".repeat()`. A heavy multi-allocation path for a tiny int like `783`.

## Fixes (all general, not fixture-specific; #317)
1. **`crates/tish_core/src/value.rs` — integer fast path in `js_number_to_string_into`:** exact integers within ±2^53 go straight through `itoa` (one allocation, plain decimal), bypassing the sci-notation round-trip. Bit-identical to the general path (such values are exact in both f64 and i64; magnitude < 1e21 ⇒ same plain decimal). **This is the dominant win and benefits every number→string on every backend** (e.g. `fasta` shows a 6.19× typing-speedup).
2. **`crates/tish_builtins/src/collections.rs` — zero-clone Map/Set lookup:** a borrowed `KeyRef<'a>(&Value)` probe (`Hash` via a shared `hash_key_value`, `Equivalent<Key>`) lets `has`/`get`/`delete` look up without cloning the key into an owned `Key`.
3. **`crates/tish_compile/src/codegen.rs`:** `Map.has`/`get` pass `&key` (not `&(key).clone()`); string-literal operands box as `Value::String("w".into())` (1 alloc) instead of `…"w".to_string().clone().into()` (3 allocs).

## Validation
- Gauntlet soundness `typed==boxed==node` (no build/run/checksum failures) on map_string_keys (checksum `2013348362` unchanged), k_nucleotide, set_ops, fasta, string_build, string_concat, json_roundtrip, fnv_hash.
- Unit: `tishlang_eval`/`bytecode`/`vm` (23) + `tishlang_core`/`builtins` (69, incl. extended `number_to_string` boundary cases) pass.
- Full integration corpus passes (every `tests/core/*.tish` across backends, incl. `number_to_string`).

## Numbers (min ms, interleaved 5×)
baseline ~76 → after-typed ~44 (≈ boxed ~43; the typed-slower-than-boxed pathology is gone) → node ~58. **map_string_keys 1.29× slower than node → 0.74× (beats node), ~1.7×; gauntlet FAIL → PASS.**

Note: a pre-existing `-0`-in-array-literal native codegen quirk surfaced during testing — unrelated to this change (reproduces on a minimal array; interp/vm/node handle it correctly).
