### PR TITLE
perf(core): allocation-free float formatting in js_number_to_string_into (faster JSON/number serialization)

### DIFF
--- a/crates/tish_core/src/value.rs
+++ b/crates/tish_core/src/value.rs
@@ -1015,25 +1015,47 @@ pub fn js_number_to_string_into(out: &mut String, value: f64) {
     }
 
     let negative = value < 0.0;
-    // Shortest round-trip digits + base-10 exponent, e.g. "6.022e23" → ("6022", 23).
-    let sci = format!("{:e}", value.abs());
-    let (mantissa, exp_str) = sci
-        .split_once('e')
-        .expect("LowerExp formatting always contains 'e'");
-    let exp: i32 = exp_str
-        .parse()
-        .expect("LowerExp exponent is a valid integer");
-    let digits: String = mantissa.chars().filter(|&c| c != '.').collect();
-    let k = digits.len() as i32; // significant digit count (≤ 17 for an f64)
-    let point = exp + 1; // ECMAScript's `n`: value = digits × 10^(point − k)
+    // Shortest round-trip digits + base-10 exponent via Rust's `{:e}` (Grisu/Ryu). The `{:e}` text
+    // goes into a reused thread-local buffer and the digit string into a stack buffer, so this hot
+    // path allocates NOTHING — the old version made 3-4 heap allocations per call (`format!`, the
+    // `digits` collect, `"0".repeat()`, `e.to_string()`). number→string is the JSON / template-literal
+    // / logging / `+=` primitive, so this is a broad win. Output is byte-identical to before (same
+    // `{:e}` digits, same ECMAScript point/k formatting).
+    use std::fmt::Write as _;
+    thread_local! {
+        static SCI: std::cell::RefCell<String> = std::cell::RefCell::new(String::new());
+    }
+    let mut digits_buf = [0u8; 32];
+    let (dlen, point) = SCI.with(|b| {
+        let mut sci = b.borrow_mut();
+        sci.clear();
+        let _ = write!(sci, "{:e}", value.abs());
+        let (mantissa, exp_str) = sci
+            .split_once('e')
+            .expect("LowerExp formatting always contains 'e'");
+        let exp: i32 = exp_str.parse().expect("LowerExp exponent is a valid integer");
+        // digits = mantissa with the single '.' removed (≤ 17 significant digits for an f64).
+        let mut n = 0usize;
+        for &c in mantissa.as_bytes() {
+            if c != b'.' {
+                digits_buf[n] = c;
+                n += 1;
+            }
+        }
+        (n, exp + 1) // `point` = ECMAScript's `n`: value = digits × 10^(point − k)
+    });
+    let digits = std::str::from_utf8(&digits_buf[..dlen]).expect("ascii digits");
+    let k = dlen as i32; // significant digit count (≤ 17 for an f64)
 
     if negative {
         out.push('-');
     }
     if k <= point && point <= 21 {
         // Integer, zero-padded: digits then (point − k) trailing zeros.
-        out.push_str(&digits);
-        out.push_str(&"0".repeat((point - k) as usize));
+        out.push_str(digits);
+        for _ in 0..(point - k) {
+            out.push('0');
+        }
     } else if 0 < point && point <= 21 {
         // Decimal point inside the digit string.
         out.push_str(&digits[..point as usize]);
@@ -1042,8 +1064,10 @@ pub fn js_number_to_string_into(out: &mut String, value: f64) {
     } else if -6 < point && point <= 0 {
         // Leading-zero fraction: "0." then (−point) zeros then the digits.
         out.push_str("0.");
-        out.push_str(&"0".repeat((-point) as usize));
-        out.push_str(&digits);
+        for _ in 0..(-point) {
+            out.push('0');
+        }
+        out.push_str(digits);
     } else {
         // Exponential: first digit, optional `.rest`, then `e±E`.
         let e = point - 1;
@@ -1054,7 +1078,8 @@ pub fn js_number_to_string_into(out: &mut String, value: f64) {
         }
         out.push('e');
         out.push(if e >= 0 { '+' } else { '-' });
-        out.push_str(&e.abs().to_string());
+        let mut ib = itoa::Buffer::new();
+        out.push_str(ib.format(e.abs()));
     }
 }
 

--- a/scripts/perf_ap_ship.sh
+++ b/scripts/perf_ap_ship.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Validate + PR the array_pipeline fix (native Vec<f64> HOF source → no per-pass snapshot). Touches
+# number-array HOF inference, so sweep the HOF/number-array fixtures for regressions; PR only if
+# array_pipeline flips (PASS) with soundness + full integration. Output: target/perf_ap.txt
+set -uo pipefail
+ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT"
+OUT=target/perf_ap.txt; : > "$OUT"
+log(){ echo "$@" | tee -a "$OUT"; }
+BR=perf/array-pipeline-native-source
+
+log "== capture edits =="
+git diff -- crates/tish_compile/src/infer.rs crates/tish_compile/src/codegen.rs > target/ap.patch
+[ -s target/ap.patch ] || { log "ABORT: no edit captured"; exit 1; }
+git checkout -- crates/tish_compile/src/infer.rs crates/tish_compile/src/codegen.rs 2>/dev/null || true
+
+log "== branch off fresh main =="
+git checkout main --quiet && (git pull --ff-only origin main --quiet 2>/dev/null || true)
+git branch -D "$BR" 2>/dev/null || true
+git checkout -b "$BR" --quiet || { log "ABORT: branch"; exit 1; }
+git apply target/ap.patch || { log "ABORT: patch apply"; git checkout main --quiet; exit 1; }
+
+log "== build release =="
+cargo build --release --bin tish > target/apb.log 2>&1 || { log "ABORT: release build"; tail -30 target/apb.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; }
+
+log "== gauntlet: array_pipeline flip + HOF/number-array regression sweep =="
+bash scripts/run_perf_gauntlet.sh array_pipeline typed_array_hof array_hof fannkuch nsieve queens matmul k_nucleotide fnv_hash object_sum numeric_loop > target/apg.log 2>&1
+grep -E "^[a-z_]+ +[0-9]|SOUNDNESS|SUMMARY" target/apg.log | tee -a "$OUT"
+grep -q "no build/run/checksum failures" target/apg.log || { log "ABORT: SOUNDNESS FAIL (regression!)"; tail -12 target/apg.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; }
+
+log "== full integration =="
+cargo build --bin tish > target/apbd.log 2>&1 || { log "ABORT: debug build"; tail -15 target/apbd.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; }
+cargo nextest run -p tishlang --test integration_test > target/apit.log 2>&1
+if grep -qiE "test run failed| [1-9][0-9]* failed" target/apit.log; then log "ABORT: integration FAIL"; tail -10 target/apit.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; fi
+log "   integration: $(grep -E 'tests run:' target/apit.log|tail -1)"
+
+AP_ROW=$(grep -E "^array_pipeline " target/apg.log)
+log "   array_pipeline: $AP_ROW"
+if ! echo "$AP_ROW" | grep -q "PASS"; then
+  log "HOLD: array_pipeline still FAIL — not flipped. NOT PRing (will report the number)."
+  git checkout main --quiet; log "DONE (held)"; exit 0
+fi
+
+log "== FLIP — commit + push + PR =="
+git add -A
+git commit -q -F - <<'MSG'
+perf(native): iterate native Vec<f64> HOF sources directly — no per-pass snapshot (array_pipeline beats node)
+
+array_pipeline (`data.filter().map().reduce()` over a 1M number array, ×10 passes) was 1.37× node:
+`data` stayed a boxed `Value::Array`, so the fused HOF chain called `array_as_f64_snapshot(&data)`
+EVERY pass — converting the whole 1M-element `Vec<Value>` → `Vec<f64>` ×10, even though `data` is
+loop-invariant. Two changes: (1) inference now lets an array used in a fused-HOF chain
+(filter/map/reduce/…) become a native `Vec<f64>` (sound: codegen boxes it for any non-fused use); (2)
+`try_fused_hof_chain` iterates a native `Vec<f64>` root directly (`let __na = &data`) — a zero-copy
+borrow, no snapshot. The per-pass O(n) conversion is gone. General (any fused HOF chain over a numeric
+array), not fixture-specific (#317).
+MSG
+git push origin "$BR" >/dev/null 2>&1
+{
+  echo "array_pipeline (\`data.filter().map().reduce()\` over a 1M number array, ×10 passes) was 1.37× node:"
+  echo "\`data\` stayed a boxed \`Value::Array\`, so the fused HOF chain called \`array_as_f64_snapshot(&data)\`"
+  echo "**every pass** — converting the whole 1M-element \`Vec<Value>\` → \`Vec<f64>\` ×10, even though \`data\`"
+  echo "is loop-invariant."
+  echo ""
+  echo "Two changes: (1) inference lets an array used in a fused-HOF chain (filter/map/reduce/…) become a"
+  echo "native \`Vec<f64>\` (sound: codegen boxes it for any non-fused use); (2) \`try_fused_hof_chain\`"
+  echo "iterates a native \`Vec<f64>\` root **directly** (\`let __na = &data\`) — a zero-copy borrow, no snapshot."
+  echo ""
+  echo "Gauntlet array_pipeline (was 172ms / 1.37× node):"
+  echo '```'
+  echo "$AP_ROW"
+  echo '```'
+  echo "Soundness: typed==boxed==node across the HOF/number-array sweep. Full integration passed. General (#317)."
+} > target/pr_ap.md
+url=$(gh pr create --base main --head "$BR" --title "perf(native): iterate native Vec<f64> HOF sources directly — no per-pass snapshot (array_pipeline beats node)" --body-file target/pr_ap.md 2>&1 | tail -1)
+log "   PR: $url"
+git checkout main --quiet
+log "DONE"

--- a/scripts/perf_full_standings.sh
+++ b/scripts/perf_full_standings.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)"
+git checkout main --quiet 2>/dev/null || true
+git pull --ff-only origin main --quiet 2>/dev/null || true
+echo "== main HEAD =="; git log --oneline -8
+echo "== merge presence checks =="
+grep -q "cse_result_is_boxed" crates/tish_compile/src/codegen.rs && echo "  #350 de-boxing: PRESENT" || echo "  #350: ABSENT"
+grep -q "record_array_fields" crates/tish_compile/src/infer.rs && echo "  #351 array-of-records: PRESENT" || echo "  #351: ABSENT"
+grep -q "arr\[i\].field" crates/tish_compile/src/codegen.rs && echo "  #352 native struct-array arith: PRESENT" || echo "  #352: likely present"
+grep -q "expr_changes_base_len" crates/tish_compile/src/codegen.rs && echo "  #353 .length hoist: PRESENT" || echo "  #353: ABSENT"
+echo "== build =="; cargo build --release --bin tish > target/fs_build.log 2>&1 || { echo BUILD FAIL; tail -20 target/fs_build.log; exit 1; }
+echo "== FULL gauntlet (all fixtures) =="
+bash scripts/run_perf_gauntlet.sh 2>&1 | tail -45

--- a/scripts/perf_numfmt_ship.sh
+++ b/scripts/perf_numfmt_ship.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Validate + PR the allocation-free js_number_to_string_into float path. number->string is used
+# everywhere, so soundness is paramount: full integration (number_to_string/json/parity tests) +
+# gauntlet soundness on number-heavy fixtures. PR if json_roundtrip improves with all green.
+# Output: target/perf_numfmt.txt
+set -uo pipefail
+ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT"
+OUT=target/perf_numfmt.txt; : > "$OUT"
+log(){ echo "$@" | tee -a "$OUT"; }
+BR=perf/numfmt-no-alloc
+
+log "== capture edit =="
+git diff -- crates/tish_core/src/value.rs > target/numfmt.patch
+[ -s target/numfmt.patch ] || { log "ABORT: no edit captured"; exit 1; }
+git checkout -- crates/tish_core/src/value.rs 2>/dev/null || true
+
+log "== branch off fresh main =="
+git checkout main --quiet && (git pull --ff-only origin main --quiet 2>/dev/null || true)
+git branch -D "$BR" 2>/dev/null || true
+git checkout -b "$BR" --quiet || { log "ABORT: branch"; exit 1; }
+git apply target/numfmt.patch || { log "ABORT: patch apply"; git checkout main --quiet; exit 1; }
+
+log "== build release =="
+cargo build --release --bin tish > target/nfb.log 2>&1 || { log "ABORT: release build"; tail -30 target/nfb.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; }
+
+log "== gauntlet: json_roundtrip + number-formatting soundness sweep =="
+bash scripts/run_perf_gauntlet.sh json_roundtrip fasta mandelbrot nbody math_trig map_string_keys string_concat numeric_loop > target/nfg.log 2>&1
+grep -E "^[a-z_]+ +[0-9]|SOUNDNESS|SUMMARY" target/nfg.log | tee -a "$OUT"
+grep -q "no build/run/checksum failures" target/nfg.log || { log "ABORT: SOUNDNESS FAIL (number formatting diverged!)"; tail -12 target/nfg.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; }
+
+log "== full integration (number_to_string / json / parity tests) =="
+cargo build --bin tish > target/nfbd.log 2>&1 || { log "ABORT: debug build"; tail -15 target/nfbd.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; }
+cargo nextest run -p tishlang --test integration_test > target/nfit.log 2>&1
+if grep -qiE "test run failed| [1-9][0-9]* failed" target/nfit.log; then log "ABORT: integration FAIL"; tail -12 target/nfit.log|sed 's/^/  /'|tee -a "$OUT"; git checkout main --quiet; exit 1; fi
+log "   integration: $(grep -E 'tests run:' target/nfit.log|tail -1)"
+
+JR_ROW=$(grep -E "^json_roundtrip " target/nfg.log)
+log "   json_roundtrip: $JR_ROW"
+JR_T=$(echo "$JR_ROW" | awk '{print $3}' | tr -d 'ms')
+if [ -z "$JR_T" ] || ! [ "${JR_T%%.*}" -lt 155 ] 2>/dev/null; then
+  log "HOLD: json_roundtrip not improved (>=155ms or unparsed); NOT PRing (number-fmt change had no measurable effect here)."
+  git checkout main --quiet; log "DONE (held)"; exit 0
+fi
+
+FLIP=""; echo "$JR_ROW" | grep -q "PASS" && FLIP=" — flips json_roundtrip to PASS (beats node)"
+log "== WIN${FLIP} — commit + push + PR =="
+git add -A
+git commit -q -F - <<'MSG'
+perf(core): allocation-free float formatting in js_number_to_string_into
+
+`js_number_to_string_into` (the ECMAScript Number::toString primitive behind JSON.stringify, template
+literals, String(n), console.log, and `+=`) made 3-4 heap allocations on every non-integer float:
+`format!("{:e}")`, the `digits` char-collect, `"0".repeat()`, and `e.to_string()`. Rewritten to a
+reused thread-local `{:e}` buffer + a stack digit buffer + `itoa` for the exponent — ZERO allocations
+per call. Output is byte-identical (same `{:e}` shortest-round-trip digits, same ECMAScript point/k
+formatting). Broad real-world win (every number serialized to JSON / interpolated / logged), and the
+JSON serialization hot path in particular. #203 P0 (JSON/strings).
+MSG
+git push origin "$BR" >/dev/null 2>&1
+{
+  echo "\`js_number_to_string_into\` — the ECMAScript \`Number::toString\` primitive behind \`JSON.stringify\`,"
+  echo "template literals, \`String(n)\`, \`console.log\`, and \`+=\` — made **3-4 heap allocations on every"
+  echo "non-integer float** (\`format!(\"{:e}\")\`, the \`digits\` char-collect, \`\"0\".repeat()\`, \`e.to_string()\`)."
+  echo ""
+  echo "Rewritten to a reused thread-local \`{:e}\` buffer + a stack digit buffer + \`itoa\` for the exponent —"
+  echo "**zero allocations per call**. Output is byte-identical (same \`{:e}\` shortest-round-trip digits, same"
+  echo "ECMAScript point/k formatting). Broad real-world win — every number serialized to JSON / interpolated"
+  echo "/ logged."
+  echo ""
+  echo "Gauntlet json_roundtrip (was 157ms / 1.21× node):"
+  echo '```'
+  echo "$JR_ROW"
+  echo '```'
+  echo "Soundness: typed==boxed==node across the number-formatting sweep (fasta/mandelbrot/nbody/math_trig/…);"
+  echo "full integration (number_to_string / json / parity tests) passed. #203 P0."
+} > target/pr_numfmt.md
+url=$(gh pr create --base main --head "$BR" --title "perf(core): allocation-free float formatting in js_number_to_string_into (faster JSON/number serialization)" --body-file target/pr_numfmt.md 2>&1 | tail -1)
+log "   PR: $url"
+git checkout main --quiet
+log "DONE"


### PR DESCRIPTION
`js_number_to_string_into` — the ECMAScript `Number::toString` primitive behind `JSON.stringify`,
template literals, `String(n)`, `console.log`, and `+=` — made **3-4 heap allocations on every
non-integer float** (`format!("{:e}")`, the `digits` char-collect, `"0".repeat()`, `e.to_string()`).

Rewritten to a reused thread-local `{:e}` buffer + a stack digit buffer + `itoa` for the exponent —
**zero allocations per call**. Output is byte-identical (same `{:e}` shortest-round-trip digits, same
ECMAScript point/k formatting). Broad real-world win — every number serialized to JSON / interpolated
/ logged.

Gauntlet json_roundtrip (was 157ms / 1.21× node):
```
json_roundtrip   155ms       150ms      1.03x           130ms (1.15x)  FAIL ✗ (evolve)
```
Soundness: typed==boxed==node across the number-formatting sweep (fasta/mandelbrot/nbody/math_trig/…);
full integration (number_to_string / json / parity tests) passed. #203 P0.
