### PR TITLE
fix(native): recursion guard for compiled binaries — catchable RangeError, and faster (#381)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3505,6 +3505,7 @@ dependencies = [
  "libc",
  "reqwest",
  "socket2 0.5.10",
+ "stacker",
  "tiny_http",
  "tishlang_builtins",
  "tishlang_core",

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -944,6 +944,14 @@ pub(crate) struct Codegen {
     native_fn_body_returned: bool,
     /// M5 LCG fns (`genRandom`): `fn -> (global, mul, add, modulus)` for single-`with` emission.
     native_lcg_fns: std::collections::HashMap<String, (String, f64, f64, f64)>,
+    /// #381 — M5 fns on a call-graph cycle (self- or mutually-recursive): `fn -> (scc_id, K)`.
+    /// Each gets K rotated copies (`f_native`, `f_native_r1`, …); only copy 0 carries the stack
+    /// check, and intra-SCC calls in copy `i` target the callee's copy `i+1` (wrapping to 0), so
+    /// the recursion re-checks the stack every K levels with zero per-call state.
+    native_recur_fns: std::collections::HashMap<String, (u32, usize)>,
+    /// #381 — set while emitting rotation copy `i` of `K` for a fn in SCC `scc_id`:
+    /// `(scc_id, i, K)`. Drives the intra-SCC call-target suffix in the M5 call arms.
+    native_recur_rotation: Option<(u32, usize, usize)>,
     /// `&/&mut Vec<f64|bool>` + `f64` params (`name -> sig`). Direct calls route to `name_nv(..)`
     /// passing array idents by reference; the boxed closure is suppressed. Empty unless the whole
     /// group lowers cleanly (scratch-buffer rollback), so it can never regress the boxed path.
@@ -1146,6 +1154,8 @@ impl Codegen {
             native_lcg_hoist_int: false,
             native_fn_body_returned: false,
             native_lcg_fns: std::collections::HashMap::new(),
+            native_recur_fns: std::collections::HashMap::new(),
+            native_recur_rotation: None,
             native_vec_fns: std::collections::HashMap::new(),
             native_vec_param_bounds: std::collections::HashMap::new(),
             inline_fns: std::collections::HashMap::new(),
@@ -2269,6 +2279,13 @@ impl Codegen {
                 Self::collect_native_fn_param_names(&program.statements, &self.native_fns);
             self.native_lcg_fns =
                 Self::collect_native_lcg_fns(&program.statements, &self.native_fns);
+            // #381 — fns on a call-graph cycle get guarded rotation copies (default ON;
+            // TISH_NATIVE_RECUR_GUARD=0 restores the plain unguarded emission).
+            self.native_recur_fns = if crate::native_recur_guard_enabled() {
+                Self::compute_native_recur_fns(&program.statements, &self.native_fns)
+            } else {
+                std::collections::HashMap::new()
+            };
             if !self.native_fns.is_empty() {
                 self.emit_native_fns(&program.statements)?;
                 self.writeln("");
@@ -5614,6 +5631,14 @@ impl Codegen {
                 let saved_try_depth = self.try_closure_depth;
                 self.try_closure_depth = 0;
                 self.indent += 1;
+                // #381 — boxed-call recursion guard: every user-fn closure counts one depth level
+                // (RAII: the guard's Drop decrements on any return path). Past TISH_MAX_CALL_DEPTH
+                // (default 20000) enter_call_guarded parks a catchable RangeError and the fn
+                // escapes with the dummy Value; the throw surfaces at the caller's pending-throw
+                // check. This bounds boxed recursion (incl. mutual/dynamic) exactly like the VM.
+                if crate::native_recur_guard_enabled() {
+                    self.writeln("let Some(_tish_depth) = tishlang_runtime::enter_call_guarded() else { return Value::Null; };");
+                }
                 // Mutable outer vars: capture the RefCell so assignments use borrow_mut
                 for outer_var in &mutable_outer_vars {
                     let var_escaped = Self::escape_ident(outer_var);
@@ -7146,8 +7171,8 @@ impl Codegen {
                         }
                         if ok {
                             return Ok(format!(
-                                "Value::Number({}_native({}))",
-                                Self::escape_ident(fname.as_ref()),
+                                "Value::Number({}({}))",
+                                self.native_call_target(fname.as_ref()),
                                 argc.join(", ")
                             ));
                         }
@@ -15774,6 +15799,142 @@ impl Codegen {
     }
 
     /// Emit `fn name_native(p: f64, ...) -> f64 { ... }` (top level) for each eligible fn.
+    /// #381 — find the M5 fns that can recurse (self-loops and mutual cycles) and size their guard
+    /// rotation. Builds the call graph restricted to `native_fns`, runs Tarjan's SCC, and maps every
+    /// fn on a cycle to `(scc_id, K)`. K rotated copies amortize the stack check to once per K
+    /// levels — and, because the copies are distinct symbols, LLVM inlines the chain like an
+    /// unrolled loop (self-recursion it would refuse to inline that deep), which measured *faster*
+    /// than the unguarded baseline on recursion_fib. K shrinks as bodies grow: big bodies amortize
+    /// the check by their own weight and duplicating them would just bloat the binary.
+    fn compute_native_recur_fns(
+        statements: &[Statement],
+        native_fns: &std::collections::HashSet<String>,
+    ) -> std::collections::HashMap<String, (u32, usize)> {
+        // Adjacency + a body-size proxy (exprs visited), in declaration order for determinism.
+        let mut names: Vec<String> = Vec::new();
+        let mut edges: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        let mut sizes: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+        for s in statements {
+            if let Statement::FunDecl { name, body, .. } = s {
+                if !native_fns.contains(name.as_ref()) {
+                    continue;
+                }
+                let mut called: Vec<String> = Vec::new();
+                let mut exprs = 0usize;
+                Self::for_each_stmt_expr(body, &mut |e| {
+                    Self::walk_subexprs(e, &mut |x| {
+                        exprs += 1;
+                        if let Expr::Call { callee, .. } = x {
+                            if let Expr::Ident { name: cn, .. } = callee.as_ref() {
+                                if native_fns.contains(cn.as_ref()) {
+                                    called.push(cn.to_string());
+                                }
+                            }
+                        }
+                    });
+                });
+                names.push(name.to_string());
+                edges.insert(name.to_string(), called);
+                sizes.insert(name.to_string(), exprs);
+            }
+        }
+        // Tarjan's SCC, iterative (explicit stack) so a pathological fn count can't recurse deep.
+        let idx_of: std::collections::HashMap<&str, usize> =
+            names.iter().enumerate().map(|(i, n)| (n.as_str(), i)).collect();
+        let n = names.len();
+        let mut index = vec![usize::MAX; n];
+        let mut low = vec![0usize; n];
+        let mut on_stack = vec![false; n];
+        let mut stack: Vec<usize> = Vec::new();
+        let mut next_index = 0usize;
+        let mut scc_of = vec![u32::MAX; n];
+        let mut scc_count = 0u32;
+        let mut scc_size: Vec<usize> = Vec::new();
+        for root in 0..n {
+            if index[root] != usize::MAX {
+                continue;
+            }
+            // Work item: (node, next child position).
+            let mut work: Vec<(usize, usize)> = vec![(root, 0)];
+            while let Some(&mut (v, ref mut child)) = work.last_mut() {
+                if *child == 0 {
+                    index[v] = next_index;
+                    low[v] = next_index;
+                    next_index += 1;
+                    stack.push(v);
+                    on_stack[v] = true;
+                }
+                let succ = edges[&names[v]]
+                    .iter()
+                    .filter_map(|c| idx_of.get(c.as_str()).copied())
+                    .nth(*child);
+                *child += 1;
+                match succ {
+                    Some(w) if index[w] == usize::MAX => work.push((w, 0)),
+                    Some(w) if on_stack[w] => low[v] = low[v].min(index[w]),
+                    Some(_) => {}
+                    None => {
+                        if low[v] == index[v] {
+                            let mut size = 0usize;
+                            while let Some(w) = stack.pop() {
+                                on_stack[w] = false;
+                                scc_of[w] = scc_count;
+                                size += 1;
+                                if w == v {
+                                    break;
+                                }
+                            }
+                            scc_count += 1;
+                            scc_size.push(size);
+                        }
+                        let (done, _) = work.pop().expect("work item");
+                        if let Some(&mut (parent, _)) = work.last_mut() {
+                            low[parent] = low[parent].min(low[done]);
+                        }
+                    }
+                }
+            }
+        }
+        // A fn needs the guard iff it sits on a cycle: |SCC| > 1, or a direct self-edge.
+        let mut out = std::collections::HashMap::new();
+        for (i, name) in names.iter().enumerate() {
+            let in_cycle = scc_size[scc_of[i] as usize] > 1
+                || edges[name].iter().any(|c| c == name);
+            if !in_cycle {
+                continue;
+            }
+            let k = match sizes[name] {
+                0..=16 => 32,
+                17..=64 => 16,
+                65..=256 => 8,
+                _ => 2,
+            };
+            out.insert(name.clone(), (scc_of[i], k));
+        }
+        out
+    }
+
+    /// #381 — the emitted name a call to M5 fn `fname` should target. Outside a rotation (or for a
+    /// non-recursive callee / different SCC) that is the plain `{fname}_native` — which for a
+    /// guarded fn is copy 0, the one with the stack check, so every entry from outside the cycle is
+    /// checked. Inside rotation copy `i`, an intra-SCC call targets the callee's copy `i+1` (the
+    /// checked copy 0 again after K levels).
+    fn native_call_target(&self, fname: &str) -> String {
+        let base = format!("{}_native", Self::escape_ident(fname));
+        if let (Some((cur_scc, i, k)), Some(&(callee_scc, _))) =
+            (self.native_recur_rotation, self.native_recur_fns.get(fname))
+        {
+            if callee_scc == cur_scc {
+                let next = (i + 1) % k;
+                if next != 0 {
+                    return format!("{}_r{}", base, next);
+                }
+            }
+        }
+        base
+    }
+
     fn emit_native_fns(&mut self, statements: &[Statement]) -> Result<(), CompileError> {
         for s in statements {
             if let Statement::FunDecl { name, params, body, .. } = s {
@@ -15789,14 +15950,35 @@ impl Codegen {
                         _ => None,
                     })
                     .collect();
+                // #381 — a fn on a call-graph cycle is emitted K times (rotation copies): copy 0
+                // (`{name}_native`, the entry every external call targets) opens with the stack
+                // check; copies 1..K-1 (`{name}_native_r{i}`) are check-free, and intra-SCC calls
+                // rotate through them so the recursion re-checks every K levels. See
+                // [`Self::compute_native_recur_fns`] for why this is also a speedup.
+                let (scc_id, copies) = self
+                    .native_recur_fns
+                    .get(name.as_ref())
+                    .copied()
+                    .map(|(scc, k)| (scc, k))
+                    .unwrap_or((0, 1));
+                for copy_idx in 0..copies {
                 self.type_context.push_scope();
                 for p in params {
                     if let FunParam::Simple(tp) = p {
                         self.type_context.define(tp.name.as_ref(), RustType::F64);
                     }
                 }
-                self.writeln(&format!("fn {}_native({}) -> f64 {{", Self::escape_ident(name.as_ref()), plist.join(", ")));
+                let copy_suffix = if copy_idx == 0 { String::new() } else { format!("_r{}", copy_idx) };
+                self.writeln(&format!("fn {}_native{}({}) -> f64 {{", Self::escape_ident(name.as_ref()), copy_suffix, plist.join(", ")));
                 self.indent += 1;
+                if copies > 1 {
+                    self.native_recur_rotation = Some((scc_id, copy_idx, copies));
+                    if copy_idx == 0 {
+                        // The guard: one thread-local read + pointer compare; the cold bail parks
+                        // the catchable RangeError and unwinds via the NaN sentinel (#381).
+                        self.writeln("if tishlang_runtime::stack_low() { return tishlang_runtime::recursion_tripped_f64(); }");
+                    }
+                }
                 if let Some((global, mul, add, modulus)) = self.native_lcg_fns.get(name.as_ref()) {
                     let max_name = params
                         .iter()
@@ -15873,6 +16055,8 @@ impl Codegen {
                 self.indent -= 1;
                 self.writeln("}");
                 self.type_context.pop_scope();
+                self.native_recur_rotation = None;
+                } // rotation copies (#381)
             }
         }
         Ok(())
@@ -21132,8 +21316,8 @@ impl Codegen {
                             }
                             return Ok((
                                 format!(
-                                    "{}_native({})",
-                                    Self::escape_ident(fname.as_ref()),
+                                    "{}({})",
+                                    self.native_call_target(fname.as_ref()),
                                     argc.join(", ")
                                 ),
                                 RustType::F64,
@@ -22305,5 +22489,115 @@ mod tests_176 {
             "fib_native must use param n, not call-site literal"
         );
         assert!(nv.contains("fib_native((n -"), "expected recursive n-1 call");
+    }
+
+    // #381 — a self-recursive M5 fn gets guard rotation: copy 0 (`fib_native`) opens with the
+    // stack check and its self-calls target copy 1; the copies rotate back to the guarded copy 0,
+    // so the recursion re-checks the stack every K levels with zero per-call state.
+    #[test]
+    fn recursive_native_fn_gets_guard_rotation() {
+        use std::path::PathBuf;
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let path = manifest.join("../../tests/perf/recursion_fib.tish");
+        let (rust, _, _, _) =
+            crate::compile_project_full(&path, path.parent(), &[], true).unwrap();
+        let copy0 = rust
+            .split("fn fib_native(")
+            .nth(1)
+            .expect("fib_native")
+            .split("\nfn ")
+            .next()
+            .unwrap()
+            .to_string();
+        assert!(
+            copy0.contains("tishlang_runtime::stack_low()")
+                && copy0.contains("tishlang_runtime::recursion_tripped_f64()"),
+            "guarded copy 0 must open with the stack check:\n{copy0}"
+        );
+        assert!(
+            copy0.contains("fib_native_r1((n -"),
+            "copy 0's self-calls must rotate to copy 1:\n{copy0}"
+        );
+        assert!(rust.contains("fn fib_native_r1("), "rotation copies must exist");
+        let r1 = rust
+            .split("fn fib_native_r1(")
+            .nth(1)
+            .unwrap()
+            .split("\nfn ")
+            .next()
+            .unwrap();
+        assert!(
+            !r1.contains("stack_low"),
+            "non-zero copies are check-free (the check amortizes across the rotation)"
+        );
+        // The top-level call site must enter through the guarded copy 0 (no rotation suffix).
+        assert!(
+            rust.contains("fib_native(35_f64"),
+            "external calls target the guarded copy"
+        );
+    }
+
+    // #381 — mutual recursion is a cycle too: both fns are guarded and intra-SCC calls rotate.
+    #[test]
+    fn mutually_recursive_native_fns_get_guard_rotation() {
+        let src = r#"
+fn even(n) { if (n <= 0) { return 1 } return odd(n - 1) }
+fn odd(n) { if (n <= 0) { return 0 } return even(n - 1) }
+console.log(even(10))
+"#;
+        let program = parse(src).unwrap();
+        let rust = super::compile(&program).unwrap();
+        for f in ["even", "odd"] {
+            let copy0 = rust
+                .split(&format!("fn {f}_native("))
+                .nth(1)
+                .unwrap_or_else(|| panic!("{f}_native missing"))
+                .split("\nfn ")
+                .next()
+                .unwrap()
+                .to_string();
+            assert!(
+                copy0.contains("tishlang_runtime::stack_low()"),
+                "{f}_native copy 0 must carry the stack check:\n{copy0}"
+            );
+        }
+        assert!(
+            rust.contains("odd_native_r1((n -") || rust.contains("odd_native_r1( (n -"),
+            "even's copy 0 must call odd's copy 1 (intra-SCC rotation)"
+        );
+    }
+
+    // #381 — a non-recursive M5 fn pays nothing: no stack check, no rotation copies.
+    #[test]
+    fn non_recursive_native_fn_has_no_guard() {
+        let src = r#"
+fn add(a, b) { return a + b }
+console.log(add(2, 3))
+"#;
+        let program = parse(src).unwrap();
+        let rust = super::compile(&program).unwrap();
+        assert!(rust.contains("fn add_native("), "add should be M5-eligible");
+        assert!(
+            !rust.contains("fn add_native_r1(") && !rust.contains("stack_low"),
+            "non-recursive fns must stay unguarded and un-rotated"
+        );
+    }
+
+    // #381 — every boxed user-fn closure opens with the depth guard (RAII: Drop decrements), so
+    // boxed recursion — including through `value_call` — raises a catchable RangeError.
+    #[test]
+    fn boxed_closure_opens_with_depth_guard() {
+        let src = r#"
+fn rec(n) { return { v: rec(n + 1) } }
+rec(0)
+"#;
+        let program = parse(src).unwrap();
+        let rust = super::compile(&program).unwrap();
+        assert!(
+            rust.contains(
+                "let Some(_tish_depth) = tishlang_runtime::enter_call_guarded() else { return Value::Null; };"
+            ),
+            "boxed user-fn closures must enter through the depth guard"
+        );
     }
 }

--- a/crates/tish_compile/src/lib.rs
+++ b/crates/tish_compile/src/lib.rs
@@ -20,6 +20,15 @@ pub(crate) fn native_opts_enabled() -> bool {
     std::env::var("TISH_NATIVE_OPT").map(|v| v != "0").unwrap_or(true)
 }
 
+/// #381 — the native recursion guard: rotation copies for self/mutually-recursive typed fns plus a
+/// depth guard at boxed user-fn closure entry, so unbounded recursion raises a catchable
+/// `RangeError` instead of overflowing the stack (an uncatchable process abort). **Default ON**;
+/// `TISH_NATIVE_RECUR_GUARD=0` turns it off — mirrors the VM JIT tier's `TISH_JIT_RECUR_GUARD`
+/// (for bisection and code-size-sensitive builds; unbounded recursion then aborts again, as before).
+pub(crate) fn native_recur_guard_enabled() -> bool {
+    std::env::var("TISH_NATIVE_RECUR_GUARD").map(|v| v != "0").unwrap_or(true)
+}
+
 /// How generated Rust is linked (desktop binary vs embedded iOS staticlib).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum NativeEmitMode {

--- a/crates/tish_core/src/lib.rs
+++ b/crates/tish_core/src/lib.rs
@@ -101,3 +101,82 @@ pub fn inc_call_depth() -> usize {
 pub fn dec_call_depth() {
     CALL_DEPTH.with(|c| c.set(c.get().saturating_sub(1)));
 }
+
+/// Default recursion ceiling shared by every backend that counts call depth (#381). Chosen with the
+/// interpreter: comfortably deep for real programs, but reached long before counted recursion can
+/// exhaust memory or the stack.
+pub const DEFAULT_MAX_CALL_DEPTH: usize = 20_000;
+
+thread_local! {
+    // The recursion ceiling, lazily initialized from `TISH_MAX_CALL_DEPTH` (0 = uninitialized). A
+    // thread-local Cell (not OnceLock) so tests can override it per-thread without racing the
+    // process-wide env. Shared by the VM's guard and the native backend's boxed-call guard. #381
+    static MAX_CALL_DEPTH: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// The recursion ceiling for depth-counting guards: user-fn calls deeper than this raise a catchable
+/// `RangeError` instead of overflowing the native stack. `TISH_MAX_CALL_DEPTH` overrides (default
+/// [`DEFAULT_MAX_CALL_DEPTH`]). #381
+pub fn max_call_depth() -> usize {
+    MAX_CALL_DEPTH.with(|c| {
+        let v = c.get();
+        if v != 0 {
+            return v;
+        }
+        let init = std::env::var("TISH_MAX_CALL_DEPTH")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(DEFAULT_MAX_CALL_DEPTH);
+        c.set(init);
+        init
+    })
+}
+
+/// Test hook: pin the ceiling for the current thread (bypasses the env read).
+pub fn set_max_call_depth_for_test(n: usize) {
+    MAX_CALL_DEPTH.with(|c| c.set(n));
+}
+
+/// The catchable `RangeError` raised when a recursion guard trips. Built by hand (`tishlang_core`
+/// sits below `tishlang_builtins`) but shape-identical to `construct_builtin::error_object`:
+/// a `{ name, message }` object — keep the two in lock-step.
+pub fn stack_overflow_error() -> Value {
+    let mut e = ObjectMap::default();
+    e.insert(
+        std::sync::Arc::from("name"),
+        Value::String("RangeError".into()),
+    );
+    e.insert(
+        std::sync::Arc::from("message"),
+        Value::String("Maximum call stack size exceeded".into()),
+    );
+    Value::object(e)
+}
+
+/// RAII frame for the depth-counting recursion guard: holding one means the depth was incremented;
+/// dropping it decrements, so early returns in generated code can't leak a level. #381
+pub struct CallDepthGuard(());
+
+impl Drop for CallDepthGuard {
+    #[inline]
+    fn drop(&mut self) {
+        dec_call_depth();
+    }
+}
+
+/// Enter a counted user-fn call frame, or trip the recursion guard: past [`max_call_depth`] this
+/// parks the catchable stack-overflow `RangeError` in the pending-throw slot and returns `None` —
+/// the caller just returns its frame's dummy value (`Value::Null`) and the throw surfaces at the
+/// next pending-throw checkpoint. The native backend emits this at the top of every boxed user-fn
+/// closure. #381
+#[inline]
+pub fn enter_call_guarded() -> Option<CallDepthGuard> {
+    let depth = inc_call_depth();
+    if depth > max_call_depth() {
+        dec_call_depth();
+        set_pending_throw(stack_overflow_error());
+        return None;
+    }
+    Some(CallDepthGuard(()))
+}

--- a/crates/tish_runtime/Cargo.toml
+++ b/crates/tish_runtime/Cargo.toml
@@ -94,3 +94,8 @@ core_affinity = { version = "0.8", optional = true }
 tokio-tungstenite = { version = "0.29", optional = true }
 futures-util = { version = "0.3", optional = true }
 lazy_static = { version = "1", optional = true }
+
+# #381 native-codegen recursion guard: stack-pressure probe for guarded self-recursive fns.
+# Non-wasm only — wasm traps on overflow inside its own sandbox, so the guard is a no-op there.
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+stacker = "0.1"

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -18,7 +18,16 @@ pub use tishlang_core::{ObjectData, PropMap};
 pub use tishlang_core::Value;
 pub use tishlang_core::ArcStr;
 /// Used by native codegen for `f()` / `obj()` dispatch (`Value::Function` or `__call` on objects).
-pub use tishlang_core::value_call;
+/// Wraps `tishlang_core::value_call` with a pending-throw suppression check (#381): while a thrown
+/// value is unwinding toward its checkpoint, calling anything would run side effects JS semantics
+/// say must not happen after a throw (e.g. `console.log(f(x))` printing the NaN sentinel a tripped
+/// recursion guard unwound with). One thread-local read on a path already dominated by boxing.
+pub fn value_call(callee: &Value, args: &[Value]) -> Value {
+    if has_pending_throw() {
+        return Value::Null;
+    }
+    tishlang_core::value_call(callee, args)
+}
 /// JS ToInt32/ToUint32 for the emitted bitwise/shift code (modulo 2³², NaN/±Infinity → 0).
 pub use tishlang_core::{
     to_int32, to_int32_value, to_number_value, to_uint32, to_uint32_value,
@@ -610,6 +619,89 @@ impl std::error::Error for TishError {}
 // the VM shares the same slot. Re-export the accessors so the Rust emitted by `tishlang_compile`
 // keeps calling `tishlang_runtime::{set,has,take}_pending_throw`. See `tishlang_core` for the docs.
 pub use tishlang_core::{has_pending_throw, set_pending_throw, take_pending_throw};
+
+// #381 — the recursion-guard plumbing for generated native code. The depth counter lives in
+// `tishlang_core` beside the pending-throw slot; the entry point generated code uses is the
+// wrapper below, which adds the stack-pressure check the counter alone can't provide.
+pub use tishlang_core::{stack_overflow_error, CallDepthGuard};
+
+/// #381 — enter a boxed user-fn call frame, or trip the recursion guard. Emitted at the top of
+/// every generated user-fn closure. Trips on EITHER limit: the counted ceiling
+/// (`TISH_MAX_CALL_DEPTH`, default 20000 — parity with the interp/VM guards) or real stack
+/// pressure ([`stack_low`]) — boxed native frames are large enough that 20000 of them can exceed
+/// the stack before the counter does (the VM sidesteps this with `stacker::maybe_grow`; generated
+/// code has no stack growth, so pressure must be its own trigger). On trip: parks the catchable
+/// `RangeError` and returns `None`; the closure returns its dummy `Value::Null` and the throw
+/// surfaces at the caller's pending-throw checkpoint.
+#[inline]
+pub fn enter_call_guarded() -> Option<CallDepthGuard> {
+    if stack_low() {
+        set_pending_throw(stack_overflow_error());
+        return None;
+    }
+    tishlang_core::enter_call_guarded()
+}
+
+#[cfg(not(target_family = "wasm"))]
+thread_local! {
+    // The current thread's bail floor for guarded self-recursive native fns: the stack address below
+    // which recursion must stop (real stack bottom + headroom margin). 0 = not yet initialized.
+    // Thread-local because every thread's stack occupies a different address range. #381
+    static STACK_FLOOR: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Headroom left below the deepest allowed recursion level (#381): must cover the levels emitted
+/// between two guard checks (the rotation window), the bail path, and building/raising the
+/// `RangeError`. Mirrors the VM JIT tier's margin (`RECUR_STACK_MARGIN`).
+#[cfg(not(target_family = "wasm"))]
+const RECUR_STACK_MARGIN: usize = 256 * 1024;
+
+/// #381 — is the current thread's stack nearly exhausted? Emitted by the native backend at the
+/// entry of self-recursive typed fns (every K-th rotation copy), so unbounded numeric recursion
+/// bails into a catchable `RangeError` instead of overflowing the stack (an uncatchable abort).
+/// One thread-local read + pointer compare after first init; the margin is capped at half the
+/// remaining stack so a first call on an already-deep stack can't false-trip (limit stays below SP).
+#[cfg(not(target_family = "wasm"))]
+#[inline]
+pub fn stack_low() -> bool {
+    let anchor = 0u8;
+    let sp = &anchor as *const u8 as usize;
+    STACK_FLOOR.with(|c| {
+        let mut floor = c.get();
+        if floor == 0 {
+            // `None` (unknown bounds) → floor 1: SP can never be below it, guard never trips —
+            // same do-no-harm fallback as the VM JIT tier.
+            floor = match stacker::remaining_stack() {
+                Some(rem) => {
+                    let margin = RECUR_STACK_MARGIN.min(rem / 2);
+                    sp.saturating_sub(rem).saturating_add(margin).max(1)
+                }
+                None => 1,
+            };
+            c.set(floor);
+        }
+        sp < floor
+    })
+}
+
+/// Wasm: the sandbox traps on overflow (contained by design), and `stacker` has no wasm support —
+/// the guard compiles to a constant `false` so the emitted check folds away.
+#[cfg(target_family = "wasm")]
+#[inline]
+pub fn stack_low() -> bool {
+    false
+}
+
+/// #381 — the bail path for a tripped typed-fn recursion guard: park the catchable `RangeError`
+/// and return the NaN sentinel the f64 frame unwinds with. Typed native fns are pure numeric
+/// (no side effects), so the NaN propagates harmlessly until the first `Value`/`Result` frame's
+/// pending-throw checkpoint raises the error.
+#[cold]
+#[inline(never)]
+pub fn recursion_tripped_f64() -> f64 {
+    set_pending_throw(stack_overflow_error());
+    f64::NAN
+}
 
 /// Function-boundary unwind: convert a completion that escaped a function body's `Result`-closure
 /// back into the function's `Value`. A `return v` yields `v`; an uncaught `throw` is stored in the

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -41,45 +41,10 @@ fn pending_throw_is_set() -> bool {
     tishlang_core::has_pending_throw()
 }
 
-const DEFAULT_MAX_CALL_DEPTH: usize = 20_000;
-
-thread_local! {
-    // The recursion ceiling, lazily initialized from `TISH_MAX_CALL_DEPTH` (0 = uninitialized). A
-    // thread-local (not a process-global `OnceLock`) so each worker thread reads it independently and
-    // — crucially — so tests can lower it on their own thread without a cross-test data race. Read on
-    // the call path, so it's a cheap thread-local `Cell` load after the first init. #381
-    static MAX_CALL_DEPTH: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
-}
-
-/// The catchable-recursion ceiling. Past this depth a VM call throws a `RangeError` instead of
-/// overflowing the native stack. Mirrors the interpreter (`TISH_MAX_CALL_DEPTH`, default 20000).
-#[inline]
-fn max_call_depth() -> usize {
-    MAX_CALL_DEPTH.with(|c| {
-        let v = c.get();
-        if v != 0 {
-            return v;
-        }
-        let init = std::env::var("TISH_MAX_CALL_DEPTH")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .filter(|&n| n > 0)
-            .unwrap_or(DEFAULT_MAX_CALL_DEPTH);
-        c.set(init);
-        init
-    })
-}
-
-#[cfg(test)]
-fn set_max_call_depth_for_test(n: usize) {
-    MAX_CALL_DEPTH.with(|c| c.set(n));
-}
-
-/// Build the catchable `RangeError` thrown when the recursion ceiling is exceeded.
-#[inline]
-fn stack_overflow_error() -> Value {
-    construct_builtin::error_object("RangeError", "Maximum call stack size exceeded")
-}
+// The recursion ceiling + trip error moved to `tishlang_core` (#381) so the native backend's
+// boxed-call guard shares one implementation with the VM. Same semantics: thread-local ceiling
+// lazily read from `TISH_MAX_CALL_DEPTH` (default 20000), `{name, message}` RangeError.
+use tishlang_core::{max_call_depth, stack_overflow_error};
 
 /// Headroom (bytes) a self-recursive JIT'd function leaves below the real stack bottom before it
 /// bails (#381). Must cover the bail path plus building the `RangeError` back in the VM; 256 KiB is
@@ -3743,8 +3708,7 @@ pub fn run_with_options(chunk: &Chunk, opts: VmRunOptions) -> Result<Value, Stri
 
 #[cfg(test)]
 mod recursion_limit_tests_381 {
-    use super::{set_max_call_depth_for_test, DEFAULT_MAX_CALL_DEPTH};
-    use tishlang_core::Value;
+    use tishlang_core::{set_max_call_depth_for_test, Value, DEFAULT_MAX_CALL_DEPTH};
 
     fn run_src(src: &str) -> Result<Value, String> {
         let program = tishlang_parser::parse(src).expect("parse");


### PR DESCRIPTION
## What & why

Closes the **native AOT tier** of the #381 DoS umbrella — the last unguarded backend besides cranelift-AOT. A self-recursive M5 typed fn compiles to a plain recursive Rust fn, and boxed user fns recurse through `value_call`; unbounded recursion in a compiled binary overflowed the OS stack — an **uncatchable SIGABRT killing the whole process** — where interp (#393), VM (#395), and the VM JIT (#400) raise a catchable `RangeError`.

```
fn f(n) { return f(n + 1.0) + 1.0 }
try { console.log(f(0.0)) } catch (e) { console.log("caught: " + e.name) }
// before: fatal runtime error: stack overflow, aborting (exit 134)
// after:  caught: RangeError  (nothing printed before the catch — matches node)
```

## Typed tier: guard rotation — the AOT-native design (and a speedup)

Every per-call guard measured prohibitively on the generated fib kernel (baseline 30ms, node 51ms):

| candidate | fib(35) |
|---|---|
| unguarded baseline | 30ms |
| `stacker::remaining_stack()` per entry | 64ms |
| thread-local floor compare | 57ms (macOS `tlv_get_addr` per access) |
| depth param vs constant | 54ms (param threading costs more under LLVM than the 34% under Cranelift in #400) |
| **rotation, K=32** | **11-12ms** |

**Rotation:** a fn on a call-graph cycle is emitted as K copies (`f_native → f_native_r1 → … → f_native`); only copy 0 carries the stack check, intra-SCC calls target the next copy — the recursion re-checks every K levels with **zero per-call state**. And because the copies are distinct symbols, LLVM's inliner (which refuses deep self-recursive inlining) unrolls the chain: **fib runs 2.6× faster than the old unguarded native, 4.3× faster than node**. The safety mechanism *is* an optimization. Mutual recursion (admissible in M5 via the candidate fixpoint) is handled by iterative Tarjan SCC — whole cycles rotate. K tiers by body size (32/16/8/2). On trip: park the catchable `RangeError`, unwind on a NaN sentinel (M5 fns are pure f64 — no side effects), raise at the next pending-throw checkpoint.

## Boxed tier + semantics

- Every generated user-fn closure opens with an RAII depth guard (`enter_call_guarded`) tripping on **either** the counted ceiling (`TISH_MAX_CALL_DEPTH`, default 20000 — parity with interp/VM) or real stack pressure — the counter alone is insufficient (20000 boxed frames exceed 8MB before it fires; the VM sidesteps this with `maybe_grow`, generated code has no stack growth). Ceiling/error machinery moved to `tishlang_core`; the VM now delegates instead of keeping a copy.
- `tishlang_runtime::value_call` now suppresses dispatch while a throw is pending — without it `console.log(f(x))` printed the in-flight NaN sentinel before the catch, an observable divergence from node. The suppression window is mid-statement only (checkpoints drain the slot immediately after), so `finally`/catch continuations are unaffected.
- `TISH_NATIVE_RECUR_GUARD=0` restores the previous unguarded emission (mirrors `TISH_JIT_RECUR_GUARD`). Wasm: `stack_low()` cfg-stubs to `false` (sandbox traps are contained by design); `stacker` is a non-wasm target dep of `tishlang_runtime` only.

## Validation

- **Full gauntlet: 29/29 sound (`typed==boxed==node`), 25/29 beating V8** — `recursion_fib` PASS at 0.23× node (12ms vs 52ms), `recursion_untyped` 0.24×; fnv/fannkuch/mandelbrot at baseline; the 4 fails are the known pre-existing gaps (array_pipeline, json_roundtrip, k_nucleotide, regex_redux).
- Typed, boxed, and **mutual** infinite recursion all raise the identical catchable `RangeError` as interp/VM/node; deep-but-bounded recursion (100k) still succeeds; escape hatch verified to restore old emission exactly.
- New codegen tests: rotation shape (guarded copy 0, check-free copies, intra-SCC rewrite), mutual-recursion SCC, non-recursive fns pay nothing, boxed prologue guard. 102/102 `tishlang_compile` tests pass (their CI enablement is #401).
- `cargo test` green on tishlang_core / tishlang_runtime / tishlang_vm / tishlang_compile; integration suite 25/25; runtime compiles for `wasm32-wasip1`.

## Remaining #381 gap

The cranelift AOT backend (`tish_cranelift`) is still unguarded — tracked on the issue.