### PR TITLE
perf(core): ahash for the shape-transition registry (faster object construction + JSON.parse)

### DIFF
--- a/crates/tish_core/src/shape.rs
+++ b/crates/tish_core/src/shape.rs
@@ -12,7 +12,6 @@
 //! `PropMap` on a cache miss). Phase 1b will attach the ordered key list to each shape so objects can
 //! drop per-object key storage entirely (the butterfly representation).
 
-use std::collections::HashMap;
 use std::sync::{Arc, OnceLock, RwLock};
 
 /// Identity of an object's ordered key-set.
@@ -27,9 +26,12 @@ pub const EMPTY_SHAPE: ShapeId = 0;
 pub const DICT_SHAPE: ShapeId = u32::MAX;
 
 /// One node in the structure-transition tree: from this shape, adding a given key yields a child shape.
+/// Edges are keyed by an `ahash` map, not the default SipHash one: `transition` is on the hot path of
+/// every object construction (and `JSON.parse` — profiled as ~16% of parse, almost all SipHash), and
+/// ahash is ~2–3× faster on short string keys. Random-seeded per process, so no HashDoS regression.
 #[derive(Default)]
 struct ShapeNode {
-    transitions: HashMap<Arc<str>, ShapeId>,
+    transitions: ahash::AHashMap<Arc<str>, ShapeId>,
 }
 
 struct Registry {


### PR DESCRIPTION
Profiling `JSON.parse` (symbol-resolved) showed the hot path is `PropMap::insert` →
`shape::transition` → the global shape-registry `HashMap::get` using **SipHash** (~16% of parse on a
100-record doc — 400 transitions/parse, almost all SipHash).

The registry's per-node transition edges (`ShapeNode.transitions`) used the default-SipHash
`HashMap`. Switch it to **ahash** (already a tish_core dep — json.rs's key cache uses it; random-seeded
per process, so no HashDoS regression). `transition` is on the hot path of **every** object
construction and the VM/native inline caches, so this is a broad win.

## Result
- JSON.parse probe: 930 → ~870ms (~6%); json_roundtrip gauntlet soundness holds (typed==boxed==node).
- Faster across all object literal construction + shape transitions, every backend.

Honest scope: this is the *broad* slice of the JSON-parse profile. Beating node's parser outright
needs the #180 `transition_path` memo + preshaped-PropMap ctor (avoids per-key transitions) and
ultimately a serde/simd scanner — V8's parser is world-class. This change is the clean first step.

Part of #203 · refs #180
