### PR TITLE
fix(parser,core): catchable errors for deep nesting + cyclic JSON/string (#381)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3457,6 +3457,7 @@ dependencies = [
 name = "tishlang_parser"
 version = "0.1.0"
 dependencies = [
+ "stacker",
  "tishlang_ast",
  "tishlang_lexer",
 ]

--- a/crates/tish_core/src/json.rs
+++ b/crates/tish_core/src/json.rs
@@ -112,7 +112,31 @@ pub fn json_stringify(value: &Value) -> String {
 /// Append a JSON-stringified `value` to `buf`. Used by JSON.stringify for
 /// the recursive case so we don't pay for an intermediate `String` per
 /// node.
+///
+/// Cyclic object graphs (`a.self = a`) are detected and — matching JS, which throws
+/// `TypeError: Converting circular structure to JSON` — set a pending throw and emit `null` for the
+/// back-reference instead of recursing forever (#381: this was an unrecoverable thread hang, directly
+/// reachable from HTTP response serialization).
 pub fn json_stringify_into(buf: &mut String, value: &Value) {
+    // Track the CURRENT ancestor path only (not all-visited): a node repeated across sibling branches
+    // is a legal DAG and must serialize twice; only a back-edge to an ancestor is a cycle.
+    let mut ancestors: Vec<*const ()> = Vec::new();
+    json_stringify_into_guarded(buf, value, &mut ancestors);
+}
+
+/// Set the JS "circular structure" TypeError as the pending throw (once) — mirrors the
+/// `{ error: <msg> }` shape `tish_builtins::helpers::make_error_value` produces (that crate sits above
+/// this one, so the shape is reproduced here rather than imported).
+fn signal_circular_json_throw() {
+    if !crate::has_pending_throw() {
+        crate::set_pending_throw(Value::object_from_pairs([(
+            std::sync::Arc::from("error"),
+            Value::String("TypeError: Converting circular structure to JSON".into()),
+        )]));
+    }
+}
+
+fn json_stringify_into_guarded(buf: &mut String, value: &Value, ancestors: &mut Vec<*const ()>) {
     match value {
         Value::Null => buf.push_str("null"),
         Value::Bool(true) => buf.push_str("true"),
@@ -124,15 +148,24 @@ pub fn json_stringify_into(buf: &mut String, value: &Value) {
             buf.push('"');
         }
         Value::Array(arr) => {
+            let ptr = arr.as_ptr();
+            if ancestors.contains(&ptr) {
+                signal_circular_json_throw();
+                buf.push_str("null");
+                return;
+            }
+            ancestors.push(ptr);
             let borrowed = arr.borrow();
             buf.push('[');
             for (i, item) in borrowed.iter().enumerate() {
                 if i > 0 {
                     buf.push(',');
                 }
-                json_stringify_into(buf, item);
+                json_stringify_into_guarded(buf, item, ancestors);
             }
             buf.push(']');
+            drop(borrowed);
+            ancestors.pop();
         }
         Value::NumberArray(arr) => {
             let borrowed = arr.borrow();
@@ -146,6 +179,13 @@ pub fn json_stringify_into(buf: &mut String, value: &Value) {
             buf.push(']');
         }
         Value::Object(obj) => {
+            let ptr = obj.as_ptr();
+            if ancestors.contains(&ptr) {
+                signal_circular_json_throw();
+                buf.push_str("null");
+                return;
+            }
+            ancestors.push(ptr);
             let borrowed = obj.borrow();
             // Iterate in insertion order (PropMap preserves it) — matches JS/Node
             // and `Object.keys`. No intermediate key Vec, no sort: one fewer
@@ -158,9 +198,11 @@ pub fn json_stringify_into(buf: &mut String, value: &Value) {
                 buf.push('"');
                 escape_json_string_into(buf, key);
                 buf.push_str("\":");
-                json_stringify_into(buf, val);
+                json_stringify_into_guarded(buf, val, ancestors);
             }
             buf.push('}');
+            drop(borrowed);
+            ancestors.pop();
         }
         Value::Function(_) | Value::Promise(_) | Value::Opaque(_) | Value::Symbol(_) => {
             buf.push_str("null");
@@ -497,6 +539,34 @@ fn parse_object<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #381: a self-referential array must NOT loop forever — `JSON.stringify` terminates, emits a
+    /// finite string, and (matching JS) leaves a pending TypeError. The test *completing* is itself
+    /// the assertion that the former infinite hang is gone.
+    #[test]
+    fn json_stringify_cyclic_array_terminates_and_throws() {
+        let _ = crate::take_pending_throw(); // isolate from any prior thread-local throw
+        let a = Value::Array(crate::VmRef::new(Vec::new()));
+        if let Value::Array(inner) = &a {
+            inner.borrow_mut().push(a.clone()); // a = [a]
+        }
+        let s = json_stringify(&a);
+        assert_eq!(s, "[null]", "back-reference serializes as null, finite output");
+        assert!(crate::has_pending_throw(), "cyclic stringify must set a pending TypeError");
+        let _ = crate::take_pending_throw(); // clean up thread-local for other tests
+    }
+
+    /// A shared (non-cyclic) node repeated across sibling branches is a legal DAG and must serialize
+    /// twice — the ancestor-only tracking must NOT misflag it as a cycle.
+    #[test]
+    fn json_stringify_shared_dag_node_is_not_a_cycle() {
+        let _ = crate::take_pending_throw();
+        let shared = Value::Array(crate::VmRef::new(vec![Value::Number(1.0)]));
+        let root = Value::Array(crate::VmRef::new(vec![shared.clone(), shared.clone()]));
+        let s = json_stringify(&root);
+        assert_eq!(s, "[[1],[1]]", "a shared node is a DAG, not a cycle");
+        assert!(!crate::has_pending_throw(), "a DAG must NOT throw");
+    }
 
     #[test]
     fn test_parse_primitives() {

--- a/crates/tish_core/src/value.rs
+++ b/crates/tish_core/src/value.rs
@@ -1268,6 +1268,14 @@ pub fn js_number_to_string_into(out: &mut String, value: f64) {
 impl Value {
     /// Convert value to display string (for console output).
     pub fn to_display_string(&self) -> String {
+        self.to_display_string_guarded(&mut Vec::new())
+    }
+
+    /// Cycle-safe recursive form (#381): `ancestors` holds the current path's container-cell pointers,
+    /// so a self-referential array/object (`a.self = a`) renders `[Circular]` instead of recursing
+    /// forever and wedging the thread. Ancestor-only (not all-visited), so a shared DAG node still
+    /// renders in full.
+    fn to_display_string_guarded(&self, ancestors: &mut Vec<*const ()>) -> String {
         match self {
             // Inspect form keeps the sign of negative zero (`console.log(-0)` → `-0`), unlike the
             // ECMAScript ToString used by `to_js_string`. See `js_number_to_string`. (#247)
@@ -1277,8 +1285,17 @@ impl Value {
             Value::Bool(b) => b.to_string(),
             Value::Null => "null".to_string(),
             Value::Array(arr) => {
-                let inner: Vec<String> =
-                    arr.borrow().iter().map(|v| v.to_display_string()).collect();
+                let ptr = arr.as_ptr();
+                if ancestors.contains(&ptr) {
+                    return "[Circular]".to_string();
+                }
+                ancestors.push(ptr);
+                let inner: Vec<String> = arr
+                    .borrow()
+                    .iter()
+                    .map(|v| v.to_display_string_guarded(ancestors))
+                    .collect();
+                ancestors.pop();
                 format!("[{}]", inner.join(", "))
             }
             Value::NumberArray(arr) => {
@@ -1290,12 +1307,18 @@ impl Value {
                 format!("[{}]", inner.join(", "))
             }
             Value::Object(obj) => {
+                let ptr = obj.as_ptr();
+                if ancestors.contains(&ptr) {
+                    return "[Circular]".to_string();
+                }
+                ancestors.push(ptr);
                 let inner: Vec<String> = obj
                     .borrow()
                     .strings
                     .iter()
-                    .map(|(k, v)| format!("{}: {}", k.as_ref(), v.to_display_string()))
+                    .map(|(k, v)| format!("{}: {}", k.as_ref(), v.to_display_string_guarded(ancestors)))
                     .collect();
+                ancestors.pop();
                 format!("{{{}}}", inner.join(", "))
             }
             Value::Symbol(s) => {
@@ -1325,16 +1348,32 @@ impl Value {
     /// renders as `"null"` here (matching `String(null)`); `join` itself maps `null`/`undefined`
     /// elements to `""` *before* calling this, per the spec.
     pub fn to_js_string(&self) -> String {
+        self.to_js_string_guarded(&mut Vec::new())
+    }
+
+    /// Cycle-safe `ToString` (#381): only arrays recurse here (objects render `[object Object]`), so a
+    /// cyclic array via `"" + a` would otherwise hang. A back-reference joins as `""` — matching V8's
+    /// `Array.prototype.join`, where a self-referential element contributes the empty string.
+    fn to_js_string_guarded(&self, ancestors: &mut Vec<*const ()>) -> String {
         match self {
-            Value::Array(arr) => arr
-                .borrow()
-                .iter()
-                .map(|v| match v {
-                    Value::Null => String::new(),
-                    other => other.to_js_string(),
-                })
-                .collect::<Vec<_>>()
-                .join(","),
+            Value::Array(arr) => {
+                let ptr = arr.as_ptr();
+                if ancestors.contains(&ptr) {
+                    return String::new();
+                }
+                ancestors.push(ptr);
+                let s = arr
+                    .borrow()
+                    .iter()
+                    .map(|v| match v {
+                        Value::Null => String::new(),
+                        other => other.to_js_string_guarded(ancestors),
+                    })
+                    .collect::<Vec<_>>()
+                    .join(",");
+                ancestors.pop();
+                s
+            }
             Value::NumberArray(arr) => arr
                 .borrow()
                 .iter()
@@ -1709,6 +1748,50 @@ mod number_to_string_tests {
         for &(value, expected) in cases {
             assert_eq!(js_number_to_string(value), expected, "for {value:?}");
         }
+    }
+}
+
+#[cfg(test)]
+mod cycle_coercion_tests_381 {
+    //! #381: string-coercing a cyclic array/object must terminate (was a silent thread hang),
+    //! matching Node — `console.log`/inspect renders `[Circular]`, `"" + a` renders the back-ref as
+    //! the empty string via `Array.prototype.join`.
+    use super::Value;
+    use crate::VmRef;
+
+    #[test]
+    fn display_string_cyclic_array_terminates() {
+        let a = Value::Array(VmRef::new(Vec::new()));
+        if let Value::Array(inner) = &a {
+            inner.borrow_mut().push(a.clone()); // a = [a]
+        }
+        assert_eq!(a.to_display_string(), "[[Circular]]");
+    }
+
+    #[test]
+    fn js_string_cyclic_array_terminates() {
+        let a = Value::Array(VmRef::new(Vec::new()));
+        if let Value::Array(inner) = &a {
+            inner.borrow_mut().push(a.clone());
+        }
+        // Node: `let a=[]; a.push(a); "" + a` === "" (the self-referential element joins as "").
+        assert_eq!(a.to_js_string(), "");
+    }
+
+    #[test]
+    fn display_string_cyclic_object_terminates() {
+        let o = Value::object_from_pairs([]);
+        if let Value::Object(inner) = &o {
+            inner.borrow_mut().strings.insert(std::sync::Arc::from("self"), o.clone());
+        }
+        assert_eq!(o.to_display_string(), "{self: [Circular]}");
+    }
+
+    #[test]
+    fn display_string_shared_dag_is_not_circular() {
+        let shared = Value::Array(VmRef::new(vec![Value::Number(1.0)]));
+        let root = Value::Array(VmRef::new(vec![shared.clone(), shared.clone()]));
+        assert_eq!(root.to_display_string(), "[[1], [1]]", "a shared node is a DAG, not a cycle");
     }
 }
 

--- a/crates/tish_core/src/vmref.rs
+++ b/crates/tish_core/src/vmref.rs
@@ -91,6 +91,13 @@ mod imp {
             Rc::ptr_eq(&a.0, &b.0)
         }
 
+        /// A stable identity pointer for this cell, for cycle detection (#381) — two `VmRef`s share it
+        /// iff `ptr_eq`. Not for dereference; only for identity comparison / hashing.
+        #[inline]
+        pub fn as_ptr(&self) -> *const () {
+            Rc::as_ptr(&self.0) as *const ()
+        }
+
         #[inline]
         pub fn strong_count(this: &Self) -> usize {
             Rc::strong_count(&this.0)
@@ -150,6 +157,13 @@ mod imp {
         #[inline]
         pub fn ptr_eq(a: &Self, b: &Self) -> bool {
             Arc::ptr_eq(&a.0, &b.0)
+        }
+
+        /// A stable identity pointer for this cell, for cycle detection (#381) — two `VmRef`s share it
+        /// iff `ptr_eq`. Not for dereference; only for identity comparison / hashing.
+        #[inline]
+        pub fn as_ptr(&self) -> *const () {
+            Arc::as_ptr(&self.0) as *const ()
         }
 
         #[inline]

--- a/crates/tish_parser/Cargo.toml
+++ b/crates/tish_parser/Cargo.toml
@@ -9,3 +9,7 @@ repository = { workspace = true }
 [dependencies]
 tishlang_lexer = { path = "../tish_lexer", version = ">=0.1" }
 tishlang_ast = { path = "../tish_ast", version = ">=0.1" }
+# #381: grow the stack on demand during the recursive descent so deeply-nested source can't overflow
+# the fixed OS thread stack before the MAX_PARSE_DEPTH bound converts it into a catchable error.
+# (No-op shim on wasm32, matching tish_eval / tish_vm.)
+stacker = "0.1"

--- a/crates/tish_parser/src/lib.rs
+++ b/crates/tish_parser/src/lib.rs
@@ -33,6 +33,33 @@ mod tests {
     use super::*;
     use tishlang_ast::{CallArg, Expr, ObjectProp, Statement};
 
+    /// #381: pathologically nested source must return a catchable `Err`, NOT overflow the native
+    /// stack and abort the process. Exercises expression nesting (`((((…`), array nesting (`[[[[…`),
+    /// and prefix-op nesting (`-!-!…`) — all funnel through the depth-guarded `parse_unary`.
+    #[test]
+    fn deeply_nested_source_errors_instead_of_aborting() {
+        let n = 50_000;
+        for (open, close) in [("(", ")"), ("[", "]")] {
+            let src = format!("let x = {}1{}", open.repeat(n), close.repeat(n));
+            let r = parse(&src);
+            assert!(r.is_err(), "{n}× nested {open} should be a catchable Err, not an abort");
+            assert!(
+                r.unwrap_err().contains("nesting too deep"),
+                "expected a depth-limit error"
+            );
+        }
+        let prefix = format!("let x = {}1", "-".repeat(n));
+        assert!(parse(&prefix).is_err(), "deep prefix-op chain should error, not abort");
+    }
+
+    /// The depth guard must not reject ordinary, modestly-nested code.
+    #[test]
+    fn normal_nesting_still_parses() {
+        assert!(parse("let x = ((((1 + 2))))").is_ok());
+        assert!(parse("let y = [[1, 2], [3, [4, [5]]]]").is_ok());
+        assert!(parse("fn f() { if (a) { if (b) { return 1 } } }").is_ok());
+    }
+
     #[test]
     fn test_async_fn_parse() {
         let program = parse("async fn foo() { }").expect("parse async fn");

--- a/crates/tish_parser/src/parser.rs
+++ b/crates/tish_parser/src/parser.rs
@@ -123,7 +123,16 @@ pub struct Parser<'a> {
     generic_specializations: Vec<Statement>,
     /// Names of specializations already generated (dedup).
     generic_done: HashSet<String>,
+    /// Current recursion depth of the expression/statement descent, bounded by [`MAX_PARSE_DEPTH`] so
+    /// pathologically nested untrusted source (`((((…`, `[[[[…`, `{{{{…`, `-!-!…`) returns a CATCHABLE
+    /// parse error instead of overflowing the native stack and aborting the whole process (#381).
+    depth: usize,
 }
+
+/// Maximum expression/statement nesting the parser will descend before returning a catchable error.
+/// Deep enough for any realistic hand-written or generated source; shallow enough that the descent
+/// stays well within the OS thread stack. Mirrors `MAX_JSON_DEPTH` in the JSON parser.
+const MAX_PARSE_DEPTH: usize = 1024;
 
 impl<'a> Parser<'a> {
     pub fn new(tokens: &'a [Token]) -> Self {
@@ -134,7 +143,23 @@ impl<'a> Parser<'a> {
             generic_aliases: HashMap::new(),
             generic_specializations: Vec::new(),
             generic_done: HashSet::new(),
+            depth: 0,
         }
+    }
+
+    /// Enter one level of recursive descent. Returns a catchable `Err` (never a panic/abort) once the
+    /// nesting exceeds [`MAX_PARSE_DEPTH`]. Pair every `Ok(())` return with a matching `self.depth -=
+    /// 1` on the way out (the `parse_unary`/`parse_statement` wrappers do this unconditionally). #381
+    fn enter_depth(&mut self) -> Result<(), String> {
+        self.depth += 1;
+        if self.depth > MAX_PARSE_DEPTH {
+            self.depth -= 1;
+            return Err(format!(
+                "parse error: nesting too deep (exceeded {} levels)",
+                MAX_PARSE_DEPTH
+            ));
+        }
+        Ok(())
     }
 
     /// Close one generic-arg `>`: use a previously-split `>>` debt, consume a `>`, or split a
@@ -259,7 +284,16 @@ impl<'a> Parser<'a> {
         Ok(Program { statements })
     }
 
+    /// Depth-guarded wrapper (#381): bounds block/statement nesting (`{{{{…`, `if(x){if(x){…`) so a
+    /// crafted deeply-nested program returns a catchable error instead of a stack-overflow abort.
     fn parse_statement(&mut self) -> Result<Statement, String> {
+        self.enter_depth()?;
+        let r = stacker::maybe_grow(64 * 1024, 512 * 1024, || self.parse_statement_inner());
+        self.depth -= 1;
+        r
+    }
+
+    fn parse_statement_inner(&mut self) -> Result<Statement, String> {
         let kind = self.peek_kind().ok_or("Unexpected EOF")?;
         let span_start = self.peek().map(|t| t.span.start).unwrap_or((0, 0));
 
@@ -1968,7 +2002,19 @@ impl<'a> Parser<'a> {
         Ok(left)
     }
 
+    /// Depth-guarded wrapper (#381): every expression operand and every nested `(…)`/`[…]`/`{…}`/
+    /// prefix-op re-enters `parse_unary`, so bounding it here bounds all expression nesting. The
+    /// `-= 1` runs on both the `Ok` and `Err` paths, keeping the counter balanced.
     fn parse_unary(&mut self) -> Result<Expr, String> {
+        self.enter_depth()?;
+        // Grow the stack on demand (each nesting level costs a whole precedence-chain of frames), so
+        // we reach the MAX_PARSE_DEPTH bound and return a catchable error rather than overflowing.
+        let r = stacker::maybe_grow(64 * 1024, 512 * 1024, || self.parse_unary_inner());
+        self.depth -= 1;
+        r
+    }
+
+    fn parse_unary_inner(&mut self) -> Result<Expr, String> {
         // Handle prefix ++/-- (consolidated)
         if let Some(is_inc) = match self.peek_kind() {
             Some(TokenKind::PlusPlus) => Some(true),


### PR DESCRIPTION
Resolves 3 of the 4 sub-items of #381 (the process-abort / infinite-hang DoS umbrella). Each vector removes a worker on the HTTP request path where Node throws a catchable error and continues.

## Fixes

**1. Parser recursion-depth guard.** Deeply nested source (~600 bytes) overflowed the native stack and `SIGABRT`'d the whole process. Added a `MAX_PARSE_DEPTH` bound (a catchable `Err`) around `parse_unary`/`parse_statement`, plus `stacker::maybe_grow` so the descent reaches the bound instead of overflowing first (each nesting level costs a whole precedence-chain of frames). 50k-deep `(((…`/`[[[…`/`-!-!…` now returns a catchable error.

**2. JSON.stringify cycle detection.** A cyclic graph (`a.self = a`) recursed forever — a silent thread wedge reachable from HTTP response serialization. Added ancestor-based detection: a back-edge emits `null` and sets a pending `TypeError` (matching JS `Converting circular structure to JSON`); a shared **DAG** node still serializes in full.

**3. String-coercion cycle detection.** `to_display_string` / `to_js_string` of a cyclic array/object looped forever. Same ancestor tracking: `console`/inspect renders `[Circular]`; `"" + a` renders the back-reference as the empty string (matching V8's `Array.prototype.join`).

Adds `VmRef::as_ptr()` for cycle-detection identity.

## Verification

Tests cover deep-nesting rejection (vs abort), cyclic-vs-DAG stringify, and cyclic string coercion. `tishlang_parser` and `tishlang_core` suites green.

## Remaining sub-item (follow-up)

Unbounded recursion → catchable `RangeError` (instead of a stack-overflow abort) needs a runtime call-depth counter threaded through the interpreter/VM call boundary — a larger semantic change left for its own PR. #381 stays open to track it.
