### PR TITLE
perf(native): ShapeUnion foundation for megamorphic (#179 Stage B)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1217,8 +1217,10 @@ impl Codegen {
         for _ in 0..8 {
             let mut changed = false;
             for (name, ann) in &raw {
-                let resolved =
-                    crate::types::RustType::from_annotation_with_aliases(ann, &self.type_aliases);
+                let resolved = Self::try_shape_union_alias(name, ann, &self.type_aliases)
+                    .unwrap_or_else(|| {
+                        crate::types::RustType::from_annotation_with_aliases(ann, &self.type_aliases)
+                    });
                 let prev: Option<crate::types::RustType> = self.type_aliases.get(name).cloned();
                 if prev.as_ref() != Some(&resolved) {
                     self.type_aliases.insert(name.clone(), resolved);
@@ -1229,6 +1231,47 @@ impl Codegen {
                 break;
             }
         }
+    }
+
+    /// #179 Stage B: a compiler-generated shape-union alias (`TishAnonUnion_N = Union([Object, …])`)
+    /// resolves to a `RustType::ShapeUnion` with deterministic per-variant struct aliases
+    /// (`<alias>_V<i>`). Only the reserved prefix is treated this way, so user object-unions are
+    /// unaffected (they keep the `from_annotation` Option/Value lowering).
+    fn try_shape_union_alias(
+        name: &str,
+        ann: &TypeAnnotation,
+        aliases: &std::collections::HashMap<String, crate::types::RustType>,
+    ) -> Option<crate::types::RustType> {
+        if !name.starts_with("TishAnonUnion_") {
+            return None;
+        }
+        let TypeAnnotation::Union(members) = ann else {
+            return None;
+        };
+        if !(2..=8).contains(&members.len()) {
+            return None;
+        }
+        let mut variants = Vec::with_capacity(members.len());
+        for (i, m) in members.iter().enumerate() {
+            let TypeAnnotation::Object(fields) = m else {
+                return None;
+            };
+            let rfields: Vec<(std::sync::Arc<str>, crate::types::RustType)> = fields
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        crate::types::RustType::from_annotation_with_aliases(v, aliases),
+                    )
+                })
+                .collect();
+            let vname: std::sync::Arc<str> = format!("{}_V{}", name, i).into();
+            variants.push((vname, rfields));
+        }
+        Some(crate::types::RustType::ShapeUnion {
+            name: name.into(),
+            variants,
+        })
     }
 
     fn walk_type_aliases<'p>(
@@ -1310,6 +1353,40 @@ impl Codegen {
                 if Self::json_fields_are_simple(fields) {
                     self.emit_struct_json_serializer(&name, fields);
                 }
+                emitted_any = true;
+            } else if let crate::types::RustType::ShapeUnion { name: uname, variants } = &ty {
+                // #179 Stage B: one struct per variant, then the enum wrapping them.
+                for (valias, vfields) in variants {
+                    let vstruct = crate::types::named_struct_ident(valias);
+                    self.write("#[derive(Clone, Debug, Default)]\n");
+                    self.write("#[allow(non_snake_case, non_camel_case_types)]\n");
+                    self.write(&format!("pub struct {} {{\n", vstruct));
+                    for (k, t) in vfields {
+                        self.write(&format!(
+                            "    pub {}: {},\n",
+                            crate::types::field_ident(k),
+                            t.to_rust_type_str()
+                        ));
+                    }
+                    self.write("}\n\n");
+                }
+                let enum_ident = crate::types::shape_union_enum_ident(uname);
+                self.write("#[derive(Clone, Debug)]\n");
+                self.write("#[allow(non_snake_case, non_camel_case_types)]\n");
+                self.write(&format!("pub enum {} {{\n", enum_ident));
+                for (i, (valias, _)) in variants.iter().enumerate() {
+                    self.write(&format!(
+                        "    {}({}),\n",
+                        crate::types::shape_union_variant_ident(i),
+                        crate::types::named_struct_ident(valias)
+                    ));
+                }
+                self.write("}\n\n");
+                // A Default impl (first variant) so a `Vec<TishUnion_…>` local can be declared with
+                // the type's `default_value()` before the pushes fill it.
+                self.write(&format!("impl Default for {} {{\n", enum_ident));
+                self.write(&format!("    fn default() -> Self {{ {} }}\n", ty.default_value()));
+                self.write("}\n\n");
                 emitted_any = true;
             }
         }
@@ -9647,6 +9724,53 @@ impl Codegen {
             return Ok(target_type.from_value_expr(&value_expr));
         }
 
+        // #179 Stage B: an object literal against a `ShapeUnion` target — select the variant by the
+        // literal's key set (inference guarantees distinct key sets, so the match is unique) and wrap
+        // the variant's struct literal in the enum. Every literal pushed into a union array is one of
+        // the collected shapes by construction, so a valid program always finds its variant.
+        if let (RustType::ShapeUnion { name: uname, variants }, Expr::Object { props, .. }) =
+            (target_type, expr)
+        {
+            let mut lit_keys: Vec<&str> = Vec::new();
+            let mut has_spread = false;
+            for p in props {
+                match p {
+                    ObjectProp::KeyValue(k, _, _) => lit_keys.push(k.as_ref()),
+                    ObjectProp::Spread(_) => has_spread = true,
+                }
+            }
+            if !has_spread {
+                lit_keys.sort_unstable();
+                let hit = variants.iter().enumerate().find(|(_, (_, vf))| {
+                    let mut vk: Vec<&str> = vf.iter().map(|(k, _)| k.as_ref()).collect();
+                    vk.sort_unstable();
+                    vk == lit_keys
+                });
+                if let Some((vi, (valias, vfields))) = hit {
+                    let named = RustType::Named {
+                        name: valias.clone(),
+                        fields: vfields.clone(),
+                    };
+                    let inner = self.emit_native_expr(expr, &named)?;
+                    return Ok(format!(
+                        "{}::{}({})",
+                        crate::types::shape_union_enum_ident(uname),
+                        crate::types::shape_union_variant_ident(vi),
+                        inner
+                    ));
+                }
+            }
+            // Unreachable for a soundly-inferred union (distinct key sets, every literal in the set);
+            // fail loud rather than silently miscompile if that invariant is ever violated.
+            return Err(CompileError::new(
+                format!(
+                    "#179 ShapeUnion {}: object literal matched no variant (keys {:?})",
+                    uname, lit_keys
+                ),
+                None,
+            ));
+        }
+
         // Try to emit object literals directly as a Rust struct literal
         // when the target is a `RustType::Named` (a user `type Foo = {...}`
         // alias). Each property in source order is matched to a struct
@@ -13045,6 +13169,24 @@ impl Codegen {
                                 {
                                     if field_ty.is_native() {
                                         return field_ty.clone();
+                                    }
+                                }
+                            }
+                            // #179 Stage B: `union[i].field` where the field is present-and-native in
+                            // EVERY variant — the enum-match read yields that native type, so a numeric
+                            // accumulator fed by it (`sum = sum + objs[i].value`) stays native f64.
+                            if let RustType::ShapeUnion { variants, .. } = inner.as_ref() {
+                                let field_ty = variants.first().and_then(|(_, vf)| {
+                                    vf.iter()
+                                        .find(|(k, _)| k.as_ref() == prop_name.as_ref())
+                                        .map(|(_, t)| t.clone())
+                                });
+                                let in_all = variants.iter().all(|(_, vf)| {
+                                    vf.iter().any(|(k, _)| k.as_ref() == prop_name.as_ref())
+                                });
+                                if let Some(field_ty) = field_ty {
+                                    if in_all && field_ty.is_native() {
+                                        return field_ty;
                                     }
                                 }
                             }
@@ -20828,6 +20970,45 @@ impl Codegen {
                                 || matches!(field_ty, RustType::Named { .. } | RustType::Vec(_))
                             {
                                 return Ok((access, field_ty.clone()));
+                            }
+                        }
+                    }
+                    // #179 Stage B: `union[i].field` — a field present in EVERY variant lowers to a
+                    // `match` reading it by fixed offset per arm (no hash, no IC). The inference safety
+                    // walk restricts reads to the common keys, so this is always all-variants here.
+                    if let RustType::ShapeUnion { name: uname, variants } = &obj_ty {
+                        let field_ty = variants.first().and_then(|(_, vf)| {
+                            vf.iter()
+                                .find(|(k, _)| k.as_ref() == prop_name.as_ref())
+                                .map(|(_, t)| t.clone())
+                        });
+                        let in_all = variants.iter().all(|(_, vf)| {
+                            vf.iter().any(|(k, _)| k.as_ref() == prop_name.as_ref())
+                        });
+                        if let Some(field_ty) = field_ty {
+                            if in_all
+                                && (field_ty.is_native()
+                                    || matches!(
+                                        field_ty,
+                                        RustType::Named { .. } | RustType::Vec(_)
+                                    ))
+                            {
+                                let field = crate::types::field_ident(prop_name.as_ref());
+                                let arms = variants
+                                    .iter()
+                                    .enumerate()
+                                    .map(|(i, _)| {
+                                        format!(
+                                            "{}::{}(__s) => __s.{}.clone()",
+                                            crate::types::shape_union_enum_ident(uname),
+                                            crate::types::shape_union_variant_ident(i),
+                                            field
+                                        )
+                                    })
+                                    .collect::<Vec<_>>()
+                                    .join(", ");
+                                let access = format!("(match &{} {{ {} }})", obj_code, arms);
+                                return Ok((access, field_ty));
                             }
                         }
                     }

--- a/crates/tish_compile/src/infer.rs
+++ b/crates/tish_compile/src/infer.rs
@@ -948,6 +948,11 @@ struct StructRegistry {
     by_shape: HashMap<String, String>,
     /// alias name → field list (for emitting the `type` decls)
     decls: Vec<StructDecl>,
+    /// #179 Stage B: canonical union key ("shape0|shape1|…") → union alias name.
+    by_union: HashMap<String, String>,
+    /// #179 Stage B: union alias → its variant shapes. Emitted as `type TishAnonUnion_N =
+    /// Union([Object(s0), Object(s1), …])`; codegen synthesizes the enum + per-variant structs.
+    union_decls: Vec<(String, Vec<Vec<(std::sync::Arc<str>, TypeAnnotation)>>)>,
 }
 
 impl StructRegistry {
@@ -963,6 +968,28 @@ impl StructRegistry {
         let name = format!("TishAnon_{}", self.decls.len());
         self.by_shape.insert(canon, name.clone());
         self.decls.push((name.clone(), fields.to_vec()));
+        name
+    }
+
+    /// #179 Stage B: register a closed set of distinct record shapes as a shape-union alias
+    /// (`TishAnonUnion_N`). Identical sets (order-insensitive per the caller's dedup) share one alias.
+    fn intern_union(&mut self, shapes: &[Vec<(std::sync::Arc<str>, TypeAnnotation)>]) -> String {
+        let canon = shapes
+            .iter()
+            .map(|s| {
+                s.iter()
+                    .map(|(k, t)| format!("{}:{}", k, type_canon(t)))
+                    .collect::<Vec<_>>()
+                    .join(";")
+            })
+            .collect::<Vec<_>>()
+            .join("|");
+        if let Some(name) = self.by_union.get(&canon) {
+            return name.clone();
+        }
+        let name = format!("TishAnonUnion_{}", self.union_decls.len());
+        self.by_union.insert(canon, name.clone());
+        self.union_decls.push((name.clone(), shapes.to_vec()));
         name
     }
 
@@ -1845,6 +1872,20 @@ fn struct_infer_program(program: Program) -> Program {
             span,
         });
     }
+    // #179 Stage B: emit each shape-union alias as `type TishAnonUnion_N = Union([Object(s0), …])`;
+    // codegen recognizes the reserved-prefix alias and synthesizes the enum + per-variant structs.
+    for (name, shapes) in reg.union_decls.drain(..) {
+        let members: Vec<TypeAnnotation> = shapes
+            .into_iter()
+            .map(TypeAnnotation::Object)
+            .collect();
+        out.push(Statement::TypeAlias {
+            name: name.as_str().into(),
+            name_span: span,
+            ty: TypeAnnotation::Union(members),
+            span,
+        });
+    }
     out.append(&mut stmts);
     Program { statements: out }
 }
@@ -1965,6 +2006,51 @@ fn si_block(stmts: Vec<Statement>, reg: &mut StructRegistry, ctx: &mut InferCtx)
                         span: *span,
                     });
                     continue;
+                }
+            }
+            // (e) #179 Stage B — array of a CLOSED SET of heterogeneous record shapes ("megamorphic":
+            // `objs.push({value,a})`, `objs.push({b,value,c})`, … all read as `objs[i].value`). Lower
+            // to a native `Vec<enum>` (ShapeUnion): a `.field` present-and-same-type in EVERY variant
+            // becomes a direct `match` load. Opt-in (TISH_SHAPE_UNION) until Stage C's integer modulo
+            // makes it a net win. The safety walk uses ONLY the common keys, so a read of a
+            // not-in-every-variant field disqualifies (stays boxed → undefined/null preserved).
+            if shape_union_enabled() {
+                if let Some(shapes) =
+                    record_array_shape_set(name.as_ref(), elements, &stmts[i + 1..], ctx)
+                {
+                    let common = shape_set_common_keys(&shapes);
+                    let common_refs: std::collections::HashSet<&str> =
+                        common.iter().map(|k| k.as_ref()).collect();
+                    if !common_refs.is_empty()
+                        && rec_arr_uses_safe(name.as_ref(), &common_refs, &stmts[i + 1..])
+                    {
+                        let union_alias = reg.intern_union(&shapes);
+                        let arr_ann = TypeAnnotation::Array(Box::new(TypeAnnotation::Simple(
+                            union_alias.as_str().into(),
+                            tishlang_ast::Span::default(),
+                        )));
+                        ctx.define(name.as_ref(), arr_ann.clone());
+                        // Register the union's COMMON fields as a struct shape so `infer_expr_type`
+                        // types `objs[i].field` as its (number) type — otherwise a numeric
+                        // accumulator fed by the read (`sum = sum + objs[i].value`) stays boxed.
+                        // All common fields share one type across variants (guaranteed above), so the
+                        // first shape's types are correct.
+                        let common_fields: Vec<(std::sync::Arc<str>, TypeAnnotation)> = shapes[0]
+                            .iter()
+                            .filter(|(k, _)| common.contains(k))
+                            .cloned()
+                            .collect();
+                        ctx.define_struct(union_alias.as_str(), common_fields);
+                        out.push(Statement::VarDecl {
+                            name: name.clone(),
+                            name_span: *name_span,
+                            mutable: *mutable,
+                            type_ann: Some(arr_ann),
+                            init: stmt_init_clone(stmt),
+                            span: *span,
+                        });
+                        continue;
+                    }
                 }
             }
         }
@@ -2310,6 +2396,134 @@ fn record_array_fields(
 /// spread, for-of, method other than push) returns false → the array stays boxed.
 fn rec_arr_uses_safe(name: &str, keys: &std::collections::HashSet<&str>, tail: &[Statement]) -> bool {
     tail.iter().all(|s| ra_stmt(s, name, keys))
+}
+
+/// #179 Stage B: opt-in flag for shape-union (megamorphic) inference. OFF by default until the
+/// integer-modulo lever (Stage C) lands to make it a net win; on it lets a heterogeneous
+/// closed-shape-set array lower to a `Vec<enum>` instead of staying boxed.
+fn shape_union_enabled() -> bool {
+    crate::native_opts_enabled() && std::env::var("TISH_SHAPE_UNION").as_deref() == Ok("1")
+}
+
+/// #179 Stage B: like [`record_array_fields`] but for a HETEROGENEOUS array — accumulate the set of
+/// DISTINCT primitive-record shapes across the initial elements + every `name.push({…})`. Returns
+/// the deduped shapes when there are 2..=8 of them (a genuine union; 1 shape is the existing
+/// single-struct path), or None if a push arg isn't a uniform primitive object literal, a non-object
+/// element appears, or the set exceeds 8 shapes.
+fn record_array_shape_set(
+    name: &str,
+    init_elements: &[tishlang_ast::ArrayElement],
+    tail: &[Statement],
+    ctx: &InferCtx,
+) -> Option<Vec<Vec<(std::sync::Arc<str>, TypeAnnotation)>>> {
+    let mut sctx = ctx.clone();
+    for _ in 0..4 {
+        for s in tail {
+            seed_numeric_locals(s, &mut sctx);
+        }
+    }
+    let mut shapes: Vec<Vec<(std::sync::Arc<str>, TypeAnnotation)>> = Vec::new();
+    let mut ok = true;
+    for el in init_elements {
+        match el {
+            tishlang_ast::ArrayElement::Expr(Expr::Object { props, .. }) => {
+                shape_set_consider(&mut shapes, &mut ok, props, &sctx);
+            }
+            _ => return None,
+        }
+        if !ok {
+            return None;
+        }
+    }
+    for s in tail {
+        walk_exprs_stmt(s, &mut |e| {
+            if let Expr::Call { callee, args, .. } = e {
+                if let Expr::Member {
+                    object,
+                    prop: tishlang_ast::MemberProp::Name { name: m, .. },
+                    ..
+                } = callee.as_ref()
+                {
+                    if m.as_ref() == "push"
+                        && matches!(object.as_ref(), Expr::Ident { name: n, .. } if n.as_ref() == name)
+                    {
+                        if let [CallArg::Expr(Expr::Object { props, .. })] = args.as_slice() {
+                            shape_set_consider(&mut shapes, &mut ok, props, &sctx);
+                        } else {
+                            ok = false;
+                        }
+                    }
+                }
+            }
+        });
+        if !ok {
+            return None;
+        }
+    }
+    if !(2..=8).contains(&shapes.len()) {
+        return None;
+    }
+    // Every variant must have a DISTINCT key set — codegen selects the variant for an object literal
+    // by its key set, so a same-keys/different-types collision would be ambiguous → stay boxed.
+    let mut keysets: Vec<Vec<&str>> = shapes
+        .iter()
+        .map(|s| {
+            let mut k: Vec<&str> = s.iter().map(|(k, _)| k.as_ref()).collect();
+            k.sort_unstable();
+            k
+        })
+        .collect();
+    let n = keysets.len();
+    keysets.sort();
+    keysets.dedup();
+    if keysets.len() != n {
+        return None;
+    }
+    Some(shapes)
+}
+
+/// Accumulate a distinct primitive-record shape into the set (dedup by `fields_eq`). Sets `ok=false`
+/// if the literal is not a primitive record or the set would exceed 8 shapes.
+fn shape_set_consider(
+    shapes: &mut Vec<Vec<(std::sync::Arc<str>, TypeAnnotation)>>,
+    ok: &mut bool,
+    props: &[tishlang_ast::ObjectProp],
+    ctx: &InferCtx,
+) {
+    match infer_object_shape(props, ctx) {
+        Some(f) => {
+            if !shapes.iter().any(|s| fields_eq(s, &f)) {
+                if shapes.len() >= 8 {
+                    *ok = false;
+                    return;
+                }
+                shapes.push(f);
+            }
+        }
+        None => *ok = false,
+    }
+}
+
+/// #179 Stage B: the fields present with an IDENTICAL type in EVERY variant of a shape set — the only
+/// fields a `union[i].field` read may soundly lower to a native `match` (a field missing from, or
+/// type-divergent across, some variant must stay boxed → undefined/null semantics preserved).
+fn shape_set_common_keys(
+    shapes: &[Vec<(std::sync::Arc<str>, TypeAnnotation)>],
+) -> std::collections::HashSet<std::sync::Arc<str>> {
+    let mut common = std::collections::HashSet::new();
+    let Some(first) = shapes.first() else {
+        return common;
+    };
+    'field: for (k, ty) in first {
+        for other in &shapes[1..] {
+            match other.iter().find(|(ok, _)| ok.as_ref() == k.as_ref()) {
+                Some((_, oty)) if type_canon(oty) == type_canon(ty) => {}
+                _ => continue 'field, // absent or type-divergent in some variant
+            }
+        }
+        common.insert(k.clone());
+    }
+    common
 }
 
 fn ra_stmt(s: &Statement, name: &str, keys: &std::collections::HashSet<&str>) -> bool {

--- a/crates/tish_compile/src/types.rs
+++ b/crates/tish_compile/src/types.rs
@@ -53,6 +53,15 @@ pub enum RustType {
     },
     /// Tuple `(T0, T1, …)` for `[T0, T1]` tuple types — a native Rust tuple.
     Tuple(Vec<RustType>),
+    /// #179 Stage B: a closed set of 2..=8 distinct primitive-record shapes read at one site — the
+    /// "megamorphic" array-of-heterogeneous-objects pattern. Emitted as a generated Rust enum
+    /// `TishUnion_<name> { V0(TishStruct_<v0>), … }` (one variant per shape); a `.field` read present
+    /// in EVERY variant lowers to a `match` with a direct field load per arm (no hash, no IC). `name`
+    /// is the union alias; each `variants` entry is `(per-variant struct alias, its fields)`.
+    ShapeUnion {
+        name: Arc<str>,
+        variants: Vec<(Arc<str>, Vec<(Arc<str>, RustType)>)>,
+    },
 }
 
 impl RustType {
@@ -254,6 +263,7 @@ impl RustType {
                 )
             }
             RustType::Tuple(elems) => tuple_text(&elems.iter().map(|e| e.to_rust_type_str()).collect::<Vec<_>>()),
+            RustType::ShapeUnion { name, .. } => shape_union_enum_ident(name),
         }
     }
 
@@ -290,6 +300,22 @@ impl RustType {
             RustType::Function { .. } => "Value::Null".to_string(),
             RustType::Tuple(elems) => {
                 tuple_text(&elems.iter().map(|e| e.default_value()).collect::<Vec<_>>())
+            }
+            RustType::ShapeUnion { name, variants } => {
+                // Default = the first variant with each of its fields defaulted.
+                let (v0_alias, v0_fields) = &variants[0];
+                let init = v0_fields
+                    .iter()
+                    .map(|(k, t)| format!("{}: {}", field_ident(k), t.default_value()))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(
+                    "{}::{}({} {{ {} }})",
+                    shape_union_enum_ident(name),
+                    shape_union_variant_ident(0),
+                    named_struct_ident(v0_alias),
+                    init
+                )
             }
         }
     }
@@ -370,6 +396,15 @@ impl RustType {
                     field_assigns
                 )
             }
+            RustType::ShapeUnion { .. } => {
+                // #179 Stage B: converting a boxed Value INTO a ShapeUnion is a boundary the safety
+                // walk forbids (a typed union element never crosses to/from boxed), so codegen must
+                // never emit this. Present for match-completeness; fails loud if gating is violated.
+                format!(
+                    "{{ let _ = {}; unreachable!(\"ShapeUnion from Value is a forbidden boundary\") }}",
+                    value_expr
+                )
+            }
             _ => value_expr.to_string(), // Fallback
         }
     }
@@ -442,6 +477,28 @@ impl RustType {
                 // count, a codegen-time constant) — no AHashMap, so key order is preserved.
                 format!("Value::object_from_pairs([{}])", pairs)
             }
+            RustType::ShapeUnion { name, variants } => {
+                // union → boxed Value::Object: one match arm per variant, delegating to that
+                // variant's Named glue (ordered `object_from_pairs`, preserving JS key order).
+                let arms = variants
+                    .iter()
+                    .enumerate()
+                    .map(|(i, (alias, fields))| {
+                        let named = RustType::Named {
+                            name: alias.clone(),
+                            fields: fields.clone(),
+                        };
+                        format!(
+                            "{}::{}(__u) => {}",
+                            shape_union_enum_ident(name),
+                            shape_union_variant_ident(i),
+                            named.to_value_expr("__u")
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("(match &{} {{ {} }})", native_expr, arms)
+            }
             _ => native_expr.to_string(), // Fallback
         }
     }
@@ -460,6 +517,16 @@ fn tuple_text(parts: &[String]) -> String {
 
 pub fn named_struct_ident(tish_name: &str) -> String {
     format!("TishStruct_{}", tish_name)
+}
+
+/// #179 Stage B: map a shape-union alias to the generated Rust enum identifier.
+pub fn shape_union_enum_ident(tish_name: &str) -> String {
+    format!("TishUnion_{}", tish_name)
+}
+
+/// #179 Stage B: the Rust variant identifier for the `idx`-th shape of a union (`V0`, `V1`, …).
+pub fn shape_union_variant_ident(idx: usize) -> String {
+    format!("V{}", idx)
 }
 
 /// Map a Tish field name (`randomNumber`) to a valid Rust identifier


### PR DESCRIPTION
## What

**Stage B of the megamorphic (#179) flip.** Lowers a **closed set of heterogeneous record shapes** — the canonical megamorphic array-of-objects — to a native `Vec<enum>` (`RustType::ShapeUnion`) instead of a boxed `Value::Array`:

```js
function makeObjs() {
  let objs = []
  objs.push({ value: 1, a: 1 }); objs.push({ b: 1, value: 2, c: 1 }); /* …8 shapes… */
  return objs
}
let objs = makeObjs()
for (let r = 0; r < N; r++) sum = sum + objs[r % n].value   // read at ONE site
```

A `.field` present-and-same-type in **every** variant lowers to `match &objs[i] { V0(s)=>s.value, V1(s)=>s.value, … }` — a direct field load per arm, **no hash, no inline cache**. This is the compile-time shape-set specialization V8/Bun can't do (they only learn hidden classes at runtime and guard every read) — it's tish, not JS.

Opt-in behind **`TISH_SHAPE_UNION`** (OFF by default) until Stage C lands the integer-modulo lever that makes it a net win. Builds on Stage A (#375) — the factory inliner brings `objs` to top level where the record-array machinery this forks can see it.

## How
- **B1** `RustType::ShapeUnion` + type glue (`to_rust_type_str` → `TishUnion_X`, `to_value_expr` match-over-variants; `from_value_expr` is a forbidden boundary — the safety walk keeps a typed union element from ever crossing to/from boxed).
- **B2** (infer) `record_array_shape_set`: 2..=8 **distinct** primitive shapes with **distinct key sets**; `shape_set_common_keys` = fields present with identical `type_canon` in every variant (a missing/type-divergent field keeps the array boxed → undefined/null preserved). Gated driver interns `TishAnonUnion_N`, emits `type … = Union([Object(s0),…])`, registers the common fields so numeric inference types the read.
- **B3** (codegen) `try_shape_union_alias` (reserved prefix → `ShapeUnion`, name known at alias-collection); `emit_named_struct_decls` emits per-variant structs + `enum TishUnion_N`; `emit_native_expr` selects the variant for an object literal by its key set; the indexed member read **and** the numeric type oracle (`expr_native_type`) lower `union[i].field` to the enum match returning the native field type (so `sum` stays native f64).

## Validation

| check | result |
|---|---|
| `TISH_SHAPE_UNION=1` strict gauntlet | **all 29 sound** (typed==boxed==node); megamorphic 485→~330ms (correct, not yet a win) |
| default (flag off) strict gauntlet | **24/29**, megamorphic boxed/unchanged, all sound |
| `cargo test --workspace` | **476 passed, 0 failed** |

This does **not** flip megamorphic yet: `objs.length` still boxes and the modulo is still boxed. **Stage C** (native `.length` on a `Vec<enum>` + constant-length integer modulo) lands the flip (~16ms in the hand-written spike) and flips `TISH_SHAPE_UNION` on by default.

Refs #179, #203.