### PR TITLE
perf(native): direct per-struct JSON.stringify serializer (#315)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1303,6 +1303,13 @@ impl Codegen {
                     ));
                 }
                 self.write("}\n\n");
+                // #315: emit a direct JSON serializer for this struct when every field is
+                // JSON-simple. Emitted for each eligible alias (unused ones are covered by
+                // the generated crate's `#![allow(unused)]`); the JSON.stringify intercept
+                // calls it only where the arg's static type matches.
+                if Self::json_fields_are_simple(fields) {
+                    self.emit_struct_json_serializer(&name, fields);
+                }
                 emitted_any = true;
             }
         }
@@ -1311,7 +1318,148 @@ impl Codegen {
         }
     }
 
+    /// #315: JSON-simple = serializable by a direct per-struct writer that is byte-identical
+    /// to node's `JSON.stringify` (reuses `write_json_number` / `escape_into`). Whitelist, so
+    /// any future RustType variant defaults to the sound Value-path fallback.
+    fn json_struct_is_simple(ty: &crate::types::RustType) -> bool {
+        use crate::types::RustType;
+        match ty {
+            RustType::F64 | RustType::String | RustType::Bool => true,
+            // One level of array of scalars or simple structs (not Vec<Vec<…>> — the element
+            // writer below only handles a single nesting level).
+            RustType::Vec(inner) => matches!(
+                inner.as_ref(),
+                RustType::F64 | RustType::String | RustType::Bool
+            ) || matches!(inner.as_ref(), RustType::Named { .. } if Self::json_struct_is_simple(inner)),
+            RustType::Named { fields, .. } => Self::json_fields_are_simple(fields),
+            _ => false,
+        }
+    }
 
+    /// All fields JSON-simple, and no field key is an array-index-like all-digit string (JS
+    /// enumerates those first in numeric order — bail so we never reorder vs node).
+    fn json_fields_are_simple(fields: &[(std::sync::Arc<str>, crate::types::RustType)]) -> bool {
+        fields.iter().all(|(k, f)| {
+            let numeric_key = !k.is_empty() && k.as_ref().bytes().all(|b| b.is_ascii_digit());
+            !numeric_key && Self::json_struct_is_simple(f)
+        })
+    }
+
+    /// Stable per-alias serializer fn name (mirrors `named_struct_ident`, so it is unique and
+    /// matches at both the emission site and the call site).
+    fn json_helper_fn_ident(tish_name: &str) -> String {
+        format!("__tish_json_{}", crate::types::named_struct_ident(tish_name))
+    }
+
+    /// Rust for writing one JSON value of type `ty` (already JSON-simple) from place `access`.
+    fn json_value_writer(access: &str, ty: &crate::types::RustType) -> String {
+        use crate::types::RustType;
+        match ty {
+            RustType::F64 => {
+                format!("tishlang_runtime::json::write_json_number(out, {});", access)
+            }
+            RustType::String => format!(
+                "out.push('\"'); tishlang_runtime::json::escape_into(out, &{}); out.push('\"');",
+                access
+            ),
+            RustType::Bool => {
+                format!("out.push_str(if {} {{ \"true\" }} else {{ \"false\" }});", access)
+            }
+            RustType::Named { name, .. } => {
+                format!("{}(&{}, out);", Self::json_helper_fn_ident(name), access)
+            }
+            RustType::Vec(inner) => {
+                // Element is a reference from `.iter()`; scalars need a deref.
+                let ew = match inner.as_ref() {
+                    RustType::F64 => {
+                        "tishlang_runtime::json::write_json_number(out, *__e);".to_string()
+                    }
+                    RustType::String => {
+                        "out.push('\"'); tishlang_runtime::json::escape_into(out, __e); out.push('\"');".to_string()
+                    }
+                    RustType::Bool => {
+                        "out.push_str(if *__e { \"true\" } else { \"false\" });".to_string()
+                    }
+                    RustType::Named { name, .. } => {
+                        format!("{}(__e, out);", Self::json_helper_fn_ident(name))
+                    }
+                    _ => "out.push_str(\"null\");".to_string(), // unreachable: gated simple
+                };
+                format!(
+                    "out.push('['); for (__i, __e) in {}.iter().enumerate() {{ if __i > 0 {{ out.push(','); }} {} }} out.push(']');",
+                    access, ew
+                )
+            }
+            _ => "out.push_str(\"null\");".to_string(), // unreachable: gated by json_struct_is_simple
+        }
+    }
+
+    /// Emit `fn __tish_json_<alias>(v: &TishStruct_<alias>, out: &mut String)` writing the
+    /// struct as compact JSON in field-declaration order (== JS insertion order), reusing the
+    /// same `write_json_number` / `escape_into` the Value path uses → byte-identical to node.
+    fn emit_struct_json_serializer(
+        &mut self,
+        tish_name: &str,
+        fields: &[(std::sync::Arc<str>, crate::types::RustType)],
+    ) {
+        let struct_name = crate::types::named_struct_ident(tish_name);
+        let fn_name = Self::json_helper_fn_ident(tish_name);
+        self.write("#[allow(non_snake_case, unused)]\n");
+        self.write(&format!(
+            "fn {}(v: &{}, out: &mut String) {{\n",
+            fn_name, struct_name
+        ));
+        self.write("    out.push('{');\n");
+        for (i, (k, ty)) in fields.iter().enumerate() {
+            if i > 0 {
+                self.write("    out.push(',');\n");
+            }
+            // Key: escape the (constant) key at runtime via the exact same helper the Value
+            // path uses, guaranteeing byte-identity for any key.
+            self.write(&format!(
+                "    out.push('\"'); tishlang_runtime::json::escape_into(out, {:?}); out.push_str(\"\\\":\");\n",
+                k.as_ref()
+            ));
+            let access = format!("v.{}", crate::types::field_ident(k));
+            self.write(&format!("    {}\n", Self::json_value_writer(&access, ty)));
+        }
+        self.write("    out.push('}');\n");
+        self.write("}\n\n");
+    }
+
+    /// #315: direct JSON serializer for `JSON.stringify(arg)` when `arg`'s static type is a
+    /// simple struct (or Vec of one). Returns None → fall through to the generic Value path.
+    fn try_emit_direct_json_stringify(
+        &mut self,
+        arg: &Expr,
+    ) -> Result<Option<String>, CompileError> {
+        use crate::types::RustType;
+        let (code, ty) = self.emit_typed_expr(arg)?;
+        match &ty {
+            RustType::Named { name, .. } if Self::json_struct_is_simple(&ty) => {
+                let fname = Self::json_helper_fn_ident(name);
+                Ok(Some(format!(
+                    "{{ let mut _js = String::new(); {}(&({}), &mut _js); Value::String(_js.into()) }}",
+                    fname, code
+                )))
+            }
+            RustType::Vec(inner)
+                if matches!(inner.as_ref(), RustType::Named { .. })
+                    && Self::json_struct_is_simple(inner) =>
+            {
+                if let RustType::Named { name, .. } = inner.as_ref() {
+                    let fname = Self::json_helper_fn_ident(name);
+                    Ok(Some(format!(
+                        "{{ let mut _js = String::new(); _js.push('['); for (_ji, _je) in ({}).iter().enumerate() {{ if _ji > 0 {{ _js.push(','); }} {}(_je, &mut _js); }} _js.push(']'); Value::String(_js.into()) }}",
+                        code, fname
+                    )))
+                } else {
+                    Ok(None)
+                }
+            }
+            _ => Ok(None),
+        }
+    }
 
     fn rc_cell_storage_contains(&self, name: &str) -> bool {
         self.rc_cell_storage_scopes
@@ -6248,6 +6396,29 @@ impl Codegen {
                 }
             }
             Expr::Call { callee, args, .. } => {
+                // #315: JSON.stringify(x) where x has a statically-known simple-struct type
+                // → emit a direct per-struct serializer (byte-identical to node) that writes
+                // straight into a String, skipping the per-call ObjectMap/PropMap Value
+                // materialization. Any non-simple arg (or a replacer/space 2nd arg) returns
+                // None and falls through to the generic boxed path — sound.
+                if let Expr::Member {
+                    object,
+                    prop: MemberProp::Name { name: m, .. },
+                    optional: false,
+                    ..
+                } = callee.as_ref()
+                {
+                    if m.as_ref() == "stringify"
+                        && matches!(object.as_ref(), Expr::Ident { name, .. } if name.as_ref() == "JSON")
+                        && args.len() == 1
+                    {
+                        if let CallArg::Expr(arg0) = &args[0] {
+                            if let Some(code) = self.try_emit_direct_json_stringify(arg0)? {
+                                return Ok(code);
+                            }
+                        }
+                    }
+                }
                 // #178: route a boxed-context call to a recursive-struct consumer
                 // (`sum(build(n))` / `sum(node)`) → `Value::Number(sum_rec(&..))`.
                 if self.rec_struct_plan.is_some() {

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -538,6 +538,10 @@ use tishlang_core::{json_parse as core_json_parse, json_stringify as core_json_s
 pub mod json {
     pub use tishlang_core::json_parse;
     pub use tishlang_core::json_stringify_into as stringify_into;
+    /// JS-correct number→JSON writer (NaN/Inf→`null`, integer fast path, else the
+    /// ECMAScript `Number::toString`). Used by codegen-emitted per-struct serialisers
+    /// (#315) for `number` fields, so their output matches `json_stringify_into` exactly.
+    pub use tishlang_core::write_json_number;
     /// Append the JSON-escaped contents of `s` (without surrounding
     /// quotes) to `buf`. Used by typed-struct serialisers for `String`
     /// fields. Falls through to `tishlang_core::json_stringify_into`'s


### PR DESCRIPTION
Supersedes #368 (auto-closed when its stacked base #367 merged). Rebased onto main — now a single commit; the #367 correctness fix is already in main.

## What

When rust codegen lowers `JSON.stringify(x)` and `x` has a statically-known **simple-struct** type (`RustType::Named`, or a `Vec` of one, whose fields are all number/string/bool/nested-simple-struct/array-of-those), emit a **direct per-struct serializer** that writes JS-correct JSON straight into a `String` — instead of building an `ObjectMap`/`PropMap` `Value` per call and walking it.

The serializer reuses the **exact same writers** as the dynamic path — `write_json_number` (JS number rules: NaN/Inf→`null`, integer fast path, ECMAScript `Number::toString`) and `json::escape_into` (JS string escaping) — so output is **byte-identical to node's `JSON.stringify`** by construction, in field-declaration order. Anything not provably simple returns `None` → existing Value path (sound).

## Why (perf)

Struct-stringify micro-bench, 1.5M `JSON.stringify(World)` calls, min of 5 (macOS, node 24 / bun 1.2):

| | ms |
|---|---|
| tish typed **+#315** (direct) | **110** |
| tish typed no-#315 (PropMap/call) | 174 |
| node 24 | 117 |
| bun 1.2 | 64 |

**1.58× over the no-#315 typed path**, and it **flips tish from behind node (174>117) to ahead (110<117)**. Per-request serialize cost for JSON APIs / TFB `/db` `/json`.

## Validation

- **Byte-identical to node** across number extremes (`1e21`, `5e-324`, `1.79e308`, `2^53+1`, `NaN`/`Inf`, `-0`), all escapes + control chars + unicode/emoji, bool, nested structs, arrays-of-structs, empty arrays, 10-field struct.
- **Clean gauntlet 23/29, all `typed==boxed==node`** — no regression; `json_roundtrip` (dynamic data) falls back → unaffected.
- `cargo test --workspace` green.

Closes #315. Relates to #203, #314, #324.