### PR TITLE
perf(runtime): arithmetic ops return bare Value, not vestigial Result

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1194,11 +1194,11 @@ impl Codegen {
     /// In async `run()` bodies, propagate runtime op errors with `?`; in sync
     /// `Value::native` closures use `.unwrap_or(Value::Null)`.
     fn ops_result_suffix(&self) -> &'static str {
-        if self.is_async && self.async_context_stack.last().copied().unwrap_or(false) {
-            "?"
-        } else {
-            ".unwrap_or(Value::Null)"
-        }
+        // Arithmetic ops (`ops::add/sub/mul/div/modulo`) now return a bare `Value` — they never
+        // error (non-number → NaN), so no `?` / `.unwrap_or` consumer suffix is needed. Kept as the
+        // single source of truth for the compound-assign emission sites. (#201 measurement: the old
+        // vestigial `Result` cost ~4× on the boxed arithmetic path.)
+        ""
     }
 
     /// Walk every `Statement::TypeAlias` in the program (including nested
@@ -21648,26 +21648,12 @@ impl Codegen {
 
     fn emit_binop(&self, l: &str, op: BinOp, r: &str, span: Span) -> Result<String, CompileError> {
         Ok(match op {
-            BinOp::Add => format!(
-                "tishlang_runtime::ops::add(&{}, &{}).unwrap_or(Value::Null)",
-                l, r
-            ),
-            BinOp::Sub => format!(
-                "tishlang_runtime::ops::sub(&{}, &{}).unwrap_or(Value::Null)",
-                l, r
-            ),
-            BinOp::Mul => format!(
-                "tishlang_runtime::ops::mul(&{}, &{}).unwrap_or(Value::Null)",
-                l, r
-            ),
-            BinOp::Div => format!(
-                "tishlang_runtime::ops::div(&{}, &{}).unwrap_or(Value::Null)",
-                l, r
-            ),
-            BinOp::Mod => format!(
-                "tishlang_runtime::ops::modulo(&{}, &{}).unwrap_or(Value::Null)",
-                l, r
-            ),
+            // ops::{add,sub,mul,div,modulo} now return a bare `Value` (never error) — no suffix.
+            BinOp::Add => format!("tishlang_runtime::ops::add(&{}, &{})", l, r),
+            BinOp::Sub => format!("tishlang_runtime::ops::sub(&{}, &{})", l, r),
+            BinOp::Mul => format!("tishlang_runtime::ops::mul(&{}, &{})", l, r),
+            BinOp::Div => format!("tishlang_runtime::ops::div(&{}, &{})", l, r),
+            BinOp::Mod => format!("tishlang_runtime::ops::modulo(&{}, &{})", l, r),
             BinOp::Pow => format!(
                 "Value::Number(tishlang_runtime::to_number_value(&({})).powf(tishlang_runtime::to_number_value(&({}))))",
                 l, r

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -399,69 +399,72 @@ pub mod ops {
     use tishlang_core::Value;
 
     #[inline]
-    pub fn add(left: &Value, right: &Value) -> Result<Value, Box<dyn std::error::Error>> {
+    // Arithmetic ops return a bare `Value` (not `Result`): they NEVER error — a non-number
+    // operand coerces to NaN, matching the VM's `eval_binop`. The former `Result<Value, Box<dyn
+    // Error>>` was vestigial and cost ~4× on the boxed path (memory-return + caller `.unwrap_or`;
+    // #201 measurement). Callers use the value directly (no suffix — see `ops_result_suffix`).
+    pub fn add(left: &Value, right: &Value) -> Value {
         match (left, right) {
-            (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a + b)),
+            (Value::Number(a), Value::Number(b)) => Value::Number(a + b),
             (Value::String(a), Value::String(b)) => {
                 let mut s = String::with_capacity(a.len() + b.len());
                 s.push_str(a);
                 s.push_str(b);
-                Ok(Value::String(s.into()))
+                Value::String(s.into())
             }
             (Value::String(a), b) => {
                 let b_str = b.to_js_string();
                 let mut s = String::with_capacity(a.len() + b_str.len());
                 s.push_str(a);
                 s.push_str(&b_str);
-                Ok(Value::String(s.into()))
+                Value::String(s.into())
             }
             (a, Value::String(b)) => {
                 let a_str = a.to_js_string();
                 let mut s = String::with_capacity(a_str.len() + b.len());
                 s.push_str(&a_str);
                 s.push_str(b);
-                Ok(Value::String(s.into()))
+                Value::String(s.into())
             }
-            // Neither operand is a string here ⇒ numeric coercion, matching the VM's `eval_binop`
-            // (`as_number().unwrap_or(NaN)`): a null/bool/object operand (e.g. an out-of-bounds array
-            // read) coerces to NaN, so `number + null` is NaN — NOT an error that the codegen's
-            // `.unwrap_or(Value::Null)` would silently turn into `null` (the old rust-AOT divergence).
-            (a, b) => Ok(Value::Number(
+            // Neither operand is a string ⇒ numeric coercion, matching the VM's `eval_binop`
+            // (`as_number().unwrap_or(NaN)`): a null/bool/object operand (e.g. an out-of-bounds
+            // array read) coerces to NaN, so `number + null` is NaN. Never an error.
+            (a, b) => Value::Number(
                 a.as_number().unwrap_or(f64::NAN) + b.as_number().unwrap_or(f64::NAN),
-            )),
+            ),
         }
     }
 
     #[inline]
-    pub fn sub(left: &Value, right: &Value) -> Result<Value, Box<dyn std::error::Error>> {
+    pub fn sub(left: &Value, right: &Value) -> Value {
         match (left, right) {
-            (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a - b)),
+            (Value::Number(a), Value::Number(b)) => Value::Number(a - b),
             // VM-parity numeric coercion (null/non-number → NaN), see `add`.
-            (a, b) => Ok(Value::Number(
+            (a, b) => Value::Number(
                 a.as_number().unwrap_or(f64::NAN) - b.as_number().unwrap_or(f64::NAN),
-            )),
+            ),
         }
     }
 
     #[inline]
-    pub fn mul(left: &Value, right: &Value) -> Result<Value, Box<dyn std::error::Error>> {
+    pub fn mul(left: &Value, right: &Value) -> Value {
         match (left, right) {
-            (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a * b)),
+            (Value::Number(a), Value::Number(b)) => Value::Number(a * b),
             // VM-parity numeric coercion (null/non-number → NaN), see `add`.
-            (a, b) => Ok(Value::Number(
+            (a, b) => Value::Number(
                 a.as_number().unwrap_or(f64::NAN) * b.as_number().unwrap_or(f64::NAN),
-            )),
+            ),
         }
     }
 
     #[inline]
-    pub fn div(left: &Value, right: &Value) -> Result<Value, Box<dyn std::error::Error>> {
+    pub fn div(left: &Value, right: &Value) -> Value {
         match (left, right) {
-            (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a / b)),
+            (Value::Number(a), Value::Number(b)) => Value::Number(a / b),
             // VM-parity numeric coercion (null/non-number → NaN), see `add`.
-            (a, b) => Ok(Value::Number(
+            (a, b) => Value::Number(
                 a.as_number().unwrap_or(f64::NAN) / b.as_number().unwrap_or(f64::NAN),
-            )),
+            ),
         }
     }
 
@@ -507,13 +510,13 @@ pub mod ops {
     }
 
     #[inline]
-    pub fn modulo(left: &Value, right: &Value) -> Result<Value, Box<dyn std::error::Error>> {
+    pub fn modulo(left: &Value, right: &Value) -> Value {
         match (left, right) {
-            (Value::Number(a), Value::Number(b)) => Ok(Value::Number(a % b)),
+            (Value::Number(a), Value::Number(b)) => Value::Number(a % b),
             // VM-parity numeric coercion (null/non-number → NaN), see `add`.
-            (a, b) => Ok(Value::Number(
+            (a, b) => Value::Number(
                 a.as_number().unwrap_or(f64::NAN) % b.as_number().unwrap_or(f64::NAN),
-            )),
+            ),
         }
     }
 }


### PR DESCRIPTION
## What

`tishlang_runtime::ops::{add,sub,mul,div,modulo}` returned `Result<Value, Box<dyn Error>>`, but **every arm is `Ok(...)`** — arithmetic never errors (a non-number operand coerces to NaN, matching the VM's `eval_binop`; there is no `Err(` anywhere in `pub mod ops`). The `Result` was dead: it forced a memory return (sret) plus a `.unwrap_or(Value::Null)` / `?` on every boxed arithmetic op in generated code.

These ops now return a bare `Value`. Codegen drops the consumer suffix — `ops_result_suffix()` → `""` (covers the compound-assign sites) and the 5 hardcoded `emit_binop` sites.

## Why (honest numbers)

Found while measuring the NaN-box #201 payoff (see [#201](https://github.com/tishlang/tish/issues/201#issuecomment-4859979841) — NaN-box turned out to be a dead end). In an *isolated* tight loop the Result-wrapped add was ~4× a bare-`Value` add. On the **real** megamorphic fixture — which runs ~7 boxed ops per iteration (modulo, index, get_prop, add, clones), so the add is a smaller share — the end-to-end win is **~9% (530→484ms)**. Not a fixture-flipper, but a **modest, general win for every dynamic / untyped / VM boxed numeric op**, and it deletes genuinely-dead error handling.

## Validation

- **Clean full gauntlet: 23/29, all fixtures `typed==boxed==node`** (no soundness failure, no regression). `fnv_hash` and `numeric_loop` flipped FAIL→PASS (borderline ties nudged green by the faster boxed arithmetic).
- `cargo test --workspace` green (91 ok, 0 failed).
- Sound by construction: no arm ever produced `Err`.

Part of #203.