### PR TITLE
fix(fmt): correct multi-line JSX layout + drop stray JSX-spread trailing space (#157)

### DIFF
--- a/crates/tish_fmt/src/lib.rs
+++ b/crates/tish_fmt/src/lib.rs
@@ -1159,6 +1159,10 @@ impl Printer {
     /// Print JSX children inline and verbatim. JSX whitespace is significant in tish, so text is
     /// emitted exactly as written and there is no reflow/indentation. A nested element/fragment is
     /// printed bare (as a child element); any other expression child gets `{ }`.
+    ///
+    /// Do NOT re-indent children by structural depth here: any injected newline/space becomes a
+    /// real `JsxChild::Text` node and changes the rendered output (and breaks idempotency). The
+    /// source's own layout inside the children is preserved as-is via the verbatim text nodes.
     fn jsx_children(&mut self, children: &[JsxChild]) {
         for ch in children {
             match ch {
@@ -1434,9 +1438,12 @@ impl Printer {
                             }
                         }
                         JsxProp::Spread(e) => {
+                            // A leading space separates this prop from the tag/prior prop; the
+                            // closing brace must NOT carry a trailing space, or a following attr
+                            // (which prepends its own space) would render as a double space.
                             self.buf.push_str(" {...");
                             self.expr(e);
-                            self.buf.push_str("} ");
+                            self.buf.push('}');
                         }
                     }
                 }
@@ -1915,6 +1922,41 @@ mod tests {
             assert_eq!(structure(src), structure(&out), "JSX structure changed: {src:?} -> {out:?}");
             assert_eq!(out, out2, "JSX not idempotent: {src:?} -> {out:?} -> {out2:?}");
         }
+    }
+
+    #[test]
+    fn multiline_jsx_children_are_bare_and_verbatim() {
+        // #157: multi-line JSX nested inside an arrow body must print element children BARE (not
+        // `{<child>}`-wrapped), must NOT emit stray blank `  ` lines, and must NOT re-indent to a
+        // hardcoded 2-space depth — JSX whitespace is significant, so the source layout is kept
+        // verbatim. This golden string locks the corrected output.
+        let src = "const x = () => {\n  return <div>\n    <span>hello</span>\n    <span>world</span>\n  </div>\n}\n";
+        let out = format_source(src).unwrap();
+        assert_eq!(
+            out,
+            "const x = () => {\n  return <div>\n    <span>hello</span>\n    <span>world</span>\n  </div>\n}\n",
+            "multi-line JSX corrupted: {out:?}"
+        );
+        // No curly-wrapped element children, and no blank two-space line.
+        assert!(!out.contains("{<"), "element child was brace-wrapped: {out:?}");
+        assert!(!out.contains("\n  \n"), "stray blank two-space line: {out:?}");
+        // Idempotent.
+        assert_eq!(format_source(&out).unwrap(), out, "not idempotent: {out:?}");
+    }
+
+    #[test]
+    fn multiline_jsx_fragment_children_are_bare_and_verbatim() {
+        // #157: the JsxFragment path shares the same layout logic as JsxElement; verify a
+        // multi-line fragment keeps its children bare and its source layout verbatim.
+        let src = "const y = () => {\n  return <>\n    <span>a</span>\n    <span>b</span>\n  </>\n}\n";
+        let out = format_source(src).unwrap();
+        assert_eq!(
+            out,
+            "const y = () => {\n  return <>\n    <span>a</span>\n    <span>b</span>\n  </>\n}\n",
+            "multi-line JSX fragment corrupted: {out:?}"
+        );
+        assert!(!out.contains("{<"), "fragment element child was brace-wrapped: {out:?}");
+        assert_eq!(format_source(&out).unwrap(), out, "not idempotent: {out:?}");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #157.

The audit flagged three problems in the multi-line JSX branch of `crates/tish_fmt/src/lib.rs`. On investigation, two of the three were already fixed by the #205 JSX rewrite (which prints JSX children inline and verbatim, because JSX whitespace is significant in tish and must not be reflowed). This PR fixes the one still-live issue, hardens the doc-comment invariant, and adds golden-string tests that lock the corrected multi-line behavior so the resolved corruption cannot silently regress.

## The three findings

1. **Text corruption (higher severity) — already resolved by #205.** The old branch emitted blank `  ` two-space lines and wrapped element children as `{<child>}`. The current code prints element/fragment children bare and injects no whitespace. Locked with new golden-string + `!contains("{<")` + no-blank-line tests.
2. **Depth-blind hardcoded 2-space indent — already resolved by #205, and the issue's suggested fix is a trap.** JSX children are now printed verbatim, preserving the source's own layout. The suggested `self.indent(self.depth + 1)` would re-inject significant whitespace as `JsxChild::Text` and re-introduce the exact corruption #205 fixed, so it is deliberately NOT applied; instead the invariant is documented on `jsx_children` and covered by an idempotency test.
3. **`JsxProp::Spread` stray trailing space (latent) — fixed here.** `push_str("} ")` → `push('}')`. Combined with a following attribute's leading space this double-spaced. The branch is unreachable today (the parser rejects both `{...props}` and `...props` in JSX props), so there is zero user-visible change, but the one-char correctness fix is applied for if/when the parser accepts spread props.

## Before / after (multi-line `<div>` in an arrow body)

Input:
```
const x = () => {
  return <div>
    <span>hello</span>
    <span>world</span>
  </div>
}
```

Formatted output (verified via `target/debug/tish-fmt`) — bare children, no blank lines, verbatim layout, idempotent:
```
const x = () => {
  return <div>
    <span>hello</span>
    <span>world</span>
  </div>
}
```

## Tests

- New `multiline_jsx_children_are_bare_and_verbatim` (nested `<div>` inside an arrow body) and `multiline_jsx_fragment_children_are_bare_and_verbatim` golden-string tests, each asserting no brace-wrapped element children, no stray blank lines, and idempotency.
- `cargo test -p tishlang_fmt`: 33 passed, 0 failed.
- Manually verified with the `tish-fmt` binary: multi-line element (a), fragment (b), and second-pass idempotency (c) all correct.
