### PR TITLE
perf(native): native arithmetic over struct-array field reads (array_records beats node)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -12570,6 +12570,25 @@ impl Codegen {
                         }
                     }
                 }
+                // `arr[i].field` where `arr` is a `Vec<struct>` — the element struct's native field
+                // type. Mirrors the `var.field` case above but for an array-of-records element, so a
+                // numeric accumulator fed by `rows[i].x * rows[i].w + …` stays native f64 instead of
+                // being demoted to a boxed Value (the array_records read loop).
+                if let Expr::Index { object: io, optional: false, .. } = object.as_ref() {
+                    if let Expr::Ident { name: arr_name, .. } = io.as_ref() {
+                        if let Some(RustType::Vec(inner)) = env.get(arr_name.as_ref()) {
+                            if let RustType::Named { fields, .. } = inner.as_ref() {
+                                if let Some((_, field_ty)) =
+                                    fields.iter().find(|(k, _)| k.as_ref() == prop_name.as_ref())
+                                {
+                                    if field_ty.is_native() {
+                                        return field_ty.clone();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
                 RustType::Value
             }
             Expr::Call { callee, args, .. } => {
@@ -20327,6 +20346,25 @@ impl Codegen {
                                 return Ok((access, field_ty.clone()));
                             }
                             if matches!(field_ty, RustType::Named { .. } | RustType::Vec(_)) {
+                                return Ok((access, field_ty.clone()));
+                            }
+                        }
+                    }
+                }
+                // `arr[i].field` — element of a `Vec<struct>`: native field read (`(rows[i]).x`)
+                // instead of boxing it through `Value::Number`, so a numeric accumulator fed by
+                // `rows[i].x * rows[i].w + rows[i].y` stays native (the array_records read loop).
+                if let Expr::Index { .. } = object.as_ref() {
+                    let (obj_code, obj_ty) = self.emit_typed_expr(object)?;
+                    if let RustType::Named { fields, .. } = &obj_ty {
+                        if let Some((_, field_ty)) =
+                            fields.iter().find(|(k, _)| k.as_ref() == prop_name.as_ref())
+                        {
+                            let field = crate::types::field_ident(prop_name.as_ref());
+                            let access = format!("({}).{}", obj_code, field);
+                            if field_ty.is_native()
+                                || matches!(field_ty, RustType::Named { .. } | RustType::Vec(_))
+                            {
                                 return Ok((access, field_ty.clone()));
                             }
                         }

--- a/scripts/perf_acctype_ship.sh
+++ b/scripts/perf_acctype_ship.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Validate + PR the demote-gate fix (native numeric accumulators across struct-array field reads).
+# Re-bases onto fresh main (applying #351 inference + #350 de-boxing if not yet merged), builds, and
+# checks whether array_records now FLIPS (beats node → PASS) with soundness + full integration.
+# Output: target/perf_acctype.txt
+set -uo pipefail
+ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT"
+OUT=target/perf_acctype.txt; : > "$OUT"
+log(){ echo "$@" | tee -a "$OUT"; }
+BR=perf/array-records-native-read
+
+log "== capture codegen edit =="
+git diff -- crates/tish_compile/src/codegen.rs > target/acctype.patch
+[ -s target/acctype.patch ] || { log "ABORT: no edit captured"; exit 1; }
+git checkout -- crates/tish_compile/src/codegen.rs 2>/dev/null || true
+
+log "== branch off fresh main =="
+git checkout main --quiet && (git pull --ff-only origin main --quiet 2>/dev/null || true)
+git branch -D "$BR" 2>/dev/null || true
+git checkout -b "$BR" --quiet || { log "ABORT: branch"; exit 1; }
+
+log "== ensure #350 + #351 present =="
+if ! grep -q "cse_result_is_boxed" crates/tish_compile/src/codegen.rs; then
+  log "  applying #350 (construct + cse)"; git apply target/construct.patch && git apply target/cse.patch || { log "ABORT #350"; git checkout main --quiet; exit 1; }
+fi
+if grep -q "record_array_fields" crates/tish_compile/src/infer.rs; then
+  log "  #351 already in main"
+else
+  log "  applying #351 infer patch"; git apply target/infer.patch || { log "ABORT: #351 infer patch failed"; git checkout main --quiet; exit 1; }
+fi
+
+log "== apply demote-gate patch =="
+git apply target/acctype.patch || { log "ABORT: acctype patch failed"; git checkout main --quiet; exit 1; }
+
+log "== build release =="
+cargo build --release --bin tish > target/atb.log 2>&1 || { log "ABORT: release build"; tail -30 target/atb.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; }
+
+log "== gauntlet: array_records (FLIP?) + neighbors (no regression) =="
+bash scripts/run_perf_gauntlet.sh array_records object_sum object_spread megamorphic nbody matmul > target/atg.log 2>&1
+grep -E "^(array_records|object_sum|object_spread|megamorphic|nbody|matmul) |SOUNDNESS|SUMMARY" target/atg.log | tee -a "$OUT"
+grep -q "no build/run/checksum failures" target/atg.log || { log "ABORT: soundness FAIL"; tail -10 target/atg.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; }
+
+log "== full integration =="
+cargo build --bin tish > target/atbd.log 2>&1 || { log "ABORT: debug build"; tail -15 target/atbd.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; }
+cargo nextest run -p tishlang --test integration_test > target/atit.log 2>&1
+if grep -qiE "test run failed| [1-9][0-9]* failed" target/atit.log; then log "ABORT: integration FAIL"; tail -10 target/atit.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; fi
+log "   integration: $(grep -E 'tests run:' target/atit.log|tail -1)"
+
+AR_ROW=$(grep -E "^array_records " target/atg.log)
+log "   array_records: $AR_ROW"
+if ! echo "$AR_ROW" | grep -q "PASS"; then
+  log "HOLD: array_records still FAIL — native read didn't flip it. NOT opening PR (improvement-only)."
+  git checkout main --quiet; log "DONE (held)"; exit 0
+fi
+
+log "== FLIP confirmed — commit + push + PR =="
+git add -A
+git commit -q -F - <<'MSG'
+perf(native): native numeric accumulators across struct-array field reads (array_records beats node)
+
+After #351 lowered untyped arrays-of-records to `Vec<struct>`, the array_records read loop was still
+boxed: the `number` accumulator `acc` got demoted to `Value` because the demote-gate oracle
+(`expr_native_type`) resolved `var.field` (Ident base) but NOT `arr[i].field` (Index base into a
+`Vec<struct>`). So `acc = (acc + rows[i].x * rows[i].w + rows[i].y) % …` typed as Value and the whole
+loop boxed. Fix: teach `expr_native_type`'s Member arm the `arr[i].field` case — the element struct's
+native field type — so the accumulator stays `f64` and the read loop emits native arithmetic. General
+(any numeric reduction over an array-of-records), not fixture-specific (#317). Completes the
+array_records lever (#203).
+MSG
+git push origin "$BR" >/dev/null 2>&1
+{
+  echo "After #351 lowered untyped arrays-of-records to \`Vec<struct>\`, the read loop was still boxed: the"
+  echo "\`number\` accumulator \`acc\` got demoted to \`Value\` because the demote-gate oracle (\`expr_native_type\`)"
+  echo "resolved \`var.field\` (Ident base) but NOT \`arr[i].field\` (Index base into a \`Vec<struct>\`)."
+  echo ""
+  echo "Fix: teach \`expr_native_type\`'s Member arm the \`arr[i].field\` case (the element struct's native"
+  echo "field type), so the accumulator stays \`f64\` and the read loop emits native arithmetic. General"
+  echo "(any numeric reduction over an array-of-records), not fixture-specific (#317)."
+  echo ""
+  echo "Gauntlet array_records (2M rows × 10 passes; was 937ms boxed → 338ms after #351 → now):"
+  echo '```'
+  echo "$AR_ROW"
+  echo '```'
+  echo "Soundness: typed==boxed==node. Full integration passed. Completes the array_records lever (#203)."
+} > target/pr_acctype.md
+url=$(gh pr create --base main --head "$BR" --title "perf(native): native numeric accumulators across struct-array field reads (array_records beats node)" --body-file target/pr_acctype.md 2>&1 | tail -1)
+log "   PR: $url"
+git checkout main --quiet
+log "DONE"

--- a/scripts/perf_dump_ar_untyped.sh
+++ b/scripts/perf_dump_ar_untyped.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Build the UNTYPED array_records fixture with #350+#351+acctype applied and dump the generated Rust
+# (acc decl + read loop) to see why acc stays boxed. Output: target/ar_untyped_rust.txt
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)"
+OUT=target/ar_untyped_rust.txt; : > "$OUT"
+exec > "$OUT" 2>&1
+
+git checkout -- . 2>/dev/null || true
+git checkout main 2>/dev/null || true
+git branch -D perf/array-records-native-read 2>/dev/null || true
+
+echo "== apply patches as needed =="
+grep -q "cse_result_is_boxed" crates/tish_compile/src/codegen.rs || { git apply target/construct.patch && git apply target/cse.patch && echo "applied #350"; }
+grep -q "record_array_fields" crates/tish_compile/src/infer.rs || { git apply target/infer.patch && echo "applied #351"; }
+git apply target/acctype.patch && echo "applied acctype"
+
+echo "== build tish =="
+cargo build --release --bin tish > target/du_build.log 2>&1 || { echo "TISH BUILD FAIL"; tail -25 target/du_build.log; git checkout -- .; exit 0; }
+
+echo "== build UNTYPED array_records into controlled dir =="
+rm -rf target/probe/aru; mkdir -p target/probe/aru
+TMPDIR="$PWD/target/probe/aru" target/release/tish build tests/perf/array_records.tish -o target/probe/aru_bin > target/probe/aru_build.log 2>&1 || { echo "variant build fail"; tail -20 target/probe/aru_build.log; }
+echo "run: $(target/probe/aru_bin 2>&1 || true)"
+
+f=$(find target/probe/aru -name main.rs 2>/dev/null | xargs grep -l "GAUNTLET array_records" 2>/dev/null | head -1 || true)
+echo "FILE: $f"
+if [ -n "$f" ]; then
+  echo "== struct decl =="; grep -nE "struct Tish|TishAnon|Vec<Tish" "$f" | head
+  echo "== rows / acc / read loop =="; grep -nE "let mut rows|let mut acc|let acc|acc =|rows\[|\.push\(|ops::|Value::Number\(\(rows" "$f" | head -40
+fi
+echo "== restore =="
+git checkout -- . 2>/dev/null || true
+echo DONE

--- a/scripts/perf_flip_ship.sh
+++ b/scripts/perf_flip_ship.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Validate + PR the array_records FLIP: both part-2 oracle fixes (demote-gate expr_native_type +
+# emitter emit_typed_expr handle `arr[i].field`) on top of #350+#351. PRs only if array_records PASSES.
+# Output: target/perf_flip.txt
+set -uo pipefail
+ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT"
+OUT=target/perf_flip.txt; : > "$OUT"
+log(){ echo "$@" | tee -a "$OUT"; }
+BR=perf/array-records-native-read
+
+log "== capture emit edit =="
+git diff -- crates/tish_compile/src/codegen.rs > target/emit.patch
+[ -s target/emit.patch ] || { log "ABORT: no emit edit captured"; exit 1; }
+[ -s target/acctype.patch ] || { log "ABORT: acctype.patch missing"; exit 1; }
+git checkout -- crates/tish_compile/src/codegen.rs 2>/dev/null || true
+
+log "== branch off fresh main =="
+git checkout main --quiet && (git pull --ff-only origin main --quiet 2>/dev/null || true)
+git branch -D "$BR" 2>/dev/null || true
+git checkout -b "$BR" --quiet || { log "ABORT: branch"; exit 1; }
+
+log "== ensure #350 + #351 present =="
+grep -q "cse_result_is_boxed" crates/tish_compile/src/codegen.rs || { git apply target/construct.patch && git apply target/cse.patch && log "  applied #350"; }
+grep -q "record_array_fields" crates/tish_compile/src/infer.rs || { git apply target/infer.patch && log "  applied #351"; }
+
+log "== apply part-2 patches (demote-gate + typed emit) =="
+git apply target/acctype.patch || { log "ABORT: acctype apply"; git checkout main --quiet; exit 1; }
+git apply target/emit.patch || { log "ABORT: emit apply"; git checkout main --quiet; exit 1; }
+
+log "== build release =="
+cargo build --release --bin tish > target/fb.log 2>&1 || { log "ABORT: release build"; tail -30 target/fb.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; }
+
+log "== gauntlet: array_records (FLIP?) + neighbors (no regression) =="
+bash scripts/run_perf_gauntlet.sh array_records object_sum object_spread megamorphic nbody matmul fasta > target/fg.log 2>&1
+grep -E "^(array_records|object_sum|object_spread|megamorphic|nbody|matmul|fasta) |SOUNDNESS|SUMMARY" target/fg.log | tee -a "$OUT"
+grep -q "no build/run/checksum failures" target/fg.log || { log "ABORT: soundness FAIL"; tail -10 target/fg.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; }
+
+log "== full integration =="
+cargo build --bin tish > target/fbd.log 2>&1 || { log "ABORT: debug build"; tail -15 target/fbd.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; }
+cargo nextest run -p tishlang --test integration_test > target/fit.log 2>&1
+if grep -qiE "test run failed| [1-9][0-9]* failed" target/fit.log; then log "ABORT: integration FAIL"; tail -10 target/fit.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; fi
+log "   integration: $(grep -E 'tests run:' target/fit.log|tail -1)"
+
+AR_ROW=$(grep -E "^array_records " target/fg.log)
+log "   array_records: $AR_ROW"
+if ! echo "$AR_ROW" | grep -q "PASS"; then
+  log "HOLD: array_records still FAIL — not flipped (check the modulo/arithmetic native path). NOT PRing."
+  git checkout main --quiet; log "DONE (held)"; exit 0
+fi
+
+log "== FLIP — commit + push + PR =="
+git add -A
+git commit -q -F - <<'MSG'
+perf(native): native arithmetic over struct-array field reads — array_records beats node (#203)
+
+Completes the array_records lever. After #351 (untyped→Vec<struct>) + #350 (alloc-free construction),
+the read loop `acc = (acc + rows[i].x * rows[i].w + rows[i].y) % …` was still boxed: even with `acc`
+native (f64), the struct-array field reads `rows[i].field` emitted boxed, forcing boxed
+`ops::add/mul/modulo`. Two oracles only handled an Ident base (`o.field`), not an Index base
+(`arr[i].field`):
+  * `expr_native_type` (the demote-gate) — so `acc` was demoted to Value;
+  * `emit_typed_expr` (the emitter) — so the field reads boxed.
+Both now resolve `arr[i].field` to the element struct's native field type → native f64 read loop.
+array_records flips to PASS. General (any numeric reduction over an array-of-records), not
+fixture-specific (#317).
+MSG
+git push origin "$BR" >/dev/null 2>&1
+{
+  echo "Completes the array_records lever. After #351 (untyped→\`Vec<struct>\`) + #350 (alloc-free"
+  echo "construction), the read loop was still boxed: even with \`acc\` native, the struct-array field reads"
+  echo "\`rows[i].field\` emitted boxed → boxed \`ops::add/mul/modulo\`. Two oracles only handled an Ident base"
+  echo "(\`o.field\`), not an Index base (\`arr[i].field\`):"
+  echo "- \`expr_native_type\` (demote-gate) → \`acc\` was demoted to Value;"
+  echo "- \`emit_typed_expr\` (emitter) → the field reads boxed."
+  echo ""
+  echo "Both now resolve \`arr[i].field\` to the element struct's native field type → native f64 read loop."
+  echo ""
+  echo "Gauntlet array_records (2M rows × 10 passes; 937ms boxed → 338ms after #351 → now):"
+  echo '```'
+  echo "$AR_ROW"
+  echo '```'
+  echo "Soundness: typed==boxed==node. Full integration passed. Completes the array_records lever (#203)."
+} > target/pr_flip.md
+url=$(gh pr create --base main --head "$BR" --title "perf(native): native arithmetic over struct-array field reads (array_records beats node)" --body-file target/pr_flip.md 2>&1 | tail -1)
+log "   PR: $url"
+git checkout main --quiet
+log "DONE"


### PR DESCRIPTION
Completes the array_records lever. After #351 (untyped→`Vec<struct>`) + #350 (alloc-free
construction), the read loop was still boxed: even with `acc` native, the struct-array field reads
`rows[i].field` emitted boxed → boxed `ops::add/mul/modulo`. Two oracles only handled an Ident base
(`o.field`), not an Index base (`arr[i].field`):
- `expr_native_type` (demote-gate) → `acc` was demoted to Value;
- `emit_typed_expr` (emitter) → the field reads boxed.

Both now resolve `arr[i].field` to the element struct's native field type → native f64 read loop.

Gauntlet array_records (2M rows × 10 passes; 937ms boxed → 338ms after #351 → now):
```
array_records  1130ms      86ms       13.14x          96ms (0.90x)   PASS ✓
```
Soundness: typed==boxed==node. Full integration passed. Completes the array_records lever (#203).
