### PR TITLE
perf(native): top-level loop counters as native locals, not thread_local Cell (#313)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -14565,7 +14565,234 @@ impl Codegen {
                 candidates.remove(&name);
             }
         }
+        // #313: a candidate referenced ONLY at top level (never inside a function/closure body) does
+        // NOT need the cross-call `thread_local Cell` — it can be a native `let mut` local in `run()`.
+        // Keeping it a TLS global forces every read/write in a tight top-level loop through
+        // `G_X.with(|c| …)` (numeric_loop's `s`/`i` counters). Demote such names so the normal
+        // numeric-local lowering emits `let mut _: f64`. Conservative: a name referenced in ANY fn
+        // body stays a TLS global (a fn can't see a `run()` local). `used_in_fn_body` over-approx.
+        candidates.retain(|name, _| Self::name_used_in_fn_body(stmts, name));
         candidates
+    }
+
+    /// #313: true iff `name` appears (as any identifier reference) inside SOME function or arrow-
+    /// function body. Conservative/over-approximating — used to decide whether a top-level numeric
+    /// binding must stay a `thread_local` global (referenced across calls) or may become a native
+    /// `run()` local (top-level-only). Complete over the AST so a missed fn-reference can't wrongly
+    /// demote a genuinely-shared global.
+    fn name_used_in_fn_body(stmts: &[Statement], name: &str) -> bool {
+        let mut found = false;
+        for s in stmts {
+            Self::scan_name_in_fns_stmt(s, name, false, &mut found);
+            if found {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn scan_name_in_fns_stmt(s: &Statement, name: &str, in_fn: bool, found: &mut bool) {
+        use Statement::*;
+        if *found {
+            return;
+        }
+        match s {
+            FunDecl { body, .. } => Self::scan_name_in_fns_stmt(body, name, true, found),
+            Block { statements, .. } | Multi { statements, .. } => {
+                statements
+                    .iter()
+                    .for_each(|x| Self::scan_name_in_fns_stmt(x, name, in_fn, found));
+            }
+            VarDecl { init: Some(e), .. } => Self::scan_name_in_fns_expr(e, name, in_fn, found),
+            VarDeclDestructure { init, .. } => Self::scan_name_in_fns_expr(init, name, in_fn, found),
+            ExprStmt { expr, .. } => Self::scan_name_in_fns_expr(expr, name, in_fn, found),
+            If { cond, then_branch, else_branch, .. } => {
+                Self::scan_name_in_fns_expr(cond, name, in_fn, found);
+                Self::scan_name_in_fns_stmt(then_branch, name, in_fn, found);
+                if let Some(e) = else_branch {
+                    Self::scan_name_in_fns_stmt(e, name, in_fn, found);
+                }
+            }
+            While { cond, body, .. } | DoWhile { cond, body, .. } => {
+                Self::scan_name_in_fns_expr(cond, name, in_fn, found);
+                Self::scan_name_in_fns_stmt(body, name, in_fn, found);
+            }
+            For { init, cond, update, body, .. } => {
+                if let Some(i) = init {
+                    Self::scan_name_in_fns_stmt(i, name, in_fn, found);
+                }
+                if let Some(c) = cond {
+                    Self::scan_name_in_fns_expr(c, name, in_fn, found);
+                }
+                if let Some(u) = update {
+                    Self::scan_name_in_fns_expr(u, name, in_fn, found);
+                }
+                Self::scan_name_in_fns_stmt(body, name, in_fn, found);
+            }
+            ForOf { iterable, body, .. } => {
+                Self::scan_name_in_fns_expr(iterable, name, in_fn, found);
+                Self::scan_name_in_fns_stmt(body, name, in_fn, found);
+            }
+            Return { value: Some(e), .. } | Throw { value: e, .. } => {
+                Self::scan_name_in_fns_expr(e, name, in_fn, found)
+            }
+            Switch { expr, cases, default_body, .. } => {
+                Self::scan_name_in_fns_expr(expr, name, in_fn, found);
+                for (t, b) in cases {
+                    if let Some(t) = t {
+                        Self::scan_name_in_fns_expr(t, name, in_fn, found);
+                    }
+                    b.iter()
+                        .for_each(|x| Self::scan_name_in_fns_stmt(x, name, in_fn, found));
+                }
+                if let Some(b) = default_body {
+                    b.iter()
+                        .for_each(|x| Self::scan_name_in_fns_stmt(x, name, in_fn, found));
+                }
+            }
+            Try { body, catch_body, finally_body, .. } => {
+                Self::scan_name_in_fns_stmt(body, name, in_fn, found);
+                if let Some(b) = catch_body {
+                    Self::scan_name_in_fns_stmt(b, name, in_fn, found);
+                }
+                if let Some(b) = finally_body {
+                    Self::scan_name_in_fns_stmt(b, name, in_fn, found);
+                }
+            }
+            Export { declaration, .. } => match declaration.as_ref() {
+                tishlang_ast::ExportDeclaration::Named(inner) => {
+                    Self::scan_name_in_fns_stmt(inner, name, in_fn, found)
+                }
+                tishlang_ast::ExportDeclaration::Default(e) => {
+                    Self::scan_name_in_fns_expr(e, name, in_fn, found)
+                }
+                tishlang_ast::ExportDeclaration::ReExport { .. } => {}
+            },
+            _ => {}
+        }
+    }
+
+    fn scan_name_in_fns_expr(e: &Expr, name: &str, in_fn: bool, found: &mut bool) {
+        use Expr::*;
+        if *found {
+            return;
+        }
+        match e {
+            Ident { name: n, .. } => {
+                if in_fn && n.as_ref() == name {
+                    *found = true;
+                }
+            }
+            ArrowFunction { body, .. } => match body {
+                tishlang_ast::ArrowBody::Expr(x) => {
+                    Self::scan_name_in_fns_expr(x, name, true, found)
+                }
+                tishlang_ast::ArrowBody::Block(s) => {
+                    Self::scan_name_in_fns_stmt(s, name, true, found)
+                }
+            },
+            Binary { left, right, .. } | NullishCoalesce { left, right, .. } => {
+                Self::scan_name_in_fns_expr(left, name, in_fn, found);
+                Self::scan_name_in_fns_expr(right, name, in_fn, found);
+            }
+            Unary { operand, .. } | TypeOf { operand, .. } | Await { operand, .. }
+            | Delete { target: operand, .. } => {
+                Self::scan_name_in_fns_expr(operand, name, in_fn, found)
+            }
+            Assign { name: n, value, .. }
+            | CompoundAssign { name: n, value, .. }
+            | LogicalAssign { name: n, value, .. } => {
+                if in_fn && n.as_ref() == name {
+                    *found = true;
+                }
+                Self::scan_name_in_fns_expr(value, name, in_fn, found);
+            }
+            PostfixInc { name: n, .. } | PostfixDec { name: n, .. } | PrefixInc { name: n, .. }
+            | PrefixDec { name: n, .. } => {
+                if in_fn && n.as_ref() == name {
+                    *found = true;
+                }
+            }
+            Call { callee, args, .. } | New { callee, args, .. } => {
+                Self::scan_name_in_fns_expr(callee, name, in_fn, found);
+                for a in args {
+                    if let CallArg::Expr(x) | CallArg::Spread(x) = a {
+                        Self::scan_name_in_fns_expr(x, name, in_fn, found);
+                    }
+                }
+            }
+            Member { object, prop, .. } => {
+                Self::scan_name_in_fns_expr(object, name, in_fn, found);
+                if let MemberProp::Expr(p) = prop {
+                    Self::scan_name_in_fns_expr(p, name, in_fn, found);
+                }
+            }
+            Index { object, index, .. } => {
+                Self::scan_name_in_fns_expr(object, name, in_fn, found);
+                Self::scan_name_in_fns_expr(index, name, in_fn, found);
+            }
+            Conditional { cond, then_branch, else_branch, .. } => {
+                Self::scan_name_in_fns_expr(cond, name, in_fn, found);
+                Self::scan_name_in_fns_expr(then_branch, name, in_fn, found);
+                Self::scan_name_in_fns_expr(else_branch, name, in_fn, found);
+            }
+            Array { elements, .. } => {
+                for el in elements {
+                    if let ArrayElement::Expr(x) | ArrayElement::Spread(x) = el {
+                        Self::scan_name_in_fns_expr(x, name, in_fn, found);
+                    }
+                }
+            }
+            Object { props, .. } => {
+                for p in props {
+                    match p {
+                        ObjectProp::KeyValue(_, v, _) => {
+                            Self::scan_name_in_fns_expr(v, name, in_fn, found)
+                        }
+                        ObjectProp::Spread(x) => Self::scan_name_in_fns_expr(x, name, in_fn, found),
+                    }
+                }
+            }
+            MemberAssign { object, value, .. } => {
+                Self::scan_name_in_fns_expr(object, name, in_fn, found);
+                Self::scan_name_in_fns_expr(value, name, in_fn, found);
+            }
+            IndexAssign { object, index, value, .. } => {
+                Self::scan_name_in_fns_expr(object, name, in_fn, found);
+                Self::scan_name_in_fns_expr(index, name, in_fn, found);
+                Self::scan_name_in_fns_expr(value, name, in_fn, found);
+            }
+            TemplateLiteral { exprs, .. } => exprs
+                .iter()
+                .for_each(|x| Self::scan_name_in_fns_expr(x, name, in_fn, found)),
+            JsxElement { props, children, .. } => {
+                for prop in props {
+                    match prop {
+                        tishlang_ast::JsxProp::Attr { value, .. } => {
+                            if let tishlang_ast::JsxAttrValue::Expr(x) = value {
+                                Self::scan_name_in_fns_expr(x, name, in_fn, found);
+                            }
+                        }
+                        tishlang_ast::JsxProp::Spread(x) => {
+                            Self::scan_name_in_fns_expr(x, name, in_fn, found)
+                        }
+                    }
+                }
+                for c in children {
+                    if let tishlang_ast::JsxChild::Expr(x) = c {
+                        Self::scan_name_in_fns_expr(x, name, in_fn, found);
+                    }
+                }
+            }
+            JsxFragment { children, .. } => {
+                for c in children {
+                    if let tishlang_ast::JsxChild::Expr(x) = c {
+                        Self::scan_name_in_fns_expr(x, name, in_fn, found);
+                    }
+                }
+            }
+            _ => {}
+        }
     }
 
     /// Disqualifying uses: compound/logical assign, inc/dec, member/index/call on the global name.

--- a/crates/tish_compile/src/lib.rs
+++ b/crates/tish_compile/src/lib.rs
@@ -98,10 +98,10 @@ fn count(): number {
 
     #[test]
     fn loop_var_decl_clone_outer_var() {
-        // outerVar = 42 is inferred as f64. With the native typed-codegen optimizations on by
-        // default, a top-level numeric global lives in a `thread_local Cell<f64>` (#176) rather than
-        // a `run()`-local slot; the read `let x = outerVar` loads it as a Copy f64 (no clone). The
-        // test verifies compilation succeeds with both lowered natively.
+        // outerVar = 42 is inferred as f64. Per #313, a top-level numeric used ONLY at top level
+        // (never inside a function/closure body) is a native `run()`-local `let mut _: f64`, NOT a
+        // `thread_local Cell<f64>` — the Cell is reserved for globals a function reads across calls
+        // (e.g. fasta's `seed`). The read `let x = outerVar` loads it as a Copy f64.
         let src = r#"
 let outerVar = 42
 for (let i = 0; i < 5; i = i + 1) {
@@ -110,10 +110,14 @@ for (let i = 0; i < 5; i = i + 1) {
 "#;
         let program = parse(src).unwrap();
         let rust = compile(&program).unwrap();
-        // outerVar is a native numeric global (Cell<f64>); x reads it as a Copy f64.
+        // outerVar is a native f64 local (no TLS Cell, since no function references it); x reads it.
         assert!(
-            rust.contains("G_OUTERVAR") && rust.contains("Cell<f64>"),
-            "expected outerVar as a native Cell<f64> global"
+            rust.contains("let mut outerVar: f64"),
+            "expected outerVar as a native f64 local (#313)"
+        );
+        assert!(
+            !rust.contains("G_OUTERVAR"),
+            "outerVar must NOT be a thread_local Cell global — it is top-level-only (#313)"
         );
         assert!(rust.contains("let mut x: f64"), "expected x: f64");
     }

--- a/crates/tish_compile/tests/perf_codegen_174.rs
+++ b/crates/tish_compile/tests/perf_codegen_174.rs
@@ -131,12 +131,13 @@ let m = n & 7
 console.log(m >>> 0)
 "#;
     let rust = compile(&parse(src).unwrap()).unwrap();
-    // `n` is a top-level numeric global, so with the typing stack on by default its read lowers to a
-    // `Cell<f64>` load `G_N.with(|c| c.get())`. The unproven fractional value must STILL pass through
-    // the guarded `to_int32` (not an unchecked truncation) before the `& 7` mask.
+    // `n` is a top-level numeric used only at top level, so per #313 it is a native `let mut n: f64`
+    // local (not a `thread_local Cell` — no function references it). The soundness invariant is
+    // unchanged: the unproven fractional value must STILL pass through the guarded `to_int32` (not an
+    // unchecked truncation) before the `& 7` mask.
     assert!(
-        rust.contains("tishlang_runtime::to_int32(G_N.with(|c| c.get())) & 7i32"),
-        "an unproven f64 global leaf must keep the guarded to_int32 before the mask:\n{}",
+        rust.contains("tishlang_runtime::to_int32(n) & 7i32"),
+        "an unproven f64 leaf must keep the guarded to_int32 before the mask:\n{}",
         rust.lines().filter(|l| l.contains("& ") || l.contains("to_int")).take(6).collect::<Vec<_>>().join("\n")
     );
     // The literal `7` still folds; only the unproven `n` keeps the guard.


### PR DESCRIPTION
## What

Closes #313 (a #176 follow-up). Top-level numeric bindings used **only** at top level now lower to native `let mut _: f64` locals in `run()` instead of `thread_local Cell<f64>` globals.

`#176` lowers reassigned top-level numerics to a `thread_local Cell<f64>` so functions can share them across calls — correct for fasta's `seed`. But it over-applied to top-level-only bindings: numeric_loop's `while (i < n) { s = s + i*2 - 1; i = i + 1 }` emitted `G_S.with(|c| get/set)` **per iteration** instead of native locals. This hurts any real-world top-level numeric loop, not just the fixture.

## How

A top-level numeric candidate that is **not referenced inside any function/closure body** is demoted from the TLS-global set, so the normal numeric-local lowering emits `let mut _: f64`. The `name_used_in_fn_body` check is complete over the AST and **conservative** — a name referenced in any function body stays a TLS global (a function can't see a `run()` local):

- fasta's `seed` (used in `genRandom`) → **keeps** `G_SEED` ✓
- `native_numeric_global`'s `counter` (used in `bump`/`read`) → **keeps** `G_COUNTER` ✓
- numeric_loop's `s`/`i`/`n` (top-level only) → native `let mut _: f64` ✓

## Validation

| check | result |
|---|---|
| numeric_loop | `s`/`i` now native `let mut: f64` (no per-iter `G_*.with`), 47→44ms, checksum identical |
| full `--strict` gauntlet | **25/29**, all 29 sound (typed==boxed==node); fasta/native_numeric_global TLS preserved |
| `cargo test --workspace` | **476 passed, 0 failed** |

Two tests that codified the old TLS-Cell lowering for a top-level-only var are updated; the #174 soundness invariant (guarded `to_int32` on an unproven fractional leaf) is unchanged — only `G_N.with()` → native `n`.

Closes #313. Refs #203.