### PR TITLE
perf(vm): OSR — JIT hot loop regions, incl. top-level (#190)

### DIFF
--- a/crates/tish_vm/src/jit.rs
+++ b/crates/tish_vm/src/jit.rs
@@ -61,15 +61,18 @@ unsafe impl Send for LoopFn {}
 unsafe impl Sync for LoopFn {}
 
 impl LoopFn {
-    /// Run the region. `buf` points at `used_slots.len()` `f64`s (the live-ins), updated in place
-    /// with the live-outs on return. `deopt` is a 1-byte flag (unused in v1). Returns the exit id.
-    ///
-    /// # Safety
-    /// `buf` must be a valid, writable `[f64; used_slots.len()]` and `deopt` a valid `*mut u8`.
+    /// Run the region. `buf` holds the live-ins (`used_slots.len()` `f64`s), updated in place with the
+    /// live-outs on return. `deopt` is a 1-byte flag (unused in v1). Returns the exit id. Safe wrapper
+    /// — the raw-pointer transmute (same soundness as [`NumericFn::call`]: immutable native code with a
+    /// fixed C ABI) is confined here, so call sites need no `unsafe`.
     #[inline]
-    pub unsafe fn call(&self, buf: *mut f64, deopt: *mut u8) -> i32 {
-        let f: extern "C" fn(*mut f64, *mut u8) -> i32 = std::mem::transmute(self.ptr);
-        f(buf, deopt)
+    pub fn call(&self, buf: &mut [f64], deopt: &mut u8) -> i32 {
+        // SAFETY: `ptr` is immutable executable code compiled for exactly this `(*mut f64, *mut u8)`
+        // ABI; `buf`/`deopt` are valid for the call and the region only touches `buf[0..used_slots]`.
+        unsafe {
+            let f: extern "C" fn(*mut f64, *mut u8) -> i32 = std::mem::transmute(self.ptr);
+            f(buf.as_mut_ptr(), deopt as *mut u8)
+        }
     }
 }
 
@@ -1910,7 +1913,7 @@ mod tests {
         assert!(!lf.used_slots.is_empty() && !lf.exits.is_empty());
         let mut buf = vec![0.0f64; lf.used_slots.len()];
         let mut deopt = 0u8;
-        let exit = unsafe { lf.call(buf.as_mut_ptr(), &mut deopt as *mut u8) };
+        let exit = lf.call(&mut buf, &mut deopt);
         assert!((exit as usize) < lf.exits.len(), "exit id in range");
         assert_eq!(deopt, 0, "v1 region never sets the deopt flag");
         let mut got = buf.clone();
@@ -1943,7 +1946,7 @@ mod tests {
         let lf = try_compile_loop(&chunk, header, end).expect("branchy numeric loop must OSR-compile");
         let mut buf = vec![0.0f64; lf.used_slots.len()];
         let mut deopt = 0u8;
-        unsafe { lf.call(buf.as_mut_ptr(), &mut deopt as *mut u8) };
+        lf.call(&mut buf, &mut deopt);
         let mut got = buf.clone();
         got.sort_by(|a, b| a.partial_cmp(b).unwrap());
         assert_eq!(got, vec![20.0, 90.0], "s=90 (0+2+…+18), i=20");

--- a/crates/tish_vm/src/jit.rs
+++ b/crates/tish_vm/src/jit.rs
@@ -675,14 +675,15 @@ fn build_loop_region_body(
     let params: Vec<ClifValue> = bcx.block_params(entry).to_vec();
     let slots_ptr = params[0]; // params[1] = deopt flag, reserved (v1 never writes it)
     let vars: Vec<Variable> = (0..num_slots).map(|_| bcx.declare_var(types::F64)).collect();
-    for slot in 0..num_slots {
+    for (slot, &var) in vars.iter().enumerate() {
+        // Live slots load from their buffer position; slots the region never touches init to 0 (dead).
         let init = if let Some(&p) = buf_pos.get(&(slot as u16)) {
             bcx.ins()
                 .load(types::F64, MemFlags::new(), slots_ptr, (p * 8) as i32)
         } else {
             bcx.ins().f64const(0.0)
         };
-        bcx.def_var(vars[slot], init);
+        bcx.def_var(var, init);
     }
     let header_block = match blocks.get(&header_ip) {
         Some(&b) => b,

--- a/crates/tish_vm/src/jit.rs
+++ b/crates/tish_vm/src/jit.rs
@@ -34,6 +34,45 @@ use cranelift_module::{Linkage, Module};
 use tishlang_ast::{BinOp, UnaryOp};
 use tishlang_bytecode::{u8_to_binop, u8_to_unaryop, Chunk, Constant, Opcode, NO_REST_PARAM};
 
+/// A JIT-compiled hot LOOP REGION for on-stack replacement (#190). Unlike [`NumericFn`] (a whole
+/// function over register-`f64` params), this is native code over a chunk's **numeric slot frame**:
+/// the VM copies the region's live-in slots into an `f64` buffer, calls the region, then copies the
+/// live-outs back. ABI: `extern "C" fn(slots: *mut f64, deopt: *mut u8) -> i32`, returning the EXIT
+/// id (index into [`exits`]). `deopt` is reserved (a `*mut u8` flag): the v1 whitelist is pure numeric
+/// slot math, which cannot deopt mid-run, so it is never set — it keeps the ABI stable for the future
+/// array/property regions that will need a bail path. The pointer is into the never-freed `JITModule`.
+#[derive(Clone)]
+pub struct LoopFn {
+    ptr: usize,
+    /// Slots read or written inside the region — the live set. The `f64` buffer is indexed by
+    /// POSITION here (buffer slot `p` ↔ chunk slot `used_slots[p]`); the emitted code loads/stores at
+    /// that same position, so the VM and the native code agree without threading slot numbers.
+    pub used_slots: Vec<u16>,
+    /// Exit id → the chunk `ip` to resume interpreting at (a loop-exit / `break` target outside the
+    /// region). The region always has ≥1 exit (an exit-less region would be an uninterruptible native
+    /// loop, so compilation bails).
+    pub exits: Vec<usize>,
+}
+
+// SAFETY: identical to `NumericFn` — `ptr` is immutable executable code in the process-global,
+// never-dropped `JITModule`; the slot buffer is caller-owned. Send/Sync so the frame VM (which may
+// run on any thread) can hold a cached `LoopFn`.
+unsafe impl Send for LoopFn {}
+unsafe impl Sync for LoopFn {}
+
+impl LoopFn {
+    /// Run the region. `buf` points at `used_slots.len()` `f64`s (the live-ins), updated in place
+    /// with the live-outs on return. `deopt` is a 1-byte flag (unused in v1). Returns the exit id.
+    ///
+    /// # Safety
+    /// `buf` must be a valid, writable `[f64; used_slots.len()]` and `deopt` a valid `*mut u8`.
+    #[inline]
+    pub unsafe fn call(&self, buf: *mut f64, deopt: *mut u8) -> i32 {
+        let f: extern "C" fn(*mut f64, *mut u8) -> i32 = std::mem::transmute(self.ptr);
+        f(buf, deopt)
+    }
+}
+
 /// A JIT-compiled numeric function: a pointer to native code plus its arity.
 /// The pointer is into a leaked, never-freed `JITModule`, so it is valid for the
 /// life of the process and safe to call from any thread.
@@ -298,6 +337,10 @@ struct JitGlobal {
     /// reused by a different chunk, so we recompile (and overwrite) instead of returning stale native
     /// code. `None` still caches "not JIT-eligible". See [`chunk_fingerprint`].
     cache: HashMap<usize, (u64, Option<NumericFn>)>,
+    /// OSR loop-region cache (#190), keyed by `(chunk address, loop header ip)` with the same
+    /// fingerprint guard as `cache`. `None` caches "region not compilable" so a loop that fails the
+    /// whitelist is scanned once, not on every back-edge past the trigger threshold.
+    osr_cache: HashMap<(usize, usize), (u64, Option<LoopFn>)>,
     counter: usize,
 }
 
@@ -328,6 +371,7 @@ fn jit() -> Option<&'static Mutex<JitGlobal>> {
             Mutex::new(JitGlobal {
                 module,
                 cache: HashMap::new(),
+                osr_cache: HashMap::new(),
                 counter: 0,
             })
         })
@@ -427,6 +471,398 @@ pub fn try_compile_numeric(chunk: &Chunk) -> Option<NumericFn> {
     let result = compile_chunk(&mut g, chunk);
     g.cache.insert(key, (fp, result));
     result
+}
+
+/// Compile the hot loop region `[header_ip, region_end)` of `chunk` to native code (#190 OSR), or
+/// `None` if it is not a pure-numeric slot loop. Cached per `(chunk, header_ip)` with a fingerprint
+/// guard (negative results included, so a non-compilable loop is scanned once). Called from the frame
+/// VM's `JumpBack` handler once a loop's back-edge counter crosses the trigger threshold.
+pub fn try_compile_loop(chunk: &Chunk, header_ip: usize, region_end: usize) -> Option<LoopFn> {
+    let key = (chunk as *const Chunk as usize, header_ip);
+    let fp = chunk_fingerprint(chunk);
+    let lock = jit()?;
+    let mut g = lock.lock().ok()?;
+    if let Some((cached_fp, cached)) = g.osr_cache.get(&key) {
+        if *cached_fp == fp {
+            return cached.clone();
+        }
+    }
+    let result = compile_loop_region(&mut g, chunk, header_ip, region_end);
+    g.osr_cache.insert(key, (fp, result.clone()));
+    result
+}
+
+/// Lower one hot loop region to a `LoopFn`. The region must be pure numeric slot math: the same
+/// opcode whitelist as [`build_body_cfg`] minus everything that touches a non-slot value (calls,
+/// member/index, arrays, objects, `LoadVar`, `Return`). Reuses [`emit_simple_op`] for the arithmetic
+/// so the region is bit-for-bit identical to the interpreter's `eval_binop`. Live-ins are loaded from
+/// the `slots` pointer at entry; each loop-exit target stores the live set back and returns its id.
+fn compile_loop_region(
+    g: &mut JitGlobal,
+    chunk: &Chunk,
+    header_ip: usize,
+    region_end: usize,
+) -> Option<LoopFn> {
+    let code = &chunk.code;
+    let num_slots = chunk.num_slots as usize;
+    if num_slots == 0 || num_slots > 256 || header_ip >= region_end || region_end > code.len() {
+        return None;
+    }
+
+    // 1. Scan the region: validate the whitelist (op_size = None ⇒ bail), collect in-region block
+    //    leaders, the live slot set, and the EXIT targets (jump targets outside the region). A
+    //    JumpBack must stay inside the region (its own loop, possibly nested); one leaving the region
+    //    is not a structured single-region loop → bail.
+    let mut leaders: std::collections::BTreeSet<usize> = std::collections::BTreeSet::new();
+    leaders.insert(header_ip);
+    let mut used: std::collections::BTreeSet<u16> = std::collections::BTreeSet::new();
+    let mut exit_targets: std::collections::BTreeSet<usize> = std::collections::BTreeSet::new();
+    let mut ip = header_ip;
+    while ip < region_end {
+        let op = Opcode::from_u8(*code.get(ip)?)?;
+        match op {
+            // Pure slot / stack / arithmetic / structured control flow — the region vocabulary.
+            Opcode::Nop
+            | Opcode::Pop
+            | Opcode::Dup
+            | Opcode::EnterBlock
+            | Opcode::ExitBlock
+            | Opcode::LoopVarsEnd
+            | Opcode::LoopVarsBegin
+            | Opcode::UnaryOp => {}
+            Opcode::LoadLocal | Opcode::StoreLocal => {
+                used.insert(peek_u16(code, ip + 1)?);
+            }
+            Opcode::LoadConst => match chunk.constants.get(peek_u16(code, ip + 1)? as usize) {
+                Some(Constant::Number(_)) | Some(Constant::Bool(_)) => {}
+                _ => return None, // a String/Null/Closure const is not numeric slot math
+            },
+            Opcode::BinOp => {
+                // Reject non-numeric binops up front (Pow/In/logical) so the scan and the emit agree.
+                match peek_u16(code, ip + 1).map(|r| r as u8).and_then(u8_to_binop)? {
+                    BinOp::And | BinOp::Or | BinOp::Pow | BinOp::In => return None,
+                    _ => {}
+                }
+            }
+            Opcode::Jump => {
+                let off = peek_u16(code, ip + 1)? as i16 as isize;
+                let t = ((ip + 3) as isize + off).max(0) as usize;
+                if t < header_ip || t >= region_end {
+                    exit_targets.insert(t);
+                } else {
+                    leaders.insert(t);
+                }
+            }
+            Opcode::JumpIfFalse => {
+                let off = peek_u16(code, ip + 1)? as i16 as isize;
+                let t = ((ip + 3) as isize + off).max(0) as usize;
+                if t < header_ip || t >= region_end {
+                    exit_targets.insert(t);
+                } else {
+                    leaders.insert(t);
+                }
+                leaders.insert(ip + 3); // fall-through
+            }
+            Opcode::JumpBack => {
+                let dist = peek_u16(code, ip + 1)? as usize;
+                let t = (ip + 3).checked_sub(dist)?;
+                if t < header_ip || t >= region_end {
+                    return None; // back-edge leaving the region — not a single structured region
+                }
+                leaders.insert(t);
+            }
+            // Everything else (Call, SelfCall, LoadVar, GetIndex, member/object/array, Return, …)
+            // reads or writes a non-slot Value the f64 buffer can't carry → not OSR-eligible.
+            _ => return None,
+        }
+        ip += op_size(op)?;
+    }
+    // An exit-less region would compile to an uninterruptible native infinite loop — never OSR it.
+    if exit_targets.is_empty() {
+        return None;
+    }
+
+    // buffer position of each live slot (both the emitted loads/stores and the VM copy use this).
+    let used_slots: Vec<u16> = used.iter().copied().collect();
+    let buf_pos: HashMap<u16, usize> = used_slots
+        .iter()
+        .enumerate()
+        .map(|(p, &s)| (s, p))
+        .collect();
+    let exits: Vec<usize> = exit_targets.iter().copied().collect();
+    let exit_id: HashMap<usize, usize> = exits.iter().enumerate().map(|(i, &t)| (t, i)).collect();
+
+    // 2. Build the region function. Signature: (slots: i64 ptr, deopt: i64 ptr) -> i32 exit id.
+    let ptr_ty = g.module.target_config().pointer_type();
+    let mut sig = g.module.make_signature();
+    sig.params.push(AbiParam::new(ptr_ty)); // slots buffer
+    sig.params.push(AbiParam::new(ptr_ty)); // deopt flag (reserved)
+    sig.returns.push(AbiParam::new(types::I32));
+
+    let name = format!("tish_osr_{}", g.counter);
+    g.counter += 1;
+    let id = g.module.declare_function(&name, Linkage::Export, &sig).ok()?;
+
+    let mut ctx = g.module.make_context();
+    ctx.func.signature = sig.clone();
+    let mut fbctx = FunctionBuilderContext::new();
+    let built = build_loop_region_body(
+        &mut ctx.func,
+        &mut fbctx,
+        chunk,
+        header_ip,
+        region_end,
+        &leaders,
+        &used_slots,
+        &buf_pos,
+        &exit_id,
+    );
+    if !built {
+        g.module.clear_context(&mut ctx);
+        return None;
+    }
+    if g.module.define_function(id, &mut ctx).is_err() {
+        g.module.clear_context(&mut ctx);
+        return None;
+    }
+    g.module.clear_context(&mut ctx);
+    if g.module.finalize_definitions().is_err() {
+        return None;
+    }
+    let fptr = g.module.get_finalized_function(id);
+    Some(LoopFn {
+        ptr: fptr as usize,
+        used_slots,
+        exits,
+    })
+}
+
+/// Emit the CLIF body of a loop region (#190). `true` on success; `false` on any shape the emitter
+/// can't lower (the caller then negative-caches the region). Structure mirrors [`build_body_cfg`]'s
+/// translate loop, but: slots load from / store to the `slots` pointer instead of register params,
+/// and a jump/branch to an EXIT target lands in an exit block that writes the live set back and
+/// returns the exit id. No self-call, no arrays, no `Return` (all rejected in the scan).
+#[allow(clippy::too_many_arguments)]
+fn build_loop_region_body(
+    func: &mut cranelift::codegen::ir::Function,
+    fbctx: &mut FunctionBuilderContext,
+    chunk: &Chunk,
+    header_ip: usize,
+    region_end: usize,
+    leaders: &std::collections::BTreeSet<usize>,
+    used_slots: &[u16],
+    buf_pos: &HashMap<u16, usize>,
+    exit_id: &HashMap<usize, usize>,
+) -> bool {
+    let code = &chunk.code;
+    let num_slots = chunk.num_slots as usize;
+    let mut bcx = FunctionBuilder::new(func, fbctx);
+
+    let blocks: HashMap<usize, Block> =
+        leaders.iter().map(|&o| (o, bcx.create_block())).collect();
+    let exit_blocks: HashMap<usize, Block> =
+        exit_id.keys().map(|&t| (t, bcx.create_block())).collect();
+
+    // A jump target is either an in-region leader or a loop-exit target (the scan proved it is one).
+    let target_block = |t: usize| -> Option<Block> {
+        blocks.get(&t).or_else(|| exit_blocks.get(&t)).copied()
+    };
+
+    // Entry: load the live-in slots from the buffer, then jump into the loop header.
+    let entry = bcx.create_block();
+    bcx.append_block_params_for_function_params(entry);
+    bcx.switch_to_block(entry);
+    let params: Vec<ClifValue> = bcx.block_params(entry).to_vec();
+    let slots_ptr = params[0]; // params[1] = deopt flag, reserved (v1 never writes it)
+    let vars: Vec<Variable> = (0..num_slots).map(|_| bcx.declare_var(types::F64)).collect();
+    for slot in 0..num_slots {
+        let init = if let Some(&p) = buf_pos.get(&(slot as u16)) {
+            bcx.ins()
+                .load(types::F64, MemFlags::new(), slots_ptr, (p * 8) as i32)
+        } else {
+            bcx.ins().f64const(0.0)
+        };
+        bcx.def_var(vars[slot], init);
+    }
+    let header_block = match blocks.get(&header_ip) {
+        Some(&b) => b,
+        None => return false,
+    };
+    bcx.ins().jump(header_block, &[]);
+
+    // Translate the region. Operand stack is empty at every block boundary (statement-level flow).
+    let mut stack: Vec<(ClifValue, bool)> = Vec::new();
+    bcx.switch_to_block(header_block);
+    let mut cur = header_block;
+    let mut terminated = false;
+    let mut ip = header_ip;
+    while ip < region_end {
+        if let Some(&blk) = blocks.get(&ip) {
+            if blk != cur {
+                if !terminated {
+                    if !stack.is_empty() {
+                        return false;
+                    }
+                    bcx.ins().jump(blk, &[]);
+                }
+                bcx.switch_to_block(blk);
+                cur = blk;
+                terminated = false;
+                stack.clear();
+            }
+        }
+        let op = match Opcode::from_u8(code[ip]).zip(op_size_at(code, ip)) {
+            Some((o, _)) => o,
+            None => return false,
+        };
+        if terminated {
+            ip += match op_size(op) {
+                Some(s) => s,
+                None => return false,
+            };
+            continue;
+        }
+        match op {
+            Opcode::LoadLocal => {
+                let slot = match peek_u16(code, ip + 1) {
+                    Some(s) => s as usize,
+                    None => return false,
+                };
+                let v = match vars.get(slot) {
+                    Some(v) => *v,
+                    None => return false,
+                };
+                stack.push((bcx.use_var(v), false));
+                ip += 3;
+            }
+            Opcode::StoreLocal => {
+                let slot = match peek_u16(code, ip + 1) {
+                    Some(s) => s as usize,
+                    None => return false,
+                };
+                let (val, is_bool) = match stack.pop() {
+                    Some(x) => x,
+                    None => return false,
+                };
+                if is_bool {
+                    return false; // no boolean slots (keeps the number/bool distinction clean)
+                }
+                let v = match vars.get(slot) {
+                    Some(v) => *v,
+                    None => return false,
+                };
+                bcx.def_var(v, val);
+                ip += 3;
+            }
+            Opcode::Pop => {
+                if stack.pop().is_none() {
+                    return false;
+                }
+                ip += 1;
+            }
+            Opcode::Dup => {
+                let top = match stack.last() {
+                    Some(x) => *x,
+                    None => return false,
+                };
+                stack.push(top);
+                ip += 1;
+            }
+            Opcode::Nop | Opcode::EnterBlock | Opcode::ExitBlock | Opcode::LoopVarsEnd => ip += 1,
+            Opcode::LoopVarsBegin => ip += 3,
+            Opcode::Jump => {
+                let off = match peek_u16(code, ip + 1) {
+                    Some(o) => o as i16 as isize,
+                    None => return false,
+                };
+                let t = ((ip + 3) as isize + off).max(0) as usize;
+                let blk = match target_block(t) {
+                    Some(b) => b,
+                    None => return false,
+                };
+                if !stack.is_empty() {
+                    return false;
+                }
+                bcx.ins().jump(blk, &[]);
+                terminated = true;
+                ip += 3;
+            }
+            Opcode::JumpBack => {
+                let dist = match peek_u16(code, ip + 1) {
+                    Some(d) => d as usize,
+                    None => return false,
+                };
+                let t = match (ip + 3).checked_sub(dist) {
+                    Some(t) => t,
+                    None => return false,
+                };
+                let blk = match blocks.get(&t) {
+                    Some(&b) => b,
+                    None => return false,
+                };
+                if !stack.is_empty() {
+                    return false;
+                }
+                bcx.ins().jump(blk, &[]);
+                terminated = true;
+                ip += 3;
+            }
+            Opcode::JumpIfFalse => {
+                let off = match peek_u16(code, ip + 1) {
+                    Some(o) => o as i16 as isize,
+                    None => return false,
+                };
+                let (cond, _) = match stack.pop() {
+                    Some(x) => x,
+                    None => return false,
+                };
+                if !stack.is_empty() {
+                    return false;
+                }
+                let falsy = falsy_flag(&mut bcx, cond);
+                let t = ((ip + 3) as isize + off).max(0) as usize;
+                let target = match target_block(t) {
+                    Some(b) => b,
+                    None => return false,
+                };
+                let fallthrough = match blocks.get(&(ip + 3)) {
+                    Some(&b) => b,
+                    None => return false,
+                };
+                bcx.ins().brif(falsy, target, &[], fallthrough, &[]);
+                terminated = true;
+                ip += 3;
+            }
+            _ => match emit_simple_op(&mut bcx, chunk, code, &mut ip, &mut stack, &[], 0) {
+                SimpleOp::Handled(_) => {}
+                _ => return false, // LoadConst/BinOp/UnaryOp handled; anything else → keep interpreting
+            },
+        }
+    }
+    if !terminated {
+        return false; // the region must end on its back-edge (a terminator)
+    }
+
+    // Exit blocks: flush the live set back through the slots pointer and return the exit id.
+    for (&t, &blk) in &exit_blocks {
+        bcx.switch_to_block(blk);
+        for (p, &slot) in used_slots.iter().enumerate() {
+            let v = bcx.use_var(vars[slot as usize]);
+            bcx.ins()
+                .store(MemFlags::new(), v, slots_ptr, (p * 8) as i32);
+        }
+        let id = bcx.ins().iconst(types::I32, exit_id[&t] as i64);
+        bcx.ins().return_(&[id]);
+    }
+
+    bcx.seal_all_blocks();
+    bcx.finalize();
+    true
+}
+
+/// `op_size` of the opcode at `off`, or `None` if the byte is not a known opcode.
+fn op_size_at(code: &[u8], off: usize) -> Option<usize> {
+    op_size(Opcode::from_u8(*code.get(off)?)?)
 }
 
 /// Lower `f64` comparison to `1.0`/`0.0` (JS boolean-in-number form).
@@ -1435,5 +1871,80 @@ mod tests {
             assert_eq!(shr.call(&[a, b]), to_int32(a).wrapping_shr(to_uint32(b)) as f64, ">> {a} {b}");
             assert_eq!(ushr.call(&[a, b]), to_uint32(a).wrapping_shr(to_uint32(b)) as f64, ">>> {a} {b}");
         }
+    }
+
+    /// Top-level chunk of compiled `src` (where hot loops live) — #190 OSR targets these.
+    fn top_chunk(src: &str) -> Chunk {
+        let prog = tishlang_parser::parse(src).expect("parse");
+        let opt = tishlang_opt::optimize(&prog);
+        tishlang_bytecode::compile(&opt).expect("compile")
+    }
+
+    /// `(header_ip, region_end)` of the FIRST loop in `chunk` — its first `JumpBack` names the region
+    /// the OSR trigger would compile.
+    fn first_region(chunk: &Chunk) -> (usize, usize) {
+        let code = &chunk.code;
+        let mut ip = 0;
+        while ip < code.len() {
+            let op = Opcode::from_u8(code[ip]).expect("op");
+            if op == Opcode::JumpBack {
+                let dist = peek_u16(code, ip + 1).unwrap() as usize;
+                let region_end = ip + 3;
+                return (region_end - dist, region_end);
+            }
+            ip += op.instruction_size(code, ip).unwrap_or(1);
+        }
+        panic!("no JumpBack (loop) in chunk");
+    }
+
+    /// #190 — the region compiler + `LoopFn` ABI run a real numeric loop end-to-end (independent of
+    /// the VM dispatch loop): `while (i < 10) { s = s + i; i = i + 1 }` from all-zero live-ins must
+    /// leave `s = 45`, `i = 10` in the live slots and return an in-range exit id, without deopting.
+    #[test]
+    fn osr_region_runs_numeric_loop() {
+        let chunk =
+            top_chunk("let s = 0.0\nlet i = 0.0\nwhile (i < 10.0) { s = s + i; i = i + 1.0 }\n");
+        let (header, end) = first_region(&chunk);
+        let lf = try_compile_loop(&chunk, header, end).expect("pure-numeric loop must OSR-compile");
+        assert!(!lf.used_slots.is_empty() && !lf.exits.is_empty());
+        let mut buf = vec![0.0f64; lf.used_slots.len()];
+        let mut deopt = 0u8;
+        let exit = unsafe { lf.call(buf.as_mut_ptr(), &mut deopt as *mut u8) };
+        assert!((exit as usize) < lf.exits.len(), "exit id in range");
+        assert_eq!(deopt, 0, "v1 region never sets the deopt flag");
+        let mut got = buf.clone();
+        got.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert_eq!(got, vec![10.0, 45.0], "s=45 (sum 0..9), i=10 after the loop");
+    }
+
+    /// #190 — a loop that touches a non-slot value (a call) is not pure-numeric slot math, so the
+    /// region must be rejected (negative-cached) and the VM keeps interpreting.
+    #[test]
+    fn osr_region_rejects_calls() {
+        let chunk = top_chunk(
+            "let a = 0.0\nfor (let i = 0; i < 100; i = i + 1) { a = a + Math.floor(i / 2.0) }\n",
+        );
+        let (header, end) = first_region(&chunk);
+        assert!(
+            try_compile_loop(&chunk, header, end).is_none(),
+            "a loop containing a call must not OSR-compile"
+        );
+    }
+
+    /// #190 — a loop with nested branches compiles and computes correctly through multiple blocks:
+    /// `while (i < 20) { if (i % 2 == 0) s = s + i; i = i + 1 }` → s = sum of evens in 0..19 = 90.
+    #[test]
+    fn osr_region_handles_branches() {
+        let chunk = top_chunk(
+            "let s = 0.0\nlet i = 0.0\nwhile (i < 20.0) { if (i % 2.0 == 0.0) { s = s + i }; i = i + 1.0 }\n",
+        );
+        let (header, end) = first_region(&chunk);
+        let lf = try_compile_loop(&chunk, header, end).expect("branchy numeric loop must OSR-compile");
+        let mut buf = vec![0.0f64; lf.used_slots.len()];
+        let mut deopt = 0u8;
+        unsafe { lf.call(buf.as_mut_ptr(), &mut deopt as *mut u8) };
+        let mut got = buf.clone();
+        got.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert_eq!(got, vec![20.0, 90.0], "s=90 (0+2+…+18), i=20");
     }
 }

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -1368,7 +1368,7 @@ impl Vm {
         let mut deopt: u8 = 0;
         // SAFETY: `buf` is a valid `[f64; used_slots.len()]`; `deopt` is a valid `*mut u8`. The region
         // was compiled for exactly this chunk+header (fingerprint-checked in the cache).
-        let exit_id = unsafe { loopfn.call(buf.as_mut_ptr(), &mut deopt as *mut u8) };
+        let exit_id = loopfn.call(&mut buf, &mut deopt);
         for (p, &slot) in loopfn.used_slots.iter().enumerate() {
             if let Some(d) = slots.get_mut(slot_base + slot as usize) {
                 *d = Value::Number(buf[p]);

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -1559,7 +1559,7 @@ impl Vm {
                         if osr_hot.1 != u32::MAX {
                             osr_hot.1 = osr_hot.1.saturating_add(1);
                             if osr_hot.1 >= OSR_THRESHOLD
-                                && (osr_hot.1 - OSR_THRESHOLD) % OSR_RETRY == 0
+                                && osr_hot.1.saturating_sub(OSR_THRESHOLD).is_multiple_of(OSR_RETRY)
                             {
                                 match Self::run_osr(
                                     &cur, header_ip, region_end, &mut slots, slot_base,
@@ -2427,7 +2427,7 @@ impl Vm {
                         if osr_hot.1 != u32::MAX {
                             osr_hot.1 = osr_hot.1.saturating_add(1);
                             if osr_hot.1 >= OSR_THRESHOLD
-                                && (osr_hot.1 - OSR_THRESHOLD) % OSR_RETRY == 0
+                                && osr_hot.1.saturating_sub(OSR_THRESHOLD).is_multiple_of(OSR_RETRY)
                             {
                                 match Self::run_osr(
                                     chunk, header_ip, region_end, &mut slot_locals, 0,

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -51,6 +51,27 @@ use tishlang_core::{max_call_depth, stack_overflow_error};
 /// comfortably more than either needs while still far larger than a single f64-ABI recursion frame.
 const RECUR_STACK_MARGIN: usize = 256 * 1024;
 
+/// OSR back-edge count at which a hot top-level loop is first offered to the region JIT (#190). High
+/// enough that the compile + first-attempt cost is amortized over a genuinely hot loop.
+#[cfg(not(target_arch = "wasm32"))]
+const OSR_THRESHOLD: u32 = 10_000;
+/// After the first attempt, retry OSR every this-many back-edges — only relevant to the live-in-miss
+/// path (a numeric loop compiles and consumes itself on the first attempt). Keeps the re-check off the
+/// per-iteration hot path.
+#[cfg(not(target_arch = "wasm32"))]
+const OSR_RETRY: u32 = 50_000;
+
+/// Outcome of an OSR attempt (#190).
+#[cfg(not(target_arch = "wasm32"))]
+enum OsrResult {
+    /// Ran the loop natively; resume interpreting at this chunk `ip` (the loop exit).
+    Compiled(usize),
+    /// A live-in slot is non-numeric; keep interpreting (may become eligible later → retry).
+    LiveInMiss,
+    /// The region is not a pure-numeric slot loop; give up on this loop (negative-cached).
+    NotCompilable,
+}
+
 /// Append the source location of the instruction at `off` to a runtime-error message, e.g.
 /// `Cannot read property 'x' of null (at app.tish:4)` (issue #74). No-ops when the chunk
 /// carries no line table (e.g. deserialized bytecode).
@@ -1312,6 +1333,64 @@ impl Vm {
         true
     }
 
+    /// On-stack replacement (#190): run one hot loop region natively, or report why we can't.
+    ///
+    /// Called from the frame VM's `JumpBack` handler once a loop's back-edge counter trips. Compiles
+    /// (cached) the region `[header_ip, region_end)`; if it is a pure-numeric slot loop AND every live
+    /// slot currently holds a `Number` (else the native f64 math would diverge from the interpreter),
+    /// copies the live-ins into an f64 buffer, runs the whole remaining loop natively, writes the
+    /// live-outs back as `Number`s, and returns the chunk `ip` of the loop exit to resume dispatch at.
+    ///
+    /// Soundness: the v1 region whitelist is pure slot/stack arithmetic — no calls, no member/index,
+    /// no object or array mutation — so nothing observable happens inside the region, and the
+    /// interpreter running the same bytecode from the same numeric live-ins produces bit-identical
+    /// slots (the `emit_simple_op` lowering matches `eval_binop`). A non-numeric live-in is the deopt
+    /// case: we simply don't OSR and keep interpreting, so state is never corrupted.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn run_osr(
+        chunk: &Chunk,
+        header_ip: usize,
+        region_end: usize,
+        slots: &mut [Value],
+        slot_base: usize,
+    ) -> OsrResult {
+        let loopfn = match crate::jit::try_compile_loop(chunk, header_ip, region_end) {
+            Some(lf) => lf,
+            None => return OsrResult::NotCompilable,
+        };
+        let mut buf: Vec<f64> = Vec::with_capacity(loopfn.used_slots.len());
+        for &slot in &loopfn.used_slots {
+            match slots.get(slot_base + slot as usize) {
+                Some(Value::Number(n)) => buf.push(*n),
+                _ => return OsrResult::LiveInMiss, // a live slot is non-numeric → deopt, keep interpreting
+            }
+        }
+        let mut deopt: u8 = 0;
+        // SAFETY: `buf` is a valid `[f64; used_slots.len()]`; `deopt` is a valid `*mut u8`. The region
+        // was compiled for exactly this chunk+header (fingerprint-checked in the cache).
+        let exit_id = unsafe { loopfn.call(buf.as_mut_ptr(), &mut deopt as *mut u8) };
+        for (p, &slot) in loopfn.used_slots.iter().enumerate() {
+            if let Some(d) = slots.get_mut(slot_base + slot as usize) {
+                *d = Value::Number(buf[p]);
+            }
+        }
+        match loopfn.exits.get(exit_id as usize) {
+            Some(&ip) => OsrResult::Compiled(ip),
+            // Out-of-range exit id is impossible (the region returns an in-range id), but if it ever
+            // happened the slots are already a consistent post-loop state, so re-interpreting the
+            // (now-false) loop header exits correctly.
+            None => OsrResult::LiveInMiss,
+        }
+    }
+
+    /// OSR is **default ON**; `TISH_OSR=0` disables it (escape hatch, mirrors `TISH_JIT_ARRAYS`).
+    #[cfg(not(target_arch = "wasm32"))]
+    #[inline]
+    fn osr_enabled() -> bool {
+        static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *ENABLED.get_or_init(|| std::env::var("TISH_OSR").map(|v| v != "0").unwrap_or(true))
+    }
+
     /// Iterative frame-stack execution of a frame-eligible `VmClosure` (the frame-VM, flag-on).
     /// Returns `None` if the entry chunk is ineligible (caller falls back to `VmClosure::call`).
     /// Calls + recursion run on the heap `frames` stack — no per-call `Vm`, no recursive `run_chunk`
@@ -1331,6 +1410,14 @@ impl Vm {
         let mut slots: Vec<Value> = Vec::new();
         let mut slot_base: usize = 0;
         slots.resize(cur.num_slots as usize, Value::Null);
+        // #190 OSR: per-`(chunk, loop header)` back-edge counters (`u32::MAX` = gave up), with a
+        // single-entry fast slot for the loop currently spinning (see the `run_chunk` copy for the
+        // rationale) so a resolved hot loop stays off the HashMap.
+        #[cfg(not(target_arch = "wasm32"))]
+        let mut osr_counters: std::collections::HashMap<(usize, usize), u32> =
+            std::collections::HashMap::new();
+        #[cfg(not(target_arch = "wasm32"))]
+        let mut osr_hot: ((usize, usize), u32) = ((usize::MAX, usize::MAX), 0);
         for i in 0..(cur.param_count as usize) {
             if let Some(v) = args.get(i) {
                 if let Some(d) = slots.get_mut(slot_base + i) {
@@ -1455,6 +1542,38 @@ impl Vm {
                 }
                 Opcode::JumpBack => {
                     let dist = Self::read_u16(code, &mut ip) as usize;
+                    // #190 OSR: `ip` now points just past the JumpBack (region end); the loop header is
+                    // `region_end - dist`. Once a loop is hot, try to run its remaining iterations in
+                    // native code (numeric slot loops only; anything else falls straight through).
+                    #[cfg(not(target_arch = "wasm32"))]
+                    if Self::osr_enabled() {
+                        let region_end = ip;
+                        let header_ip = ip.saturating_sub(dist);
+                        let key = (Arc::as_ptr(&cur) as usize, header_ip);
+                        if key != osr_hot.0 {
+                            if osr_hot.0 .0 != usize::MAX {
+                                osr_counters.insert(osr_hot.0, osr_hot.1);
+                            }
+                            osr_hot = (key, osr_counters.get(&key).copied().unwrap_or(0));
+                        }
+                        if osr_hot.1 != u32::MAX {
+                            osr_hot.1 = osr_hot.1.saturating_add(1);
+                            if osr_hot.1 >= OSR_THRESHOLD
+                                && (osr_hot.1 - OSR_THRESHOLD) % OSR_RETRY == 0
+                            {
+                                match Self::run_osr(
+                                    &cur, header_ip, region_end, &mut slots, slot_base,
+                                ) {
+                                    OsrResult::Compiled(exit_ip) => {
+                                        ip = exit_ip;
+                                        continue;
+                                    }
+                                    OsrResult::LiveInMiss => {}
+                                    OsrResult::NotCompilable => osr_hot.1 = u32::MAX,
+                                }
+                            }
+                        }
+                    }
                     ip = ip.saturating_sub(dist);
                 }
                 Opcode::Pop => {
@@ -1605,6 +1724,15 @@ impl Vm {
         // frame indexed by slot — no per-call hashmap, no name lookups. Args bind
         // to slots 0..param_count. Empty for name-based chunks.
         let mut slot_locals: Vec<Value> = Vec::new();
+        // #190 OSR: per-loop-header back-edge counters for this frame (`u32::MAX` = gave up). `osr_hot`
+        // is a single-entry fast slot for the loop currently spinning — its header is constant across
+        // iterations, so the common hot loop never touches the HashMap (which is hit only when the
+        // active loop changes: entry, exit, or a nested-loop switch). Keeps the per-back-edge cost of a
+        // resolved loop to two integer compares.
+        #[cfg(not(target_arch = "wasm32"))]
+        let mut osr_counters: std::collections::HashMap<usize, u32> = std::collections::HashMap::new();
+        #[cfg(not(target_arch = "wasm32"))]
+        let mut osr_hot: (usize, u32) = (usize::MAX, 0);
         // Frame-local string builder for `acc += x` on a slot local (Opcode::AppendLocal): keeps the
         // accumulator in a growable `sb_buf` so appends are amortized O(1) instead of reallocating the
         // whole string each time. `sb_slot` is the slot currently buffered (at most one). The slot's
@@ -2281,6 +2409,39 @@ impl Vm {
                 }
                 Opcode::JumpBack => {
                     let dist = Self::read_u16(code, &mut ip) as usize;
+                    // #190 OSR: on a hot back-edge, try to finish the loop natively. Slot-based frames
+                    // only (`slot_locals` is the live frame); non-slot / non-numeric loops fail the
+                    // whitelist or the live-in check and fall straight through to the interpreter.
+                    #[cfg(not(target_arch = "wasm32"))]
+                    if chunk.slot_based && Self::osr_enabled() {
+                        let region_end = ip;
+                        let header_ip = ip.saturating_sub(dist);
+                        // Switch the fast slot only when the active loop changes: stash the old count,
+                        // load this header's (default 0). The hot loop keeps `header_ip == osr_hot.0`.
+                        if header_ip != osr_hot.0 {
+                            if osr_hot.0 != usize::MAX {
+                                osr_counters.insert(osr_hot.0, osr_hot.1);
+                            }
+                            osr_hot = (header_ip, osr_counters.get(&header_ip).copied().unwrap_or(0));
+                        }
+                        if osr_hot.1 != u32::MAX {
+                            osr_hot.1 = osr_hot.1.saturating_add(1);
+                            if osr_hot.1 >= OSR_THRESHOLD
+                                && (osr_hot.1 - OSR_THRESHOLD) % OSR_RETRY == 0
+                            {
+                                match Self::run_osr(
+                                    chunk, header_ip, region_end, &mut slot_locals, 0,
+                                ) {
+                                    OsrResult::Compiled(exit_ip) => {
+                                        ip = exit_ip;
+                                        continue;
+                                    }
+                                    OsrResult::LiveInMiss => {}
+                                    OsrResult::NotCompilable => osr_hot.1 = u32::MAX,
+                                }
+                            }
+                        }
+                    }
                     ip = ip.saturating_sub(dist);
                 }
                 Opcode::BinOp => {


### PR DESCRIPTION
## What & why

Closes #190. The VM's Cranelift JIT only compiled **whole functions**, gated on `param_count`, so a hot loop in **top-level code** (`param_count == 0`) ran fully interpreted forever — a script written without a `main()` wrapper paid the interpreter tax on its main loop no matter how long it ran.

On-stack replacement fixes it: on each `JumpBack` back-edge the frame VM counts the loop; once hot (10k iters) it compiles the loop **region** `[header, backedge]` to native code over the chunk's numeric slot frame, copies the live-in slots into an f64 buffer, runs the remaining iterations natively, and resumes interpretation at the loop exit.

```
let sum = 0.0; let i = 0.0
while (i < 50000000.0) { sum = sum + i * 2.0 - 1.0; i = i + 1.0 }
// before: 3819ms   after: 57ms   (Node: 60ms)
```

## Design

- **jit.rs**: `try_compile_loop` → `compile_loop_region` → `build_loop_region_body`, reusing `emit_simple_op` so the arithmetic is **bit-for-bit identical to `eval_binop`** (same ToInt32/shift lowering the whole-function JIT already uses). ABI `extern "C" fn(slots: *mut f64, deopt: *mut u8) -> i32` returns the exit id; a jump target outside the region is an exit block that flushes the live set and returns its id. Nested loops + branches within the region are handled. Per-`(chunk, header)` cache with **negative caching** (a non-compilable loop is scanned once).
- **vm.rs**: the `JumpBack` handlers of `run_chunk` (default path) and `run_framed` gain the counter + trigger; `run_osr` does the live-in check, copy-in, native call, copy-out, and returns the resume ip.

## Soundness

The v1 whitelist is **pure slot/stack arithmetic** — no calls, member/index, arrays, objects, `LoadVar`, or `Return`. So nothing observable happens inside a region, and the interpreter running the same bytecode from the same **numeric** live-ins produces bit-identical slots. **The live-in check is the deopt**: if any live slot is non-numeric at the trigger, we don't OSR and keep interpreting — a type-unstable loop stays on the interpreter, state never corrupted. No mid-run deopt is possible for a pure-numeric region, so the `deopt` out-param is reserved for the future array/property regions.

## Perf hygiene

Per-back-edge cost on a resolved loop is **two integer compares**: a single-entry `osr_hot` fast slot holds the spinning loop's counter (header constant across iterations), so the HashMap is touched only when the active loop changes. Confirmed **no regression** on hot non-OSR loops — megamorphic (a 20M-iter top-level loop that fails the whitelist) is within noise: ON median 2718ms vs OFF 2714ms. `TISH_OSR=0` disables OSR; cfg'd out on wasm.

## Validation

- **3 region unit tests**: numeric loop end-to-end (`s=45, i=10`), branch handling (sum of evens), call-rejection (not-compilable).
- **Differential harness (OSR on == off)**: branches, nested loops, break/continue, bitwise/shifts, call-in-loop, **type-transition deopt** (a fn OSR'd on numeric args, live-in-misses on a string arg → correct string result), triple-nested loops.
- **Cross-backend integration 25/25** (interp/vm/native/cranelift/wasi/js) with OSR default-on.
- **VM benchmark checksums identical on/off**: megamorphic, typed_array_hof, mandelbrot, fnv_hash, nbody, spectral_norm.
- wasm gate compiles (`wasm32-wasip1`).

## Honest scope

Flips **no gauntlet fixture by itself** (as the issue states): the native backend is untouched, and megamorphic/typed_array_hof need the property/array support the v1 whitelist deliberately excludes. This is the **harness** that lets future FStruct/array-region work reach top-level loops, and it removes the "hot top-level numeric loop runs interpreted forever" cliff for real scripts.