### PR TITLE
fix: handle ExportDeclaration::ReExport in wasm resolver + refresh stale spectral_norm shim tests

### DIFF
--- a/crates/tish_compile/tests/perf_codegen_175.rs
+++ b/crates/tish_compile/tests/perf_codegen_175.rs
@@ -138,29 +138,38 @@ fn spectral_norm_devirtualizes_with_inlined_evala() {
 }
 
 #[test]
-fn spectral_norm_embedded_lib_native_shim_compiles() {
+fn spectral_norm_embedded_lib_devirtualizes_to_native_vec_fns() {
+    // EmbeddedLib mode fully de-virtualizes the `multiply*` group to native-vec (`_nv`) fns over
+    // `Vec<f64>` params (#350-352 native struct-array codegen). Once the whole group de-virtualizes,
+    // the old boxed `*_native` shims this test used to assert are correctly no longer emitted —
+    // matching the typed-mode `spectral_norm_devirtualizes_with_inlined_evala` check above (which
+    // asserts `multiplyAtAv` routes to `_nv`, not the boxed `_native` shim). Cross-backend soundness
+    // of the de-virtualized code is covered by the gauntlet + `tests/core/native_vec_params`.
     let rust = compile_fixture_embedded_lib("tests/perf/spectral_norm.tish");
-    let mav = rust
-        .split("fn multiplyAv_native(")
-        .nth(1)
-        .and_then(|s| s.split("fn multiplyAtv_native").next())
-        .expect("multiplyAv_native");
     assert!(
-        mav.contains("let mut j: f64")
-            || mav.contains("get_index(&Value::Number(v), &Value::Number((_usize_j"),
-        "boxed native shim must bind j from the usize loop counter:\n{}",
-        mav.lines().take(12).collect::<Vec<_>>().join("\n")
+        rust.contains("fn multiplyAv_nv(")
+            && rust.contains("fn multiplyAtv_nv(")
+            && rust.contains("fn multiplyAtAv_nv("),
+        "multiply* should de-virtualize to native-vec fns:\n{}",
+        rust.lines().filter(|l| l.contains("_nv(")).take(6).collect::<Vec<_>>().join("\n")
     );
     assert!(
-        mav.contains("let mut i: f64")
-            || mav.contains("set_index(&(Value::Number(av)), &(Value::Number((_usize_i"),
-        "boxed native shim must bind i from the usize loop counter:\n{}",
-        mav.lines().take(12).collect::<Vec<_>>().join("\n")
+        rust.contains("v: &Vec<f64>") && rust.contains("av: &mut Vec<f64>"),
+        "native-vec fns take Vec<f64> params by &/&mut ref"
+    );
+    assert!(
+        !rust.contains("fn multiplyAv_native(")
+            && !rust.contains("fn multiplyAtv_native(")
+            && !rust.contains("fn multiplyAtAv_native("),
+        "the boxed `*_native` shims must be elided once the group fully de-virtualizes:\n{}",
+        rust.lines().filter(|l| l.contains("_native(")).take(6).collect::<Vec<_>>().join("\n")
     );
 }
 
 #[test]
-fn spectral_norm_embedded_lib_with_runtime_features_native_shim_compiles() {
+fn spectral_norm_embedded_lib_with_runtime_features_devirtualizes() {
+    // The same de-virtualization holds with the runtime features enabled — they swap the embedded
+    // runtime in, but don't change the native-vec lowering of the user fns (still no boxed shims).
     let features: Vec<String> = [
         "http", "timers", "fs", "process", "regex", "ws", "tty",
     ]
@@ -169,14 +178,13 @@ fn spectral_norm_embedded_lib_with_runtime_features_native_shim_compiles() {
     .collect();
     let rust =
         compile_fixture_embedded_lib_with_features("tests/perf/spectral_norm.tish", &features);
-    let mav = rust
-        .split("fn multiplyAv_native(")
-        .nth(1)
-        .and_then(|s| s.split("fn multiplyAtv_native").next())
-        .expect("multiplyAv_native");
     assert!(
-        !mav.contains("Value::Number(j)") && !mav.contains("Value::Number(i)"),
-        "runtime-feature build must not reference bare i/j in boxed shims:\n{}",
-        mav.lines().take(12).collect::<Vec<_>>().join("\n")
+        rust.contains("fn multiplyAv_nv(") && rust.contains("fn multiplyAtAv_nv("),
+        "runtime-feature build still de-virtualizes multiply* to native-vec fns:\n{}",
+        rust.lines().filter(|l| l.contains("_nv(")).take(6).collect::<Vec<_>>().join("\n")
+    );
+    assert!(
+        !rust.contains("fn multiplyAv_native(") && !rust.contains("fn multiplyAtAv_native("),
+        "no boxed `*_native` shims under runtime features either"
     );
 }

--- a/crates/tish_compiler_wasm/src/resolve_virtual.rs
+++ b/crates/tish_compiler_wasm/src/resolve_virtual.rs
@@ -98,6 +98,21 @@ fn resolve_import_to_key(
     ))
 }
 
+/// The module specifier a statement imports/re-exports from, if any — covers both
+/// `import … from "x"` and `export … from "x"` (#305 re-export). Dependency discovery and cycle
+/// detection use this so they follow re-export edges, not just plain imports (otherwise a module
+/// reached only via a re-export would never be loaded).
+fn stmt_module_source(stmt: &Statement) -> Option<&str> {
+    match stmt {
+        Statement::Import { from, .. } => Some(&**from),
+        Statement::Export { declaration, .. } => match declaration.as_ref() {
+            ExportDeclaration::ReExport { from, .. } => Some(&**from),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 /// Resolve all modules starting from the entry file. Returns modules in dependency order.
 pub fn resolve_virtual(
     entry_path: &str,
@@ -163,7 +178,7 @@ fn load_module_recursive(
 
     let from_dir = parent_dir(module_path);
     for stmt in &program.statements {
-        if let Statement::Import { from, .. } = stmt {
+        if let Some(from) = stmt_module_source(stmt) {
             if is_native_import(from) {
                 continue;
             }
@@ -217,7 +232,7 @@ fn has_cycle_from(
     visiting: &mut HashSet<usize>,
 ) -> Result<bool, String> {
     for stmt in &program.statements {
-        if let Statement::Import { from, .. } = stmt {
+        if let Some(from) = stmt_module_source(stmt) {
             if is_native_import(from) {
                 continue;
             }
@@ -291,6 +306,40 @@ pub fn merge_modules_virtual(modules: Vec<VirtualModule>) -> Result<Program, Str
                     ExportDeclaration::Default(_) => {
                         let default_name = format!("__default_{}", idx);
                         module_exports[idx].insert("default".to_string(), default_name);
+                    }
+                    // #305: re-export — map each re-exported name to the DEP's binding (the dep is
+                    // earlier in load order, so its export table is already built). `export *` copies
+                    // every dep export without overriding an explicit one; `export { a as b }` maps
+                    // b -> dep's binding for a. Mirrors `merge_modules` in tish_compile/src/resolve.rs.
+                    ExportDeclaration::ReExport {
+                        specifiers,
+                        all,
+                        from,
+                        ..
+                    } => {
+                        let dir = parent_dir(&module.path);
+                        let dep = resolve_import_to_key_for_cycle(from, dir, &path_to_idx)
+                            .ok()
+                            .and_then(|key| path_to_idx.get(&key).copied())
+                            .map(|dep_idx| module_exports[dep_idx].clone());
+                        if let Some(dep) = dep {
+                            if *all {
+                                for (k, v) in &dep {
+                                    module_exports[idx]
+                                        .entry(k.clone())
+                                        .or_insert_with(|| v.clone());
+                                }
+                            }
+                            for spec in specifiers {
+                                if let ImportSpecifier::Named { name, alias, .. } = spec {
+                                    if let Some(binding) = dep.get(name.as_ref()) {
+                                        let export_name =
+                                            alias.as_deref().unwrap_or(name.as_ref()).to_string();
+                                        module_exports[idx].insert(export_name, binding.clone());
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -440,6 +489,10 @@ pub fn merge_modules_virtual(modules: Vec<VirtualModule>) -> Result<Program, Str
                             span: espan,
                         });
                     }
+                    // #305: re-export emits no code — `module_exports` already maps the re-exported
+                    // names to the dep's bindings (in scope in the flattened bundle), so downstream
+                    // imports resolve directly. Nothing to push here.
+                    ExportDeclaration::ReExport { .. } => {}
                 },
                 _ => statements.push(stmt.clone()),
             }
@@ -470,5 +523,50 @@ mod tests {
         detect_cycles_virtual(&modules).unwrap();
         let program = merge_modules_virtual(modules).unwrap();
         assert!(!program.statements.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_virtual_reexport_alias() {
+        // #305: `export { add as plus } from "./dep"` re-exports dep's `add` as `plus`; a downstream
+        // `import { plus }` must resolve to dep's binding. Regression guard: the merge previously did
+        // not handle `ExportDeclaration::ReExport` (E0004 build failure), and discovery did not follow
+        // the re-export edge (so a dep reached only via re-export was never loaded).
+        let mut files = HashMap::new();
+        files.insert(
+            "dep.tish".to_string(),
+            "export fn add(a, b) { return a + b }".to_string(),
+        );
+        files.insert(
+            "mid.tish".to_string(),
+            "export { add as plus } from \"./dep.tish\"".to_string(),
+        );
+        files.insert(
+            "main.tish".to_string(),
+            "import { plus } from \"./mid.tish\"\nconsole.log(plus(1, 2))".to_string(),
+        );
+        let modules = resolve_virtual("main.tish", &files).unwrap();
+        // dep.tish is reached ONLY via mid's re-export → discovery must have loaded it.
+        assert!(
+            modules.iter().any(|m| m.path == "dep.tish"),
+            "re-exported dep should be discovered and loaded"
+        );
+        detect_cycles_virtual(&modules).unwrap();
+        let program = merge_modules_virtual(modules).unwrap();
+        let has_add_fn = program
+            .statements
+            .iter()
+            .any(|s| matches!(s, Statement::FunDecl { name, .. } if name.as_ref() == "add"));
+        let binds_plus_to_add = program.statements.iter().any(|s| {
+            matches!(
+                s,
+                Statement::VarDecl { name, init: Some(Expr::Ident { name: src, .. }), .. }
+                if name.as_ref() == "plus" && src.as_ref() == "add"
+            )
+        });
+        assert!(has_add_fn, "dep's `add` fn should be in the merged bundle");
+        assert!(
+            binds_plus_to_add,
+            "import of re-exported `plus` should bind to dep's `add`"
+        );
     }
 }


### PR DESCRIPTION
Two deterministic pre-existing failures on `main` (verified independent of any other in-flight
work), both blocking a clean `cargo test --workspace`.

## 1. `tishlang_compiler_wasm` did not compile (E0004)

The two `match declaration.as_ref()` expressions in `resolve_virtual.rs` (the export-table
collection pass and the statement-emission pass) didn't cover the `ExportDeclaration::ReExport`
variant added with #305 → `error[E0004]: non-exhaustive patterns`.

Handled it, mirroring `merge_modules` in `tish_compile/src/resolve.rs`:
- **Collection pass:** map each re-exported name to the dep's binding — `export *` copies every
  dep export (without overriding an explicit one); `export { a as b }` maps `b` → dep's binding
  for `a`.
- **Emission pass:** no-op — the names already exist in the flattened bundle, so downstream
  imports resolve directly.
- **Discovery + cycle detection:** a new `stmt_module_source` helper returns the `from` for both
  `import … from` and `export … from`, so a module reached *only* via a re-export is still loaded
  (previously discovery scanned `Statement::Import` only → the dep was never loaded and the
  re-export resolved to nothing).

Adds `test_resolve_virtual_reexport_alias` (dep reached only via a re-export, aliased) covering
discovery + collection + emission end-to-end.

## 2. Stale `spectral_norm` shim tests in `perf_codegen_175.rs`

`spectral_norm_embedded_lib_native_shim_compiles` and
`spectral_norm_embedded_lib_with_runtime_features_native_shim_compiles` both panicked at
`.expect("multiplyAv_native")` — the generated Rust no longer contains a boxed `multiplyAv_native`
shim. That's the **intended** result of the #350-352 native struct-array codegen work: the whole
`multiply*` group now fully de-virtualizes to `*_nv` fns over `Vec<f64>`, so the boxed shims are
correctly elided (the already-passing typed-mode `spectral_norm_devirtualizes_with_inlined_evala`
test asserts the same — `multiplyAtAv` routes to `_nv`, not `_native`).

Rewrote both tests to assert the de-virtualized `_nv` form (with `&/&mut Vec<f64>` params) and the
absence of the boxed `*_native` shims, in both the plain and runtime-feature builds.

## Validation

- `cargo test -p tishlang_compiler_wasm` → green (2/2, incl. the new re-export test).
- `cargo test -p tishlang_compile --test perf_codegen_175` → green (5/5).
- Gauntlet `spectral_norm` stays **sound**: typed == boxed == node (no checksum failures), 24ms
  vs node 38ms — confirms the elided-shim codegen is correct, not a hidden regression.
