### PR TITLE
perf(native): native in-place sort over Vec<struct> — sort_comparator beats node (#373)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -2055,6 +2055,29 @@ impl Codegen {
         out
     }
 
+    /// #373: render a native `sort_by` comparator body for a `Vec<struct>` from a detected key list.
+    /// Each single-segment key compares the struct field via `partial_cmp` (NaN → Equal, matching a
+    /// JS comparator `a-b` yielding NaN→0); descending keys `.reverse()`; keys chain with `then_with`.
+    fn render_struct_sort_chain(keys: &[(Vec<std::sync::Arc<str>>, bool)]) -> String {
+        let term = |path: &[std::sync::Arc<str>], asc: bool| -> String {
+            let f = crate::types::field_ident(&path[0]);
+            let base =
+                format!("a.{f}.partial_cmp(&b.{f}).unwrap_or(std::cmp::Ordering::Equal)");
+            if asc {
+                base
+            } else {
+                format!("{base}.reverse()")
+            }
+        };
+        let mut it = keys.iter();
+        let (p0, a0) = it.next().expect("non-empty key list");
+        let mut out = term(p0, *a0);
+        for (p, a) in it {
+            out = format!("{out}.then_with(|| {})", term(p, *a));
+        }
+        out
+    }
+
     fn emit_program(&mut self, program: &Program) -> Result<(), CompileError> {
         self.is_async = program_uses_async(program);
         self.program_has_jsx = tishlang_ui::jsx::program_contains_jsx(program);
@@ -6472,6 +6495,48 @@ impl Codegen {
                                         "{{ {} Value::Null }}",
                                         push_stmts.join(" ")
                                     ));
+                                }
+                            }
+                        }
+                    }
+
+                    // ── #373: native Vec<struct> sort fast path ───────────────────
+                    // A `structArr.sort(cmp)` where the receiver is a native `Vec<Named>`. The boxed
+                    // fallback below would sort a THROWAWAY boxed copy (wrong — the real Vec is left
+                    // unsorted), so we MUST handle it here. Key-comparators lower to a native in-place
+                    // `sort_by` over struct fields (stable, matching JS); any other comparator boxes,
+                    // sorts via the runtime, and writes the result back into the Vec (correct).
+                    if method_name.as_ref() == "sort" {
+                        if let Expr::Ident { name, .. } = object.as_ref() {
+                            if !self.refcell_wrapped_vars.contains(name.as_ref()) {
+                                if let RustType::Vec(elem_type) =
+                                    self.type_context.get_type(name.as_ref())
+                                {
+                                    if matches!(elem_type.as_ref(), RustType::Named { .. }) {
+                                        let esc = Self::escape_ident(name.as_ref()).into_owned();
+                                        if let Some(CallArg::Expr(cmp)) = args.first() {
+                                            if let Some(keys) =
+                                                Self::detect_lexicographic_key_comparator(cmp)
+                                            {
+                                                if keys.iter().all(|(p, _)| p.len() == 1) {
+                                                    let chain = Self::render_struct_sort_chain(&keys);
+                                                    return Ok(format!(
+                                                        "{{ {esc}.sort_by(|a, b| {chain}); Value::Null }}"
+                                                    ));
+                                                }
+                                            }
+                                            // General comparator: box → sort → write back (correct).
+                                            let cmp_code = self.emit_expr(cmp)?;
+                                            let to_v = elem_type.to_value_expr("__e");
+                                            let from_v = elem_type.from_value_expr("__v");
+                                            return Ok(format!(
+                                                "{{ let __sv: Vec<Value> = {esc}.iter().map(|__e| {to_v}).collect(); \
+                                                 let __sorted = tishlang_runtime::array_sort(&Value::Array(VmRef::new(__sv)), Some(&({cmp_code}))); \
+                                                 if let Value::Array(__a) = __sorted {{ {esc} = __a.borrow().iter().map(|__v| {from_v}).collect(); }} \
+                                                 Value::Null }}"
+                                            ));
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/crates/tish_compile/src/infer.rs
+++ b/crates/tish_compile/src/infer.rs
@@ -26,6 +26,10 @@ pub struct InferCtx {
     /// through to an implicit `undefined`). Lets `infer_expr_type(f(...))` be `number`, so
     /// `a.push(f(...))` infers `a: number[]` (e.g. k_nucleotide's `seq.push(nextBase())`).
     number_returning_fns: std::collections::HashSet<String>,
+    /// #373: registered struct-alias shapes (alias → ordered fields), so `infer_expr_type` can
+    /// resolve `<expr: Simple(alias)>.field` → the field's type — needed to type a CROSS-ARRAY
+    /// struct-field read like `base[i].key` when building another record array (`rows`).
+    struct_shapes: HashMap<String, Vec<(std::sync::Arc<str>, TypeAnnotation)>>,
 }
 
 impl InferCtx {
@@ -34,7 +38,20 @@ impl InferCtx {
             scopes: vec![HashMap::new()],
             native_vec_array_params: HashMap::new(),
             number_returning_fns: std::collections::HashSet::new(),
+            struct_shapes: HashMap::new(),
         }
+    }
+
+    fn define_struct(&mut self, alias: &str, fields: Vec<(std::sync::Arc<str>, TypeAnnotation)>) {
+        self.struct_shapes.insert(alias.to_string(), fields);
+    }
+
+    fn struct_field(&self, alias: &str, key: &str) -> Option<&TypeAnnotation> {
+        self.struct_shapes
+            .get(alias)?
+            .iter()
+            .find(|(k, _)| k.as_ref() == key)
+            .map(|(_, t)| t)
     }
 
     fn push_scope(&mut self) {
@@ -125,6 +142,13 @@ pub fn infer_expr_type(expr: &Expr, ctx: &InferCtx) -> Option<TypeAnnotation> {
         Expr::Binary {
             left, op, right, ..
         } => {
+            // Always-numeric ops coerce BOTH operands to Number (JS ToNumber) → result is Number
+            // regardless of operand types, even when an operand type is unknown (e.g. a call result).
+            // Excludes `+` (string concat) and comparisons. Lets `{ key: r % 65536 }` type as number.
+            if matches!(op, BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod | BinOp::Pow
+                | BinOp::BitAnd | BinOp::BitOr | BinOp::BitXor | BinOp::Shl | BinOp::Shr | BinOp::UShr) {
+                return Some(number_ann());
+            }
             let lt = infer_expr_type(left, ctx)?;
             let rt = infer_expr_type(right, ctx)?;
             if is_number(&lt) && is_number(&rt) {
@@ -174,6 +198,17 @@ pub fn infer_expr_type(expr: &Expr, ctx: &InferCtx) -> Option<TypeAnnotation> {
             }
         }
         // Index of a typed array yields its element type (`a[i]` where `a: T[]` → `T`).
+        // `<expr: Simple(alias)>.field` — struct field read → the field's type (alias shape must be
+        // registered in ctx). Enables cross-array reads like `base[i].key` (#373). Non-struct
+        // receivers (or `Simple("number")` etc.) resolve to None, unchanged.
+        Expr::Member {
+            object,
+            prop: tishlang_ast::MemberProp::Name { name: k, .. },
+            ..
+        } => match infer_expr_type(object, ctx)? {
+            TypeAnnotation::Simple(alias, _) => ctx.struct_field(alias.as_ref(), k.as_ref()).cloned(),
+            _ => None,
+        },
         Expr::Index { object, .. } => match infer_expr_type(object, ctx) {
             Some(TypeAnnotation::Array(elem)) => Some(*elem),
             _ => None,
@@ -1350,6 +1385,7 @@ fn si_block(stmts: Vec<Statement>, reg: &mut StructRegistry, ctx: &mut InferCtx)
                         tishlang_ast::Span::default(),
                     )));
                     ctx.define(name.as_ref(), arr_ann.clone());
+                    ctx.define_struct(alias.as_str(), fields.clone()); // #373: enable cross-array field reads
                     out.push(Statement::VarDecl {
                         name: name.clone(),
                         name_span: *name_span,
@@ -1747,10 +1783,13 @@ fn ra_expr(e: &Expr, name: &str, keys: &std::collections::HashSet<&str>) -> bool
             };
             match object.as_ref() {
                 Ident { name: n, .. } if n.as_ref() == name => mname == "length",
-                Index { object: io, index, .. } => {
-                    matches!(io.as_ref(), Ident { name: n, .. } if n.as_ref() == name)
-                        && keys.contains(mname)
-                        && ra_expr(index, name, keys)
+                // `name[i].<key>` field read of THIS array. Guard on `io == name` so a DIFFERENT
+                // record array's `other[i].field` falls through to the safe `_` recursion (bug: the
+                // old unguarded arm returned false for it, failing any 2+-record-array program).
+                Index { object: io, index, .. }
+                    if matches!(io.as_ref(), Ident { name: n, .. } if n.as_ref() == name) =>
+                {
+                    keys.contains(mname) && ra_expr(index, name, keys)
                 }
                 _ => ra_expr(object, name, keys),
             }
@@ -1793,6 +1832,13 @@ fn ra_expr(e: &Expr, name: &str, keys: &std::collections::HashSet<&str>) -> bool
                                         tishlang_ast::ObjectProp::KeyValue(_, v, _) if ra_expr(v, name, keys)))
                             );
                         }
+                        // `.sort(cmp)` is an in-place PERMUTATION, not an escape (shape + element
+                        // values unchanged). Safe iff the comparator does not escape `name`.
+                        if m.as_ref() == "sort" {
+                            return args
+                                .iter()
+                                .all(|a| matches!(a, CallArg::Expr(x) if ra_expr(x, name, keys)));
+                        }
                     }
                     return false;
                 }
@@ -1813,6 +1859,12 @@ fn ra_expr(e: &Expr, name: &str, keys: &std::collections::HashSet<&str>) -> bool
         Object { props, .. } => props
             .iter()
             .all(|pr| matches!(pr, tishlang_ast::ObjectProp::KeyValue(_, v, _) if ra_expr(v, name, keys))),
+        // HOF callbacks (e.g. the `.sort` comparator): recurse into the body precisely — a comparator
+        // over `a.key`/`b.key` never touches `name` (pi_mentions is too conservative on closures).
+        ArrowFunction { body, .. } => match body {
+            tishlang_ast::ArrowBody::Expr(e) => ra_expr(e, name, keys),
+            tishlang_ast::ArrowBody::Block(st) => ra_stmt(st, name, keys),
+        },
         _ => false,
     }
 }


### PR DESCRIPTION
## What

Lands the `sort_comparator` gauntlet flip end to end: the canonical *"sort a list of records by a field"* shape now stays on the native typed path instead of boxing into a throwaway `Value::Array`.

```js
rows.sort((a, b) => {
  if (a.key !== b.key) { return a.key - b.key }
  return a.idx - b.idx
})
```

Previously `rows` inferred as `Vec<struct>`, but the `.sort` call lowered to a boxed `array_sort` over a **throwaway** `Value::Array` copy — the real `Vec` was left unsorted (a correctness hazard) and every compare paid full property-name-hashing boxing. This makes the whole shape native.

## How

**`infer.rs` (front-end typing — general, not fixture-shaped):**
- Always-numeric binary ops (`- * / % ** & | ^ << >> >>>`) type as `Number` even when an operand type is unknown (JS `ToNumber` coerces both sides). Lets `{ key: r % 65536 }` type as a number field so the record shape is inferable.
- `<expr: Simple(alias)>.field` resolves to the field's type via a registered struct-shape table, so a **cross-array** read like `base[i].key` (building `rows` from `base`) types correctly.
- `ra_expr` record-array escape analysis: fixed an over-broad `Index` arm that failed any program with 2+ record arrays (`other[i].field` returned `false`); `.sort(cmp)` is now recognized as an **in-place permutation** (not an escape) iff the comparator doesn't escape the array; recurse precisely into HOF closure bodies.

**`codegen.rs` (back-end lowering):**
- `structArr.sort(cmp)` on a native `Vec<Named>` receiver: a detected lexicographic key comparator (including the `if (a.k!==b.k) return a.k-b.k; return a.j-b.j` tiebreak chain) lowers to an in-place `sort_by` chaining `partial_cmp(...).then_with(...)` over struct fields. Any other comparator boxes, sorts via the runtime, and **writes the result back into the `Vec`** (correct).

## Validation

| check | result |
|---|---|
| `sort_comparator` gauntlet | **FAIL→PASS** — typed **31ms** vs node **157ms** (5.0× faster) |
| soundness (this fixture) | typed == boxed == node ✓ |
| full gauntlet | **24/29 PASS, all 29 sound** — no regressions from the global infer change |
| `cargo test --workspace` | **476 passed, 0 failed** (incl. the debug-bin integration suite) |

Refs #203. Closes #373.