### PR TITLE
test(compile): repoint #174 range-proof test at intent; run tishlang_compile tests in CI

### DIFF
--- a/.github/workflows/build-npm-binaries.yml
+++ b/.github/workflows/build-npm-binaries.yml
@@ -162,10 +162,13 @@ jobs:
         with:
           tool: nextest,cargo-llvm-cov
 
-      # Restore cache from compile job, then run tests and coverage.
+      # Restore cache from compile job, then run tests and coverage. tishlang_compile is included
+      # explicitly: its generated-Rust text assertions (crates/tish_compile/tests/*) run under no
+      # other package, and PR #387 merged green while breaking one because only tishlang +
+      # tishlang_vm were tested here.
       - name: Run tests and coverage
         run: |
-          ./scripts/ci_build_retry.sh cargo llvm-cov nextest -p tishlang -p tishlang_vm --features full --no-fail-fast --profile ci \
+          ./scripts/ci_build_retry.sh cargo llvm-cov nextest -p tishlang -p tishlang_vm -p tishlang_compile --features full --no-fail-fast --profile ci \
             --lcov --output-path lcov.info
           mkdir -p test-results
           cp target/nextest/ci/junit.xml test-results/junit.xml

--- a/crates/tish_compile/tests/perf_codegen_174.rs
+++ b/crates/tish_compile/tests/perf_codegen_174.rs
@@ -73,8 +73,12 @@ fn issue_174_fnv_accumulator_still_i32_register_no_regression() {
 
 #[test]
 fn issue_174_range_proven_counter_drops_is_finite_guard() {
-    // A loop counter masked into a bitwise op is range-proven integral, so its ToInt32 drops the
-    // is_finite guard (unchecked truncation) instead of a guarded `to_int32(i)` call.
+    // A loop counter masked into a bitwise op is range-proven integral, so its ToInt32 must not
+    // round-trip through the guarded `to_int32(i)` call. The guard-free lowering is the saturating
+    // `(i) as i64 as i32` cast — #380 (PR #387) replaced the original `to_int_unchecked::<i64>()`
+    // here because `int_valued_locals` proves integrality but not magnitude, making the unchecked
+    // truncation UB on an overflowing accumulator; the saturating cast is defined for all f64 at
+    // the same hot-path cost (fnv_hash/fannkuch/mandelbrot measured at baseline in #387).
     let src = r#"
 let acc = 0
 for (let i = 0; i < 64; i = i + 1) {
@@ -84,9 +88,20 @@ console.log(acc >>> 0)
 "#;
     let rust = compile(&parse(src).unwrap()).unwrap();
     assert!(
-        rust.contains("to_int_unchecked::<i64>()"),
-        "a range-proven counter `i` in `i & 15` must drop the is_finite guard:\n{}",
+        rust.contains("as i64 as i32"),
+        "a range-proven counter `i` in `i & 15` must lower to the guard-free saturating cast:\n{}",
         rust.lines().filter(|l| l.contains("acc") || l.contains("to_int")).take(8).collect::<Vec<_>>().join("\n")
+    );
+    assert!(
+        !rust.contains("to_int32(i)"),
+        "a range-proven counter must not round-trip through the guarded to_int32 call:\n{}",
+        rust.lines().filter(|l| l.contains("to_int32(")).take(8).collect::<Vec<_>>().join("\n")
+    );
+    // Nothing in this program is the bounded `(h * C) >>> 0` excursion shape, so the UB-prone
+    // unchecked truncation must not appear at all (#380).
+    assert!(
+        !rust.contains("to_int_unchecked"),
+        "no unchecked truncation may appear for an unbounded-magnitude program"
     );
 }
 


### PR DESCRIPTION
## What

Two fixes for one silently-broken test:

**1. `issue_174_range_proven_counter_drops_is_finite_guard` fails on current main.** It pinned the *mechanism* of the #174 guard elision — `to_int_unchecked::<i64>()` — instead of its *intent* (a range-proven loop counter in `i & 15` must not round-trip through the guarded `to_int32(i)` call). #387 (the #380 UB fix) deliberately replaced that mechanism with the saturating `as i64 as i32` cast: defined for all f64 (`int_valued_locals` proves integrality, not magnitude, so the unchecked truncation was UB on overflowing accumulators), same hot-path cost, with fnv_hash/fannkuch/mandelbrot measured at baseline in #387's gauntlet A/B. The test now asserts the intent:
- the guard-free saturating cast is present,
- no guarded `to_int32(i)` round-trip,
- no `to_int_unchecked` anywhere in this program (the one *bounded* legitimate user — the `(h * C) >>> 0` excursion — is covered by its own passing test, `issue_174_fnv_accumulator_still_i32_register_no_regression`).

**2. Why CI never caught it:** "Test & coverage" runs `cargo llvm-cov nextest -p tishlang -p tishlang_vm` — `tishlang_compile`'s test suite (the generated-Rust text assertions under `crates/tish_compile/tests/`) has never run in CI, so #387 merged green while breaking this test. Added `-p tishlang_compile` to the invocation. Verified locally with the exact 3-package nextest shape (`--features full` resolves fine since `tishlang` carries the feature): 102 tests, all passing, seconds of runtime — and the crate already builds as a dependency, so the added CI cost is just the test execution.

This PR's own CI run exercises the new invocation.