### PR TITLE
perf(native): hoist loop-invariant string .length out of loop conditions (string_build 92×→19×)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -4673,15 +4673,33 @@ impl Codegen {
                             let is_boxed = matches!(base_ty, RustType::Value)
                                 && self.module_const_f64_array_rust_ref(base).is_none()
                                 && !self.refcell_wrapped_vars.contains(base);
-                            if is_boxed && !Self::stmt_has_length_changer(body) {
+                            // A native `String` receiver: `.length` is loop-invariant (strings are
+                            // immutable) and otherwise emits a per-iteration deep `clone()` of the
+                            // whole string into a `Value` just to read its length — an O(n²) trap in
+                            // strided `charCodeAt` checksum loops (string_build). Hoist it too.
+                            let is_native_string = matches!(base_ty, RustType::String)
+                                && !self.refcell_wrapped_vars.contains(base);
+                            // Gate is base-specific: only an actual length-mutation of `base`
+                            // (push/splice/`base.length =`/`base[k] =`/delete/passing `base` to a
+                            // callee/reassign) blocks the hoist — a read-only method like
+                            // `base.charCodeAt(i)` does NOT (the old gate bailed on any call).
+                            if (is_boxed || is_native_string) && !Self::stmt_changes_base_len(body, base) {
                                 let mut assigned = HashSet::new();
                                 Self::collect_assigned_idents_in_stmt(body, &mut assigned);
                                 if !assigned.contains(base) {
                                     let base_esc = Self::escape_ident(base).into_owned();
                                     let len_tmp = format!("_len{}", self.loop_label_index);
+                                    // For a native `String`, box once (one-time clone) to reuse
+                                    // get_prop's exact length semantics; for a boxed `Value`, clone the
+                                    // handle (cheap Rc bump).
+                                    let len_src = if is_native_string {
+                                        format!("tishlang_runtime::get_prop(&Value::String(({}).clone().into()), \"length\")", base_esc)
+                                    } else {
+                                        format!("tishlang_runtime::get_prop(&({}).clone(), \"length\")", base_esc)
+                                    };
                                     self.writeln(&format!(
-                                        "let {} = (tishlang_runtime::get_prop(&({}).clone(), \"length\")).as_number().unwrap_or(f64::NAN);",
-                                        len_tmp, base_esc
+                                        "let {} = ({}).as_number().unwrap_or(f64::NAN);",
+                                        len_tmp, len_src
                                     ));
                                     let (ctr_code, ctr_ty) = self.emit_typed_expr(counter)?;
                                     let lhs = if ctr_ty == RustType::F64 {
@@ -7870,6 +7888,146 @@ impl Codegen {
                 Self::expr_has_length_changer(e)
             }
             // Anything else (switch/try/funct decl/break/continue/…) — be conservative.
+            _ => true,
+        }
+    }
+
+    /// Read-only string/array methods that cannot change the receiver's `.length`. Used by
+    /// [`Self::expr_changes_base_len`] so a loop body like `sum += s.charCodeAt(i)` does not block
+    /// hoisting `s.length`. Conservative: an unknown method is NOT here, so it is treated as a mutator.
+    fn is_readonly_len_method(m: &str) -> bool {
+        matches!(
+            m,
+            "charCodeAt" | "charAt" | "codePointAt" | "at" | "slice" | "substring" | "substr"
+                | "indexOf" | "lastIndexOf" | "includes" | "startsWith" | "endsWith"
+                | "toUpperCase" | "toLowerCase" | "toString" | "valueOf" | "concat" | "repeat"
+                | "padStart" | "padEnd" | "trim" | "trimStart" | "trimEnd" | "split" | "search"
+                | "normalize" | "localeCompare" | "map" | "filter" | "reduce" | "reduceRight"
+                | "forEach" | "find" | "findIndex" | "findLast" | "findLastIndex" | "some" | "every"
+                | "join" | "flat" | "flatMap" | "keys" | "values" | "entries"
+        )
+    }
+
+    /// True if evaluating `e` could change `base`'s `.length`: a non-read-only method called ON
+    /// `base`, `base` passed as a call/new argument (the callee could mutate it), a `base.<prop> =`
+    /// / `base[k] =` / `delete base[k]` write, or a reassignment of `base`. Read-only methods on
+    /// `base` (charCodeAt/slice/map/…) and calls not involving `base` do NOT. The base-specific
+    /// refinement of [`Self::expr_has_length_changer`] used by the `.length` hoist.
+    fn expr_changes_base_len(e: &Expr, base: &str) -> bool {
+        let is_base = |x: &Expr| matches!(x, Expr::Ident { name, .. } if name.as_ref() == base);
+        let arg_is_base = |a: &CallArg| matches!(a, CallArg::Expr(x) | CallArg::Spread(x) if is_base(x));
+        match e {
+            Expr::Call { callee, args, .. } => {
+                if let Expr::Member { object, prop: MemberProp::Name { name: m, .. }, .. } =
+                    callee.as_ref()
+                {
+                    if is_base(object) && !Self::is_readonly_len_method(m.as_ref()) {
+                        return true;
+                    }
+                }
+                args.iter().any(arg_is_base)
+                    || Self::expr_changes_base_len(callee, base)
+                    || args.iter().any(|a| match a {
+                        CallArg::Expr(x) | CallArg::Spread(x) => Self::expr_changes_base_len(x, base),
+                    })
+            }
+            Expr::New { callee, args, .. } => {
+                args.iter().any(arg_is_base)
+                    || Self::expr_changes_base_len(callee, base)
+                    || args.iter().any(|a| match a {
+                        CallArg::Expr(x) | CallArg::Spread(x) => Self::expr_changes_base_len(x, base),
+                    })
+            }
+            Expr::MemberAssign { object, value, .. } => {
+                is_base(object) || Self::expr_changes_base_len(value, base)
+            }
+            Expr::IndexAssign { object, index, value, .. } => {
+                is_base(object)
+                    || Self::expr_changes_base_len(index, base)
+                    || Self::expr_changes_base_len(value, base)
+            }
+            Expr::Delete { target, .. } => {
+                matches!(target.as_ref(), Expr::Index { object, .. } if is_base(object))
+                    || Self::expr_changes_base_len(target, base)
+            }
+            Expr::Assign { name, value, .. }
+            | Expr::CompoundAssign { name, value, .. }
+            | Expr::LogicalAssign { name, value, .. } => {
+                name.as_ref() == base || Self::expr_changes_base_len(value, base)
+            }
+            Expr::Binary { left, right, .. } | Expr::NullishCoalesce { left, right, .. } => {
+                Self::expr_changes_base_len(left, base) || Self::expr_changes_base_len(right, base)
+            }
+            Expr::Unary { operand, .. } | Expr::TypeOf { operand, .. } | Expr::Await { operand, .. } => {
+                Self::expr_changes_base_len(operand, base)
+            }
+            Expr::Index { object, index, .. } => {
+                Self::expr_changes_base_len(object, base) || Self::expr_changes_base_len(index, base)
+            }
+            Expr::Member { object, prop, .. } => {
+                Self::expr_changes_base_len(object, base)
+                    || matches!(prop, MemberProp::Expr(k) if Self::expr_changes_base_len(k, base))
+            }
+            Expr::Conditional { cond, then_branch, else_branch, .. } => {
+                Self::expr_changes_base_len(cond, base)
+                    || Self::expr_changes_base_len(then_branch, base)
+                    || Self::expr_changes_base_len(else_branch, base)
+            }
+            Expr::TemplateLiteral { exprs, .. } => {
+                exprs.iter().any(|x| Self::expr_changes_base_len(x, base))
+            }
+            Expr::Array { elements, .. } => elements.iter().any(|el| match el {
+                ArrayElement::Expr(x) | ArrayElement::Spread(x) => Self::expr_changes_base_len(x, base),
+            }),
+            Expr::Object { props, .. } => props.iter().any(|p| match p {
+                ObjectProp::KeyValue(_, x, _) | ObjectProp::Spread(x) => {
+                    Self::expr_changes_base_len(x, base)
+                }
+            }),
+            Expr::PostfixInc { name, .. }
+            | Expr::PostfixDec { name, .. }
+            | Expr::PrefixInc { name, .. }
+            | Expr::PrefixDec { name, .. } => name.as_ref() == base,
+            // An arrow could capture+mutate base; conservative.
+            Expr::ArrowFunction { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Statement-level [`Self::expr_changes_base_len`] for the `.length` hoist gate.
+    fn stmt_changes_base_len(stmt: &Statement, base: &str) -> bool {
+        match stmt {
+            Statement::ExprStmt { expr, .. } => Self::expr_changes_base_len(expr, base),
+            Statement::VarDecl { init: Some(e), .. } => Self::expr_changes_base_len(e, base),
+            Statement::VarDecl { init: None, .. } => false,
+            Statement::VarDeclDestructure { init, .. } => Self::expr_changes_base_len(init, base),
+            Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
+                statements.iter().any(|s| Self::stmt_changes_base_len(s, base))
+            }
+            Statement::If { cond, then_branch, else_branch, .. } => {
+                Self::expr_changes_base_len(cond, base)
+                    || Self::stmt_changes_base_len(then_branch, base)
+                    || else_branch.as_ref().is_some_and(|b| Self::stmt_changes_base_len(b, base))
+            }
+            Statement::For { init, cond, update, body, .. } => {
+                init.as_ref().is_some_and(|i| Self::stmt_changes_base_len(i, base))
+                    || cond.as_ref().is_some_and(|c| Self::expr_changes_base_len(c, base))
+                    || update.as_ref().is_some_and(|u| Self::expr_changes_base_len(u, base))
+                    || Self::stmt_changes_base_len(body, base)
+            }
+            Statement::ForOf { iterable, body, .. } => {
+                Self::expr_changes_base_len(iterable, base) || Self::stmt_changes_base_len(body, base)
+            }
+            Statement::While { cond, body, .. } | Statement::DoWhile { body, cond, .. } => {
+                Self::expr_changes_base_len(cond, base) || Self::stmt_changes_base_len(body, base)
+            }
+            Statement::Return { value: Some(e), .. } | Statement::Throw { value: e, .. } => {
+                Self::expr_changes_base_len(e, base)
+            }
+            Statement::Return { value: None, .. }
+            | Statement::Break { .. }
+            | Statement::Continue { .. } => false,
+            // switch/try/funcdecl/etc. — conservative (could hide a mutation of base).
             _ => true,
         }
     }

--- a/scripts/perf_dump_ap.sh
+++ b/scripts/perf_dump_ap.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)"
+OUT=target/ap_rust.txt; : > "$OUT"; exec > "$OUT" 2>&1
+rm -rf target/probe/ap; mkdir -p target/probe/ap
+TMPDIR="$PWD/target/probe/ap" target/release/tish build tests/perf/array_pipeline.tish -o target/probe/ap_bin > target/probe/ap_build.log 2>&1 || { echo "build fail"; tail -20 target/probe/ap_build.log; }
+echo "run: $(target/probe/ap_bin 2>&1 || true)"
+f=$(find target/probe/ap -name main.rs 2>/dev/null | xargs grep -l "GAUNTLET array_pipeline" 2>/dev/null | head -1 || true)
+echo "FILE: $f"
+[ -n "$f" ] && { echo "== data decl + fused pipeline loop =="; grep -nE "let mut data|NumberArray|Vec<f64>|let mut check|let mut total|filter|\.map|reduce|for_loop|borrow|ops::|value_call|% 3|x \* 2|2147483647|\.iter\(\)" "$f" | head -45; }
+echo DONE

--- a/scripts/perf_dump_sb.sh
+++ b/scripts/perf_dump_sb.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)"
+OUT=target/sb_rust.txt; : > "$OUT"; exec > "$OUT" 2>&1
+rm -rf target/probe/sb; mkdir -p target/probe/sb
+TMPDIR="$PWD/target/probe/sb" target/release/tish build tests/perf/string_build.tish -o target/probe/sb_bin > target/probe/sb_build.log 2>&1 || { echo "build fail"; tail -20 target/probe/sb_build.log; }
+echo "run: $(target/probe/sb_bin 2>&1 || true)"
+f=$(find target/probe/sb -name main.rs 2>/dev/null | xargs grep -l "GAUNTLET string_build" 2>/dev/null | head -1 || true)
+echo "FILE: $f"
+[ -n "$f" ] && { echo "== acc / parts / += / join / push =="; grep -nE "let mut acc|let mut parts|acc =|\.push_str|push\(|join|ops::add|ops::concat|Value::String|string_concat|to_display_string|\+= " "$f" | head -40; }
+echo DONE

--- a/scripts/perf_standings.sh
+++ b/scripts/perf_standings.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)"
+git checkout main --quiet 2>/dev/null || true
+git pull --ff-only origin main --quiet 2>/dev/null || true
+cargo build --release --bin tish > target/st_build.log 2>&1 || { echo "BUILD FAIL"; tail -20 target/st_build.log; exit 1; }
+echo "== current standings (close FAILs + controls) =="
+bash scripts/run_perf_gauntlet.sh array_pipeline json_roundtrip sort_comparator k_nucleotide regex_redux fannkuch fnv_hash string_build numeric_loop 2>&1 | tail -25

--- a/scripts/perf_strlen_pr.sh
+++ b/scripts/perf_strlen_pr.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)"
+OUT=target/strlen_pr.txt; : > "$OUT"; log(){ echo "$@" | tee -a "$OUT"; }
+BR=perf/string-length-hoist
+[ -s target/strlen.patch ] || { log "ABORT: patch missing"; exit 1; }
+git checkout -- . 2>/dev/null || true
+git checkout main --quiet && (git pull --ff-only origin main --quiet 2>/dev/null || true)
+git branch -D "$BR" 2>/dev/null || true
+git checkout -b "$BR" --quiet || { log ABORT; exit 1; }
+git apply target/strlen.patch || { log "ABORT: apply"; git checkout main --quiet; exit 1; }
+cargo build --release --bin tish > target/sp.log 2>&1 || { log "ABORT: build"; tail -20 target/sp.log; git checkout main --quiet; exit 1; }
+git add -A
+git commit -q -F - <<'MSG'
+perf(native): hoist loop-invariant string .length out of loop conditions
+
+A `for (i = 0; i < str.length; …)` loop re-evaluated `str.length` every iteration. For a native
+`String` receiver that meant a full `Value::String(s.clone())` DEEP COPY of the whole string per
+iteration (an O(n²) trap in strided charCodeAt checksum loops); for a boxed `Value` string the #317
+hoist was blocked because its gate bailed on ANY call in the body — including read-only ones like
+`s.charCodeAt(i)`. Two fixes to the #317 .length hoist: (1) the gate is now base-specific — only an
+actual length-mutation of `base` (push/splice/`base.length =`/`base[k] =`/delete/passing `base` to a
+callee/reassign) blocks the hoist, not a read-only method (charCodeAt/slice/map/…); (2) native
+`String` receivers are hoisted too (strings are immutable, so `.length` is always loop-invariant).
+
+string_build's strided checksum loops go O(n²) → O(n): 3187ms → 675ms (92× → 19× node). General (any
+`for (i; i<str.length; …)` with a read-only body), not fixture-specific (#317). The residual gap to
+node is the build loops (boxed array push+join, `+=` number→string, `nextVal()` calls) — separate
+follow-up. Soundness: typed==boxed==node across the .length-loop controls; full integration passed. #203 P0.
+MSG
+git push origin "$BR" >/dev/null 2>&1
+{
+  echo "A \`for (i = 0; i < str.length; …)\` loop re-evaluated \`str.length\` **every iteration**. For a native"
+  echo "\`String\` receiver that was a full \`Value::String(s.clone())\` **deep copy of the whole string per"
+  echo "iteration** (O(n²) in strided charCodeAt loops); for a boxed \`Value\` string the #317 hoist was"
+  echo "blocked because its gate bailed on **any** call in the body — including read-only \`s.charCodeAt(i)\`."
+  echo ""
+  echo "Two fixes to the #317 \`.length\` hoist: (1) base-specific gate — only an actual length-mutation of"
+  echo "\`base\` blocks it, not a read-only method; (2) native \`String\` receivers hoist too (strings are"
+  echo "immutable). string_build's strided checksum loops go **O(n²) → O(n)**:"
+  echo ""
+  echo '```'
+  echo "string_build  3187ms → 675ms  (4.72× typing-speedup; 92× → 19× node)"
+  echo '```'
+  echo ""
+  echo "General (any \`for (i; i<str.length; …)\` read-only body), not fixture-specific (#317). Residual gap"
+  echo "to node = the build loops (boxed array push+join, \`+=\` number→string, \`nextVal()\` calls), a separate"
+  echo "follow-up. Soundness: typed==boxed==node across the .length-loop controls; full integration passed. #203 P0 (strings)."
+} > target/pr_strlen.md
+url=$(gh pr create --base main --head "$BR" --title "perf(native): hoist loop-invariant string .length out of loop conditions (string_build 92×→19×)" --body-file target/pr_strlen.md 2>&1 | tail -1)
+log "PR: $url"
+git checkout main --quiet
+log DONE

--- a/scripts/perf_strlen_ship.sh
+++ b/scripts/perf_strlen_ship.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Validate + PR the loop-invariant string .length hoist (string_build O(n²)->O(n)) using the already
+# captured target/strlen.patch. Lean fixture set (string_build + .length-loop controls) + full
+# integration; PR only if string_build flips with no soundness failure. Output: target/perf_strlen.txt
+set -uo pipefail
+ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT"
+OUT=target/perf_strlen.txt; : > "$OUT"
+log(){ echo "$@" | tee -a "$OUT"; }
+BR=perf/string-length-hoist
+[ -s target/strlen.patch ] || { log "ABORT: target/strlen.patch missing/empty"; exit 1; }
+
+log "== clean state + branch off fresh main =="
+git checkout -- . 2>/dev/null || true
+git checkout main --quiet && (git pull --ff-only origin main --quiet 2>/dev/null || true)
+git branch -D "$BR" 2>/dev/null || true
+git checkout -b "$BR" --quiet || { log "ABORT: branch"; exit 1; }
+git apply target/strlen.patch || { log "ABORT: patch apply"; git checkout main --quiet; exit 1; }
+
+log "== build release =="
+cargo build --release --bin tish > target/slb.log 2>&1 || { log "ABORT: release build"; tail -30 target/slb.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; }
+
+log "== lean gauntlet (string_build flip + .length-loop regression controls) =="
+bash scripts/run_perf_gauntlet.sh string_build fannkuch queens nsieve regex_redux k_nucleotide fnv_hash > target/slg.log 2>&1
+grep -E "^[a-z_]+ +[0-9]|SOUNDNESS|SUMMARY" target/slg.log | tee -a "$OUT"
+grep -q "no build/run/checksum failures" target/slg.log || { log "ABORT: SOUNDNESS FAIL (regression!)"; tail -12 target/slg.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; }
+
+log "== full integration =="
+cargo build --bin tish > target/slbd.log 2>&1 || { log "ABORT: debug build"; tail -15 target/slbd.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; }
+cargo nextest run -p tishlang --test integration_test > target/slit.log 2>&1
+if grep -qiE "test run failed| [1-9][0-9]* failed" target/slit.log; then log "ABORT: integration FAIL"; tail -10 target/slit.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; fi
+log "   integration: $(grep -E 'tests run:' target/slit.log|tail -1)"
+
+SB_ROW=$(grep -E "^string_build " target/slg.log)
+log "   string_build: $SB_ROW"
+if ! echo "$SB_ROW" | grep -q "PASS"; then
+  log "HOLD: string_build still FAIL — not flipped. NOT PRing (will report the number)."
+  git checkout main --quiet; log "DONE (held)"; exit 0
+fi
+
+log "== FLIP — commit + push + PR =="
+git add -A
+git commit -q -F - <<'MSG'
+perf(native): hoist loop-invariant string .length out of loop conditions (string_build beats node)
+
+string_build was 92x slower than node: its strided `charCodeAt` checksum loops re-evaluated
+`str.length` EVERY iteration — O(n²). Two causes in the #317 .length hoist:
+  * `acc` (a native `String`) was never hoisted (`is_boxed` required `Value`), and `acc.length`
+    emitted a full `Value::String(acc.clone())` DEEP COPY of the whole string per iteration;
+  * `joined` (a boxed `Value` string) was blocked because the hoist gate bailed on ANY call in the
+    body — including the read-only `joined.charCodeAt(i)`.
+Fixes: (1) the gate is now base-specific — only an actual length-mutation of `base`
+(push/splice/`base.length =`/`base[k] =`/delete/passing `base` to a callee/reassign) blocks the
+hoist; a read-only method (charCodeAt/slice/map/…) does not. (2) native `String` receivers are
+hoisted too — strings are immutable, so `.length` is always loop-invariant. Both check loops drop
+from O(n²) to O(n). General (any `for (i…; i<str.length; …)` with a read-only body), not
+fixture-specific (#317). #203 P0 (strings).
+MSG
+git push origin "$BR" >/dev/null 2>&1
+{
+  echo "string_build was **92× slower than node**: its strided \`charCodeAt\` checksum loops re-evaluated"
+  echo "\`str.length\` **every iteration** — O(n²). Two causes in the #317 \`.length\` hoist:"
+  echo "- \`acc\` (a native \`String\`) was never hoisted, and \`acc.length\` emitted a full"
+  echo "  \`Value::String(acc.clone())\` **deep copy of the whole string per iteration**;"
+  echo "- \`joined\` (a boxed \`Value\` string) was blocked because the gate bailed on **any** call in the"
+  echo "  body — including the read-only \`joined.charCodeAt(i)\`."
+  echo ""
+  echo "Fixes: (1) base-specific gate — only an actual length-mutation of \`base\` blocks the hoist, not a"
+  echo "read-only method; (2) native \`String\` receivers hoist too (strings are immutable). Both loops go"
+  echo "O(n²) → O(n). General (any \`for (i; i<str.length; …)\` read-only body), not fixture-specific (#317)."
+  echo ""
+  echo "Gauntlet string_build (was 3223ms / 92× node):"
+  echo '```'
+  echo "$SB_ROW"
+  echo '```'
+  echo "Soundness: typed==boxed==node across the .length-loop controls. Full integration passed. #203 P0."
+} > target/pr_strlen.md
+url=$(gh pr create --base main --head "$BR" --title "perf(native): hoist loop-invariant string .length out of loop conditions (string_build beats node)" --body-file target/pr_strlen.md 2>&1 | tail -1)
+log "   PR: $url"
+git checkout main --quiet
+log "DONE"


### PR DESCRIPTION
A `for (i = 0; i < str.length; …)` loop re-evaluated `str.length` **every iteration**. For a native
`String` receiver that was a full `Value::String(s.clone())` **deep copy of the whole string per
iteration** (O(n²) in strided charCodeAt loops); for a boxed `Value` string the #317 hoist was
blocked because its gate bailed on **any** call in the body — including read-only `s.charCodeAt(i)`.

Two fixes to the #317 `.length` hoist: (1) base-specific gate — only an actual length-mutation of
`base` blocks it, not a read-only method; (2) native `String` receivers hoist too (strings are
immutable). string_build's strided checksum loops go **O(n²) → O(n)**:

```
string_build  3187ms → 675ms  (4.72× typing-speedup; 92× → 19× node)
```

General (any `for (i; i<str.length; …)` read-only body), not fixture-specific (#317). Residual gap
to node = the build loops (boxed array push+join, `+=` number→string, `nextVal()` calls), a separate
follow-up. Soundness: typed==boxed==node across the .length-loop controls; full integration passed. #203 P0 (strings).
