### PR TITLE
fix(interp,core): interp cyclic JSON/string guards + node-shaped circular TypeError (#381)

### DIFF
--- a/crates/tish_core/src/json.rs
+++ b/crates/tish_core/src/json.rs
@@ -124,15 +124,23 @@ pub fn json_stringify_into(buf: &mut String, value: &Value) {
     json_stringify_into_guarded(buf, value, &mut ancestors);
 }
 
-/// Set the JS "circular structure" TypeError as the pending throw (once) — mirrors the
-/// `{ error: <msg> }` shape `tish_builtins::helpers::make_error_value` produces (that crate sits above
-/// this one, so the shape is reproduced here rather than imported).
+/// Set the JS "circular structure" TypeError as the pending throw (once). The `{ name, message }`
+/// shape matches node (`e.name === "TypeError"`, `e.message === "Converting circular structure to
+/// JSON"`) and tish's own thrown-error convention (`construct_builtin::error_object`, the recursion
+/// `RangeError` from [`crate::stack_overflow_error`]) — the previous `{ error: <msg> }` shape left
+/// `e.name` null in a catch block, diverging from node.
 fn signal_circular_json_throw() {
     if !crate::has_pending_throw() {
-        crate::set_pending_throw(Value::object_from_pairs([(
-            std::sync::Arc::from("error"),
-            Value::String("TypeError: Converting circular structure to JSON".into()),
-        )]));
+        crate::set_pending_throw(Value::object_from_pairs([
+            (
+                std::sync::Arc::from("name"),
+                Value::String("TypeError".into()),
+            ),
+            (
+                std::sync::Arc::from("message"),
+                Value::String("Converting circular structure to JSON".into()),
+            ),
+        ]));
     }
 }
 

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -4109,8 +4109,13 @@ impl Evaluator {
         }
     }
 
-    fn json_stringify_value(v: &Value) -> String {
-        match v {
+    /// #381 — ancestor-guarded like `tishlang_core::json_stringify_into_guarded`: a back-edge to an
+    /// ancestor (`a.self = a`) is a cycle and returns `Err(())` instead of recursing forever (this
+    /// was an unguarded native-stack overflow → uncatchable abort; core's guard from #389 never
+    /// covered the interpreter's own stringifier). Ancestor-path only, not all-visited: a node
+    /// repeated across sibling branches is a legal DAG and must serialize twice.
+    fn json_stringify_value(v: &Value, ancestors: &mut Vec<*const ()>) -> Result<String, ()> {
+        Ok(match v {
             Value::Null => "null".to_string(),
             Value::Bool(b) => b.to_string(),
             Value::Number(n) => {
@@ -4130,28 +4135,39 @@ impl Evaluator {
                     .replace('\t', "\\t")
             ),
             Value::Array(arr) => {
-                let inner: Vec<String> = arr
-                    .borrow()
-                    .iter()
-                    .map(Self::json_stringify_value)
-                    .collect();
+                let ptr = Rc::as_ptr(arr) as *const ();
+                if ancestors.contains(&ptr) {
+                    return Err(());
+                }
+                ancestors.push(ptr);
+                let borrowed = arr.borrow();
+                let mut inner: Vec<String> = Vec::with_capacity(borrowed.len());
+                for item in borrowed.iter() {
+                    inner.push(Self::json_stringify_value(item, ancestors)?);
+                }
+                drop(borrowed);
+                ancestors.pop();
                 format!("[{}]", inner.join(","))
             }
             Value::Object(map) => {
+                let ptr = Rc::as_ptr(map) as *const ();
+                if ancestors.contains(&ptr) {
+                    return Err(());
+                }
+                ancestors.push(ptr);
                 // Insertion order (PropMap is an IndexMap) — matches JS/Node and the
                 // VM/rust backends. No key sort.
-                let entries: Vec<String> = map
-                    .borrow()
-                    .strings
-                    .iter()
-                    .map(|(k, v)| {
-                        format!(
-                            "\"{}\":{}",
-                            k.replace('\\', "\\\\").replace('"', "\\\""),
-                            Self::json_stringify_value(v)
-                        )
-                    })
-                    .collect();
+                let borrowed = map.borrow();
+                let mut entries: Vec<String> = Vec::with_capacity(borrowed.strings.len());
+                for (k, v) in borrowed.strings.iter() {
+                    entries.push(format!(
+                        "\"{}\":{}",
+                        k.replace('\\', "\\\\").replace('"', "\\\""),
+                        Self::json_stringify_value(v, ancestors)?
+                    ));
+                }
+                drop(borrowed);
+                ancestors.pop();
                 format!("{{{}}}", entries.join(","))
             }
             Value::Symbol(_) => "null".to_string(),
@@ -4170,7 +4186,7 @@ impl Evaluator {
             #[cfg(feature = "regex")]
             Value::RegExp(_) => "null".to_string(),
             Value::Opaque(_) | Value::OpaqueMethod(_, _) => "null".to_string(),
-        }
+        })
     }
 
     // Static native wrapper functions (these need to be fn pointers, not closures with &self)
@@ -4181,7 +4197,13 @@ impl Evaluator {
 
     fn json_stringify_native(args: &[Value]) -> Result<Value, String> {
         let v = args.first().cloned().unwrap_or(Value::Null);
-        Ok(Value::String(Self::json_stringify_value(&v).into()))
+        let mut ancestors: Vec<*const ()> = Vec::new();
+        match Self::json_stringify_value(&v, &mut ancestors) {
+            Ok(s) => Ok(Value::String(s.into())),
+            // Surfaced by `call_func` as `EvalError::Error`, which the Try handler boxes as
+            // `{ name: "TypeError", message }` — node-identical for the circular case (#381).
+            Err(()) => Err("Converting circular structure to JSON".to_string()),
+        }
     }
 
     fn object_keys(args: &[Value]) -> Result<Value, String> {

--- a/crates/tish_eval/src/value.rs
+++ b/crates/tish_eval/src/value.rs
@@ -207,18 +207,13 @@ impl std::fmt::Display for Value {
             Value::String(s) => write!(f, "{}", s),
             Value::Bool(b) => write!(f, "{}", b),
             Value::Null => write!(f, "null"),
-            Value::Array(arr) => {
-                let inner: Vec<String> = arr.borrow().iter().map(|v| v.to_string()).collect();
-                write!(f, "[{}]", inner.join(", "))
-            }
-            Value::Object(obj) => {
-                let inner: Vec<String> = obj
-                    .borrow()
-                    .strings
-                    .iter()
-                    .map(|(k, v)| format!("{}: {}", k.as_ref(), v))
-                    .collect();
-                write!(f, "{{{}}}", inner.join(", "))
+            // #381 — containers render through the cycle-guarded walker: a self-referential
+            // array/object (`a.self = a`) previously recursed forever here (uncatchable native
+            // stack overflow from any `console.log`/interpolation). Mirrors
+            // `tishlang_core::Value::to_display_string_guarded` so interp output (`[Circular]`)
+            // matches the VM/native backends.
+            Value::Array(_) | Value::Object(_) => {
+                write!(f, "{}", self.to_display_string_guarded(&mut Vec::new()))
             }
             Value::Symbol(s) => {
                 if let Some(d) = &s.description {
@@ -272,16 +267,76 @@ impl Value {
     /// elements elide to `""`. Mirrors `tishlang_core::Value::to_js_string` so interp output matches
     /// the VM/rust/cranelift/wasi backends (and Node) for join/coercion.
     pub fn to_js_string(&self) -> String {
+        self.to_js_string_guarded(&mut Vec::new())
+    }
+
+    /// Cycle-safe inspect walker (#381): `ancestors` holds the current path's container pointers, so
+    /// a self-referential array/object renders `[Circular]` (matching the VM/native backends via
+    /// `tishlang_core::Value::to_display_string_guarded`) instead of recursing forever. Non-container
+    /// leaves defer to `Display`, whose container arms route back here — with a fresh path — only
+    /// for values this match already proved are not containers, so the guard cannot be bypassed.
+    fn to_display_string_guarded(&self, ancestors: &mut Vec<*const ()>) -> String {
         match self {
-            Value::Array(arr) => arr
-                .borrow()
-                .iter()
-                .map(|v| match v {
-                    Value::Null => String::new(),
-                    other => other.to_js_string(),
-                })
-                .collect::<Vec<_>>()
-                .join(","),
+            Value::Array(arr) => {
+                let ptr = Rc::as_ptr(arr) as *const ();
+                if ancestors.contains(&ptr) {
+                    return "[Circular]".to_string();
+                }
+                ancestors.push(ptr);
+                let inner: Vec<String> = arr
+                    .borrow()
+                    .iter()
+                    .map(|v| v.to_display_string_guarded(ancestors))
+                    .collect();
+                ancestors.pop();
+                format!("[{}]", inner.join(", "))
+            }
+            Value::Object(obj) => {
+                let ptr = Rc::as_ptr(obj) as *const ();
+                if ancestors.contains(&ptr) {
+                    return "[Circular]".to_string();
+                }
+                ancestors.push(ptr);
+                let inner: Vec<String> = obj
+                    .borrow()
+                    .strings
+                    .iter()
+                    .map(|(k, v)| {
+                        format!("{}: {}", k.as_ref(), v.to_display_string_guarded(ancestors))
+                    })
+                    .collect();
+                ancestors.pop();
+                format!("{{{}}}", inner.join(", "))
+            }
+            other => other.to_string(),
+        }
+    }
+
+    /// Cycle-safe `ToString` (#381): only arrays recurse here, so a cyclic array via `"" + a` would
+    /// otherwise overflow the native stack (uncatchable abort). A back-reference joins as `""` —
+    /// matching V8's `Array.prototype.join` and `tishlang_core::Value::to_js_string_guarded`, so
+    /// interp coercion output matches the VM/native backends. Ancestor-path only: a node repeated
+    /// across sibling branches is a legal DAG and still stringifies in full.
+    fn to_js_string_guarded(&self, ancestors: &mut Vec<*const ()>) -> String {
+        match self {
+            Value::Array(arr) => {
+                let ptr = Rc::as_ptr(arr) as *const ();
+                if ancestors.contains(&ptr) {
+                    return String::new();
+                }
+                ancestors.push(ptr);
+                let s = arr
+                    .borrow()
+                    .iter()
+                    .map(|v| match v {
+                        Value::Null => String::new(),
+                        other => other.to_js_string_guarded(ancestors),
+                    })
+                    .collect::<Vec<_>>()
+                    .join(",");
+                ancestors.pop();
+                s
+            }
             Value::Object(_) => "[object Object]".to_string(),
             // ECMAScript ToString of a number drops `-0`'s sign (`String(-0) === "0"`), distinct
             // from the inspect `Display` above which keeps it. Explicit arm so the `_` fallback to


### PR DESCRIPTION
## What

Re-verifying #381 end-to-end before closing it surfaced two **interpreter** gaps in sub-items 3/4 that #389 left open, plus one error-shape divergence:

**1. Interp `JSON.stringify` on a cyclic graph → uncatchable stack-overflow abort.** #389 guarded `tishlang_core::json_stringify_into`, but the interpreter never calls it — it has its own recursive `json_stringify_value` (eval.rs), still unguarded. `a.self = a; JSON.stringify(a)` overflowed the native stack (worse than the pre-#389 infinite hang: exit 134, uncatchable). Now ancestor-guarded exactly like core's; a cycle surfaces through the native `Err(String)` channel, which the interp's Try handler already boxes as `{name: "TypeError", message}` — so `catch (e) { e.name }` sees `"TypeError"`, node-identical.

**2. Interp `console.log` / `"" + x` on a cyclic value → same abort.** The interpreter's own `Display` and `to_js_string` recurse into containers unguarded. Containers now render through ancestor-guarded walkers mirroring core's: `[Circular]` in inspect output, back-references join as `""` (V8's `Array.prototype.join` behavior). Interp output is now byte-identical to VM/native for cyclic values.

**3. Core's circular-JSON throw had the `{error: msg}` shape**, leaving `e.name` null in a catch block. It now parks `{name: "TypeError", message: "Converting circular structure to JSON"}` — matching node and tish's own thrown-error convention (`error_object`, the recursion `RangeError`).

## Validation

- All three cyclic probes (`JSON.stringify` caught, `""+b` empty-join, `console.log` `[Circular]`) agree across **interp / VM / native**, and match node's observable behavior (`e.name === "TypeError"`, message identical, `""+b` → `""`).
- Uncaught interp case exits 1 with `Error: Converting circular structure to JSON` (no abort).
- Ancestor-path-only guards (not all-visited): shared DAG nodes still serialize/render in full.
- Full crate suites (core/eval/vm) + the 25-test integration suite pass.

Part of the #381 umbrella; with this and #402 merged, the remaining gap on that issue is the cranelift AOT backend.