### PR TITLE
fix(runtime): drain handler-scheduled timers in the HTTP serve loop (#384)

### DIFF
--- a/crates/tish_runtime/src/http.rs
+++ b/crates/tish_runtime/src/http.rs
@@ -1110,16 +1110,30 @@ where
     drop(tx);
 
     let mut count = 0usize;
-    while let Ok((req_prim, resp_tx)) = rx.recv() {
-        let req_value = req_prim.into_value();
-        let response_value = handler.call(&[req_value]);
-        let resp_prim = ResponsePrimitive::from_value(&response_value);
-        let _ = resp_tx.send(resp_prim);
+    // #384: `recv_timeout` (not a blocking `recv`) so a handler's scheduled timers still fire when the
+    // server is idle. Handler calls all run on this single VM thread, so the timer registry is here.
+    loop {
+        match rx.recv_timeout(Duration::from_millis(250)) {
+            Ok((req_prim, resp_tx)) => {
+                let req_value = req_prim.into_value();
+                let response_value = handler.call(&[req_value]);
+                crate::timers::drain_timers();
+                let resp_prim = ResponsePrimitive::from_value(&response_value);
+                let _ = resp_tx.send(resp_prim);
 
-        count += 1;
-        if max_requests.map(|m| count >= m).unwrap_or(false) {
-            stop.store(true, Ordering::Relaxed);
-            break;
+                count += 1;
+                if max_requests.map(|m| count >= m).unwrap_or(false) {
+                    stop.store(true, Ordering::Relaxed);
+                    break;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                crate::timers::drain_timers();
+                if stop.load(Ordering::Relaxed) {
+                    break;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
         }
     }
 
@@ -1181,6 +1195,10 @@ fn worker_loop_direct(
             Ok(None) => {} // timeout; re-check stop flag
             Err(_) => break,
         }
+        // #384: fire any timers a handler scheduled. The handler runs on this accept thread, so its
+        // `setTimeout`/`setInterval` callbacks live in this thread's registry; the ≤250ms `recv_timeout`
+        // above means they fire within that window even when no new requests arrive.
+        crate::timers::drain_timers();
     }
 }
 


### PR DESCRIPTION
Resolves the timer-drain strand of #384 (the live-timer cap landed in #394).

## Problem

`setTimeout`/`setInterval` scheduled from an HTTP handler **never fired**. The timer registry is thread-local, and neither serve loop ever called `run_due_timers` on the handler's thread — so a handler that scheduled deferred work (cleanup, metrics flush, retries) silently did nothing.

## Fix

Drain timers in both serve loops, on the handler's thread:
- **`worker_loop_direct`** (the `send-values` path — the default `serve()`): drain once per loop iteration. Its existing `recv_timeout(250ms)` means a handler's timer fires within ≤250ms even when the server is idle.
- **the mpsc VM-thread dispatch loop** (non-`send-values`): switch the blocking `rx.recv()` to `recv_timeout(250ms)` so idle ticks fire due timers too, and drain after each handler call.

`drain_timers()` over an empty registry is a cheap thread-local check, so the no-timers hot path is unaffected.

## Verification

End-to-end: a server whose handler does `setTimeout(() => console.log("…"), 30)` now logs the callback — confirmed for both single-process and prefork (multi-process) modes. Both HTTP feature configs (`http`, `http,send-values`) build and test green.

## Remaining #384 items (follow-up)

Per-build temp-dir cleanup + the output-basename build-cache collision, and an `execFile`-style argv exec API.
