### PR TITLE
feat(process): add process.execFile — safe non-shell exec (#384)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1613,9 +1613,10 @@ impl Codegen {
                     "exit" => Some("Value::native(|args: &[Value]| tish_process_exit(args))"),
                     "cwd" => Some("Value::native(|args: &[Value]| tish_process_cwd(args))"),
                     "exec" => Some("Value::native(|args: &[Value]| tish_process_exec(args))"),
+                    "execFile" => Some("Value::native(|args: &[Value]| tish_process_exec_file(args))"),
                     "argv" => Some("Value::Array(VmRef::new(std::env::args().map(|s| Value::String(s.into())).collect()))"),
                     "env" => Some("Value::object(std::env::vars().map(|(k,v)| (Arc::from(k.as_str()), Value::String(v.into()))).collect())"),
-                    "process" => Some("{ let mut m = ObjectMap::default(); m.insert(Arc::from(\"exit\"), Value::native(|args: &[Value]| tish_process_exit(args))); m.insert(Arc::from(\"cwd\"), Value::native(|args: &[Value]| tish_process_cwd(args))); m.insert(Arc::from(\"exec\"), Value::native(|args: &[Value]| tish_process_exec(args))); m.insert(Arc::from(\"argv\"), Value::Array(VmRef::new(std::env::args().map(|s| Value::String(s.into())).collect()))); m.insert(Arc::from(\"env\"), Value::object(std::env::vars().map(|(k,v)| (Arc::from(k.as_str()), Value::String(v.into()))).collect::<ObjectMap>())); Value::object(m) }"),
+                    "process" => Some("{ let mut m = ObjectMap::default(); m.insert(Arc::from(\"exit\"), Value::native(|args: &[Value]| tish_process_exit(args))); m.insert(Arc::from(\"cwd\"), Value::native(|args: &[Value]| tish_process_cwd(args))); m.insert(Arc::from(\"exec\"), Value::native(|args: &[Value]| tish_process_exec(args))); m.insert(Arc::from(\"execFile\"), Value::native(|args: &[Value]| tish_process_exec_file(args))); m.insert(Arc::from(\"argv\"), Value::Array(VmRef::new(std::env::args().map(|s| Value::String(s.into())).collect()))); m.insert(Arc::from(\"env\"), Value::object(std::env::vars().map(|(k,v)| (Arc::from(k.as_str()), Value::String(v.into()))).collect::<ObjectMap>())); Value::object(m) }"),
                     _ => None,
                 },
             "tish:ws" if self.has_feature("ws") => match export_name {
@@ -2169,7 +2170,7 @@ impl Codegen {
             self.write("use tishlang_ui::{fragment_value, install_thread_local_host, native_create_root, native_use_state, ui_h, ui_text, HeadlessHost};\n");
         }
         if self.has_feature("process") {
-            self.write("use tishlang_runtime::{process_exit as tish_process_exit, process_cwd as tish_process_cwd, process_exec as tish_process_exec};\n");
+            self.write("use tishlang_runtime::{process_exit as tish_process_exit, process_cwd as tish_process_cwd, process_exec as tish_process_exec, process_exec_file as tish_process_exec_file};\n");
         }
         if self.has_feature("timers") {
             self.write("use tishlang_runtime::{timer_set_timeout as tish_timer_set_timeout, timer_clear_timeout as tish_timer_clear_timeout, timer_set_interval as tish_timer_set_interval, timer_clear_interval as tish_timer_clear_interval};\n");
@@ -2525,6 +2526,7 @@ impl Codegen {
             self.writeln("p.insert(Arc::from(\"exit\"), Value::native(|args: &[Value]| tish_process_exit(args)));");
             self.writeln("p.insert(Arc::from(\"cwd\"), Value::native(|args: &[Value]| tish_process_cwd(args)));");
             self.writeln("p.insert(Arc::from(\"exec\"), Value::native(|args: &[Value]| tish_process_exec(args)));");
+            self.writeln("p.insert(Arc::from(\"execFile\"), Value::native(|args: &[Value]| tish_process_exec_file(args)));");
             self.writeln("let argv: Vec<Value> = std::env::args().map(|s| Value::String(s.into())).collect();");
             self.writeln("p.insert(Arc::from(\"argv\"), Value::Array(VmRef::new(argv)));");
             self.writeln("let mut env_obj = ObjectMap::default();");

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -311,6 +311,7 @@ impl Evaluator {
                 process_obj.insert("exit".into(), Value::Native(natives::process_exit));
                 process_obj.insert("cwd".into(), Value::Native(natives::process_cwd));
                 process_obj.insert("exec".into(), Value::Native(natives::process_exec));
+                process_obj.insert("execFile".into(), Value::Native(natives::process_exec_file));
                 let argv: Vec<Value> = tishlang_core::process_argv()
                     .into_iter()
                     .map(|s| Value::String(s.into()))
@@ -1242,6 +1243,7 @@ impl Evaluator {
                     exports.insert("exit".into(), Value::Native(natives::process_exit));
                     exports.insert("cwd".into(), Value::Native(natives::process_cwd));
                     exports.insert("exec".into(), Value::Native(natives::process_exec));
+                    exports.insert("execFile".into(), Value::Native(natives::process_exec_file));
                     let argv: Vec<Value> = tishlang_core::process_argv()
                         .into_iter()
                         .map(|s| Value::String(s.into()))
@@ -1261,6 +1263,7 @@ impl Evaluator {
                     process_obj.insert("exit".into(), Value::Native(natives::process_exit));
                     process_obj.insert("cwd".into(), Value::Native(natives::process_cwd));
                     process_obj.insert("exec".into(), Value::Native(natives::process_exec));
+                    process_obj.insert("execFile".into(), Value::Native(natives::process_exec_file));
                     process_obj.insert("argv".into(), Value::Array(Rc::new(RefCell::new(argv))));
                     process_obj.insert("env".into(), Value::object(env_obj));
                     exports.insert(

--- a/crates/tish_eval/src/natives.rs
+++ b/crates/tish_eval/src/natives.rs
@@ -411,6 +411,25 @@ pub fn process_exec(args: &[Value]) -> Result<Value, String> {
     Ok(Value::Number(code as f64))
 }
 
+/// `process.execFile(program, [args])` — run a program directly, without a shell, passing each arg
+/// verbatim (the safe, no-`sh -c` counterpart to `exec`). Returns the exit code. #384
+pub fn process_exec_file(args: &[Value]) -> Result<Value, String> {
+    use std::process::Command;
+    let program = args.first().map(|v| v.to_string()).unwrap_or_default();
+    if program.is_empty() {
+        return Ok(Value::Number(0.0));
+    }
+    let argv: Vec<String> = match args.get(1) {
+        Some(Value::Array(a)) => a.borrow().iter().map(|v| v.to_string()).collect(),
+        _ => Vec::new(),
+    };
+    let output = Command::new(&program)
+        .args(&argv)
+        .output()
+        .map_err(|e| format!("execFile failed: {}", e))?;
+    Ok(Value::Number(output.status.code().unwrap_or(1) as f64))
+}
+
 #[cfg(feature = "fs")]
 pub fn read_file(args: &[Value]) -> Result<Value, String> {
     let path = args.first().map(|v| v.to_string()).unwrap_or_default();

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -880,6 +880,48 @@ pub fn process_exec(args: &[Value]) -> Value {
     }
 }
 
+/// `process.execFile(program, [args])` — run a program directly, WITHOUT a shell (no `sh -c`). Each
+/// argument is passed to the program verbatim, so shell metacharacters in untrusted argument data are
+/// never interpreted — the safe counterpart to `exec` when arguments derive from input (#384). Returns
+/// the exit code, like `exec`.
+#[cfg(feature = "process")]
+pub fn process_exec_file(args: &[Value]) -> Value {
+    use std::process::Command;
+    let program = args
+        .first()
+        .map(|v| v.to_display_string())
+        .unwrap_or_default();
+    if program.is_empty() {
+        return Value::Number(0.0);
+    }
+    let argv: Vec<String> = match args.get(1) {
+        Some(Value::Array(a)) => a.borrow().iter().map(|v| v.to_display_string()).collect(),
+        _ => Vec::new(),
+    };
+    match Command::new(&program).args(&argv).status() {
+        Ok(status) => Value::Number(status.code().unwrap_or(1) as f64),
+        Err(_) => Value::Number(1.0),
+    }
+}
+
+#[cfg(all(test, feature = "process", unix))]
+mod execfile_tests_384 {
+    use super::process_exec_file;
+    use tishlang_core::{Value, VmRef};
+
+    #[test]
+    fn execfile_runs_without_shell_and_returns_exit_code() {
+        // Runs the program directly (no `sh -c`); `true`/`false`/`echo` exist on unix.
+        assert!(matches!(process_exec_file(&[Value::String("true".into())]), Value::Number(n) if n == 0.0));
+        assert!(matches!(process_exec_file(&[Value::String("false".into())]), Value::Number(n) if n == 1.0));
+        // args are passed verbatim as a Value::Array.
+        let args = Value::Array(VmRef::new(vec![Value::String("ok".into())]));
+        assert!(matches!(process_exec_file(&[Value::String("echo".into()), args]), Value::Number(n) if n == 0.0));
+        // empty program is a no-op returning 0, matching `exec`.
+        assert!(matches!(process_exec_file(&[]), Value::Number(n) if n == 0.0));
+    }
+}
+
 #[cfg(feature = "fs")]
 pub fn read_file(args: &[Value]) -> Value {
     let path = args

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -302,6 +302,9 @@ fn get_builtin_export(enabled: &HashSet<String>, spec: &str, export_name: &str) 
             "exec" => Some(Value::native(|args: &[Value]| {
                 tishlang_runtime::process_exec(args)
             })),
+            "execFile" => Some(Value::native(|args: &[Value]| {
+                tishlang_runtime::process_exec_file(args)
+            })),
             "argv" => Some(Value::Array(VmRef::new(
                 tishlang_core::process_argv().into_iter().map(|s| Value::String(s.into())).collect(),
             ))),
@@ -323,6 +326,10 @@ fn get_builtin_export(enabled: &HashSet<String>, spec: &str, export_name: &str) 
                 m.insert(
                     "exec".into(),
                     Value::native(|args: &[Value]| tishlang_runtime::process_exec(args)),
+                );
+                m.insert(
+                    "execFile".into(),
+                    Value::native(|args: &[Value]| tishlang_runtime::process_exec_file(args)),
                 );
                 m.insert(
                     "argv".into(),
@@ -823,6 +830,10 @@ fn init_globals(enabled: &HashSet<String>) -> ObjectMap {
         process_obj.insert(
             "exec".into(),
             Value::native(|args: &[Value]| tishlang_runtime::process_exec(args)),
+        );
+        process_obj.insert(
+            "execFile".into(),
+            Value::native(|args: &[Value]| tishlang_runtime::process_exec_file(args)),
         );
         process_obj.insert(
             "argv".into(),


### PR DESCRIPTION
Adds the `execFile` argv API from the #384 hardening sweep.

## Motivation

`process.exec(cmd)` runs `sh -c <cmd>`, so shell metacharacters in untrusted argument data are interpreted by the shell — an injection sink (by design, like Node's `child_process.exec`). There was no safe, no-shell alternative.

## Fix

Add **`process.execFile(program, [args])`**: runs the program directly via `Command::new(program).args(argv)` with **no shell**, so each argument is passed verbatim and never interpreted. Returns the exit code, like `exec`.

Wired across every backend for parity:
- `tishlang_runtime::process_exec_file` (used by the **VM** and **native codegen**),
- `tish_eval::natives::process_exec_file` (**interp**),
- registered on the global `process` object and the `tish:process` module exports on all three backends.

## Verification

`execFile("echo", ["hello"])` and exit codes (`true`→0, `false`→1) confirmed on **interp, VM, and native**. Unit test covers the runtime path (no-shell exec + verbatim args + exit codes). The stdout-capture vs -inherit difference between backends exactly mirrors the pre-existing `exec` behavior.

## Remaining #384 item

Capping growth of the shared workspace `target/` (the larger disk driver).
