### PR TITLE
fix(native): preserve struct→Value key order (was non-deterministic AHashMap)

### DIFF
--- a/crates/tish_compile/src/types.rs
+++ b/crates/tish_compile/src/types.rs
@@ -414,12 +414,15 @@ impl RustType {
                 )
             }
             RustType::Named { fields, .. } => {
-                // Walk fields, build an ObjectMap, wrap in Value::Object.
-                // The boundary is paid only when crossing into untyped
-                // Tish (JSON.stringify, calling a Value::Function, etc.);
-                // direct Rust-to-Rust paths between two Named values stay
-                // as plain struct moves.
-                let inserts = fields
+                // Build the boxed Value with an ORDERED PropMap via `object_from_pairs` (no
+                // intermediate `AHashMap`), so key order == field-declaration order == JS
+                // insertion order. The old `ObjectMap::default()` (`AHashMap`) + insert path
+                // scrambled key order NON-DETERMINISTICALLY per run (ahash seed) — a shipped
+                // `JSON.stringify` / `Object.keys` / `for..in` divergence from node whenever a
+                // native struct crosses back into untyped Tish. This boundary is paid only on
+                // that crossing (JSON.stringify, calling a Value::Function, etc.); direct
+                // Rust-to-Rust paths between two Named values stay as plain struct moves.
+                let pairs = fields
                     .iter()
                     .map(|(k, ty)| {
                         let access = format!("{}.{}", native_expr, field_ident(k));
@@ -431,22 +434,13 @@ impl RustType {
                         } else {
                             ty.to_value_expr(&access)
                         };
-                        format!(
-                            "_om.insert(::std::sync::Arc::from({:?}), {});",
-                            k.as_ref(),
-                            v_expr
-                        )
+                        format!("(::std::sync::Arc::from({:?}), {})", k.as_ref(), v_expr)
                     })
                     .collect::<Vec<_>>()
-                    .join(" ");
-                // `Value::object` wraps the `ObjectMap` in an `ObjectData` (what `Value::Object`
-                // actually holds) — emitting `Value::Object(VmRef::new(_om))` directly is a type
-                // error (`ObjectMap` != `ObjectData`); only surfaced once a whole struct is boxed
-                // into a `Value`, e.g. passing it to a function.
-                format!(
-                    "{{ let mut _om = ObjectMap::default(); {} Value::object(_om) }}",
-                    inserts
-                )
+                    .join(", ");
+                // `object_from_pairs::<N>` builds the `PropMap` in one ordered pass (N = field
+                // count, a codegen-time constant) — no AHashMap, so key order is preserved.
+                format!("Value::object_from_pairs([{}])", pairs)
             }
             _ => native_expr.to_string(), // Fallback
         }


### PR DESCRIPTION
## The bug

When a native struct crosses back into untyped Tish — `JSON.stringify(s)`, `Object.keys(s)`, `for..in`, passing to a `Value`-typed function — codegen's `to_value_expr` for a `Named` struct built an **`ObjectMap::default()` (an `AHashMap`)**, inserted the fields, then `Value::object(_om)`. The AHashMap has no order, so the resulting `PropMap`'s keys came out in a **per-run-random hash order**.

The shipped **typed (default)** native build therefore emitted `JSON.stringify`/`Object.keys` key order that was both **non-deterministic across runs** and **divergent from node**:

```
type Rec = { a: number, b: number, c: number, s: string, f: boolean }
// node:         {"a":0,"b":0,"c":0.1,"s":"hi","f":true}
// tish (before): {"s":"hi","b":0,"c":0.1,"a":0,"f":true}   ← scrambled, different every run
```

It was uncaught because **no gauntlet fixture compares multi-field struct key order to node**, and the boxed path (no struct emission → ordered `PropMap` literal) is already correct — so it was a **typed-path-only ≠node divergence**.

## The fix

Emit `Value::object_from_pairs([...])` instead — it builds the `PropMap` in one ordered pass with no intermediate `AHashMap`, so key order == field-declaration order == JS insertion order. (Also 14/-20 lines: simpler than the old `_om.insert` sequence.)

## Validation

- **Byte-identical to node** and **deterministic across runs** on a struct-stringify probe covering tricky numbers (`-0`, `1e21`, `1e-7`, `2^53`, `NaN`/`Inf`→`null`), string escapes, unicode, and the array-of-structs case.
- Plain (untyped) object stringify **unaffected** (already correct via ordered `PropMap` literals).
- `cargo test --workspace` green.
- **Clean full gauntlet: 22/29, all fixtures `typed==boxed==node`** — no build/run/checksum regression.

Found while implementing #315 (direct struct `JSON.stringify` serializer); this is the correctness foundation under it. Relates to #203, #314.