### PR TITLE
perf(vm): string-builder fast path for `s = s + <str>` plain assign (#186)

### DIFF
--- a/crates/tish_bytecode/src/compiler.rs
+++ b/crates/tish_bytecode/src/compiler.rs
@@ -18,6 +18,21 @@ enum SimpleMapResult {
     BinOp(BinOp, Constant, bool), // op, constant, param_on_left
 }
 
+/// Provably evaluates to a `String` at runtime — the safety gate for the plain-assign `AppendLocal`
+/// builder fast path (#186). A string literal, a template literal, or an `+` chain containing one
+/// (JS `+` string-coerces the whole expression). Conservative: an unknown/numeric operand returns
+/// `false`, so a numeric accumulator never routes through the builder.
+fn is_string_typed(expr: &Expr) -> bool {
+    match expr {
+        Expr::Literal { value: Literal::String(_), .. } => true,
+        Expr::TemplateLiteral { .. } => true,
+        Expr::Binary { left, op: BinOp::Add, right, .. } => {
+            is_string_typed(left) || is_string_typed(right)
+        }
+        _ => false,
+    }
+}
+
 fn literal_to_constant(expr: &Expr) -> Option<Constant> {
     if let Expr::Literal { value, .. } = expr {
         Some(match value {
@@ -1248,6 +1263,24 @@ impl<'a> Compiler<'a> {
                         self.compile_expr(value)?;
                         self.emit_u16(Opcode::AppendLocal, slot);
                         return Ok(());
+                    }
+                }
+                // Same builder fast path for the plain-assign spelling `s = s + <str>` — but ONLY when
+                // the appended operand is PROVABLY a string. A numeric accumulator (`i = i + 1`) must
+                // NOT builder-ize: the VM keeps a single string builder slot, so a second builder-ized
+                // slot flushes the first every iteration → O(n²) (#186). Restricting to string-typed
+                // RHS keeps `s = s + "x"` fast (string_concat) while `i = i + 1` stays a plain store.
+                if let Expr::Assign { name, value, .. } = expr {
+                    if let Expr::Binary { left, op: BinOp::Add, right, .. } = value.as_ref() {
+                        if matches!(left.as_ref(), Expr::Ident { name: ln, .. } if ln == name)
+                            && is_string_typed(right)
+                        {
+                            if let Some(slot) = self.resolve_slot(name) {
+                                self.compile_expr(right)?;
+                                self.emit_u16(Opcode::AppendLocal, slot);
+                                return Ok(());
+                            }
+                        }
                     }
                 }
                 self.compile_expr(expr)?;

--- a/crates/tish_bytecode/tests/append_local_string_builder.rs
+++ b/crates/tish_bytecode/tests/append_local_string_builder.rs
@@ -1,0 +1,63 @@
+//! #186 — the plain-assign string-builder fast path: `s = s + <str>` compiles to `AppendLocal`, but a
+//! numeric accumulator `i = i + 1` must NOT (or the VM's single string-builder slot thrashes → O(n²)).
+
+use tishlang_bytecode::{compile, Chunk, Opcode};
+use tishlang_parser::parse;
+
+fn count_opcode(chunk: &Chunk, op: u8) -> usize {
+    // Opcodes are variable-width; the compiler here emits only slot-carrying ops, so a byte-value
+    // scan is a sufficient upper bound for these targeted single-loop programs. We assert presence
+    // vs absence, not exact counts, so an incidental operand collision can't cause a false pass.
+    let mut n = chunk.code.iter().filter(|&&b| b == op).count();
+    for nested in &chunk.nested {
+        n += count_opcode(nested, op);
+    }
+    n
+}
+
+fn chunk_of(src: &str) -> Chunk {
+    let program = parse(src).expect("parse");
+    let optimized = tishlang_opt::optimize(&program);
+    compile(&optimized).expect("compile")
+}
+
+#[test]
+fn string_plus_assign_uses_append_local() {
+    // `s = s + "x"` must route through the builder (the string_concat 55x→2.5x win).
+    let chunk = chunk_of("let s = \"\"\nlet i = 0\nwhile (i < 10) { s = s + \"x\"; i = i + 1 }\n");
+    assert!(
+        count_opcode(&chunk, Opcode::AppendLocal as u8) >= 1,
+        "`s = s + \"x\"` must emit AppendLocal"
+    );
+}
+
+#[test]
+fn numeric_plus_assign_does_not_use_append_local() {
+    // A pure numeric loop must NOT builder-ize — no AppendLocal at all.
+    let chunk = chunk_of("let n = 0\nlet i = 0\nwhile (i < 10) { n = n + 2; i = i + 1 }\n");
+    assert_eq!(
+        count_opcode(&chunk, Opcode::AppendLocal as u8),
+        0,
+        "`n = n + 2` / `i = i + 1` must NOT emit AppendLocal (would thrash the single builder slot)"
+    );
+}
+
+#[test]
+fn template_literal_rhs_uses_append_local() {
+    let chunk = chunk_of("let t = \"\"\nlet j = 0\nwhile (j < 3) { t = t + `[${j}]`; j = j + 1 }\n");
+    assert!(
+        count_opcode(&chunk, Opcode::AppendLocal as u8) >= 1,
+        "`t = t + `[${{j}}]`` (template RHS) must emit AppendLocal"
+    );
+}
+
+#[test]
+fn prepend_does_not_use_append_local() {
+    // `p = "a" + p` is a prepend — the builder appends, so it must NOT match.
+    let chunk = chunk_of("let p = \"z\"\np = \"a\" + p\n");
+    assert_eq!(
+        count_opcode(&chunk, Opcode::AppendLocal as u8),
+        0,
+        "prepend `p = \"a\" + p` must not use the append builder"
+    );
+}


### PR DESCRIPTION
## What & why

The `AppendLocal` string builder only fired for the compound `s += x` spelling. The common (and benchmarked) `s = s + "x"` plain-assign form fell to the generic `LoadLocal; Add; StoreLocal` path and **reallocated the whole string every iteration** — string_concat on the VM was **166ms vs Node 4ms (55×)**.

Now `s = s + <str>` compiles to `<rhs>; AppendLocal slot` too — amortized O(1):

```
while (i < 100000) { s = s + "x"; i = i + 1 }
// VM: 166ms → 10ms  (55× → 2.5× vs Node's 4ms)
```

## The trap, and the safe gate

The naive fix (match `left == name` syntactically) is a correctness/perf trap: it also matches the numeric accumulator `i = i + 1`, and the VM keeps a **single** string-builder slot — so a second builder-ized slot flushes the first every iteration → **O(n²)**.

The gate is a compile-time type check, `is_string_typed`: route through the builder **only when the appended operand is provably a string** — a string literal, a template literal, or a `+` chain containing one (JS `+` string-coerces). A numeric or unknown operand keeps the generic path, so `i = i + 1` never builder-izes and the interleaved `acc = acc + "q"; cnt = cnt + 1` loop stays **O(n)** (measured 8ms at 100k).

Purely additive and VM-only — native/interp are already fast, and the result is identical string concatenation.

## Validation

- **Cross-backend integration 25/25** (interp == vm == native == cranelift == wasi == js == node).
- Edge cases match across all backends: numeric accumulator (not builder-ized), number→string transition (`5 + "x"` → `"5xy"`), template RHS, prepend, chained concat, and the interleaved string+numeric trap case.
- **4 new bytecode-emission regression tests**: string/template RHS emits `AppendLocal`; numeric and prepend do not.
- String core fixtures pass.

## Honest scope

This is #186's **string half**. The Math-intrinsics half (a real nbody prerequisite) is unbuilt, and string_build's own accumulator is a different shape (unmoved). Part of the VM-perf track surfaced by the fresh VM-vs-node audit on #203.