### PR TITLE
perf(vm): Math unary intrinsics — MathUnary opcode + JIT lowering (#186)

### DIFF
--- a/crates/tish_bytecode/src/compiler.rs
+++ b/crates/tish_bytecode/src/compiler.rs
@@ -11,7 +11,7 @@ use tishlang_ast::{
 
 use crate::chunk::{Chunk, Constant};
 use crate::encoding::{binop_to_u8, compound_op_to_u8, unaryop_to_u8};
-use crate::opcode::Opcode;
+use crate::opcode::{MathUnaryFn, Opcode};
 
 enum SimpleMapResult {
     Identity,
@@ -125,6 +125,11 @@ struct Compiler<'a> {
     /// JIT lowers it to a native recursive call). `None` for anonymous fns, top-level, or anywhere the
     /// self-binding can't be proven stable.
     self_fn_name: Option<Arc<str>>,
+    /// #186 — `Math` is provably the global builtin: it is never rebound/shadowed anywhere in the
+    /// program (via the conservative [`stmt_rebinds`] scan). Only then may `Math.<fn>(arg)` lower to
+    /// the [`Opcode::MathUnary`] intrinsic, which the numeric JIT can compile without a shape guard.
+    /// `false` on nested-fn compilers and whenever the scan can't prove stability.
+    math_is_global: bool,
 }
 
 /// Does `e` reference only the given params (no free/global vars, no nested
@@ -613,6 +618,7 @@ impl<'a> Compiler<'a> {
             general_slots: false,
             finally_stack: Vec::new(),
             self_fn_name: None,
+            math_is_global: false,
         }
     }
 
@@ -2010,6 +2016,30 @@ impl<'a> Compiler<'a> {
                 self.emit_u8(Opcode::UnaryOp, unaryop_to_u8(*op));
             }
             Expr::Call { callee, args, .. } => {
+                // #186: `Math.<unaryfn>(arg)` → `<arg>; MathUnary(id)` when `Math` is provably the
+                // global builtin (unshadowed program-wide) and there is exactly one argument. Lets the
+                // numeric JIT lower the intrinsic (math_trig; a Math.* prereq for other kernels).
+                if self.math_is_global && args.len() == 1 {
+                    if let Expr::Member {
+                        object,
+                        prop: MemberProp::Name { name: fname, .. },
+                        optional: false,
+                        ..
+                    } = callee.as_ref()
+                    {
+                        if let (Expr::Ident { name: obj, .. }, CallArg::Expr(arg)) =
+                            (object.as_ref(), &args[0])
+                        {
+                            if obj.as_ref() == "Math" && self.resolve_slot("Math").is_none() {
+                                if let Some(mfn) = MathUnaryFn::from_name(fname.as_ref()) {
+                                    self.compile_expr(arg)?;
+                                    self.emit_u16(Opcode::MathUnary, mfn as u16);
+                                    return Ok(());
+                                }
+                            }
+                        }
+                    }
+                }
                 // Fast path: arr.sort((a,b)=>a-b) or arr.sort((a,b)=>b-a) -> ArraySortNumeric
                 if !args.iter().any(|a| matches!(a, CallArg::Spread(_)))
                     && args.len() == 1
@@ -2714,6 +2744,10 @@ fn compile_internal(
     let mut chunk = Chunk::new();
     chunk.source = source; // tag before compiling so nested chunks inherit it (#74)
     let mut compiler = Compiler::new(&mut chunk, retain_last_expr);
+    // #186 — `Math` intrinsics are sound only if `Math` is never rebound anywhere in the program.
+    // `stmt_rebinds` is conservative (any rebind, destructure, FunDecl, or unknown node → true), so a
+    // `false` here only forgoes the optimization, never risks a miscompile.
+    compiler.math_is_global = !program.statements.iter().any(|s| stmt_rebinds(s, "Math"));
     compiler.compile_program(program)?;
     if peephole {
         crate::peephole::optimize(&mut chunk);

--- a/crates/tish_bytecode/src/lib.rs
+++ b/crates/tish_bytecode/src/lib.rs
@@ -16,5 +16,5 @@ pub use compiler::{
     compile_with_source, CompileError,
 };
 pub use encoding::{binop_to_u8, compound_op_to_u8, u8_to_binop, u8_to_unaryop, unaryop_to_u8};
-pub use opcode::Opcode;
+pub use opcode::{MathUnaryFn, Opcode};
 pub use serialize::{deserialize, serialize};

--- a/crates/tish_bytecode/src/opcode.rs
+++ b/crates/tish_bytecode/src/opcode.rs
@@ -204,13 +204,33 @@ impl MathUnaryFn {
         })
     }
 
-    /// Decode an opcode operand to the fn id.
+    /// Decode an opcode operand to the fn id (safe match — no transmute).
     pub fn from_u16(v: u16) -> Option<MathUnaryFn> {
-        if v <= 20 {
-            Some(unsafe { std::mem::transmute::<u16, MathUnaryFn>(v) })
-        } else {
-            None
-        }
+        use MathUnaryFn::*;
+        Some(match v {
+            0 => Sqrt,
+            1 => Cbrt,
+            2 => Abs,
+            3 => Floor,
+            4 => Ceil,
+            5 => Round,
+            6 => Trunc,
+            7 => Sign,
+            8 => Sin,
+            9 => Cos,
+            10 => Tan,
+            11 => Asin,
+            12 => Acos,
+            13 => Atan,
+            14 => Sinh,
+            15 => Cosh,
+            16 => Tanh,
+            17 => Exp,
+            18 => Log,
+            19 => Log2,
+            20 => Log10,
+            _ => return None,
+        })
     }
 
     /// Apply the intrinsic (the single source of truth for VM + JIT + interp result parity).

--- a/crates/tish_bytecode/src/opcode.rs
+++ b/crates/tish_bytecode/src/opcode.rs
@@ -139,13 +139,139 @@ pub enum Opcode {
     /// nothing on the stack — only emitted where the assignment's result is discarded. Slots are
     /// frame-private (never captured), so the buffer needs no cross-frame sharing.
     AppendLocal = 54,
+    /// #186 — apply a unary `Math.<fn>` intrinsic to the top-of-stack number: pop one value, push
+    /// `Math.fn(x)`. The u16 operand is the [`MathUnaryFn`] id. Emitted by the compiler ONLY when
+    /// `Math` is provably the global builtin (never shadowed in the program), so the numeric JIT can
+    /// lower it to a native op / libcall without a runtime shape guard. Behaviour is identical to
+    /// `LoadVar Math; GetMember fn; <arg>; Call 1` on a number.
+    MathUnary = 55,
+}
+
+/// The unary `Math` functions the [`Opcode::MathUnary`] fast path recognizes (#186). f64→f64;
+/// the discriminant is the opcode operand. Kept in sync with the VM handler and the JIT lowering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub enum MathUnaryFn {
+    Sqrt = 0,
+    Cbrt = 1,
+    Abs = 2,
+    Floor = 3,
+    Ceil = 4,
+    Round = 5,
+    Trunc = 6,
+    Sign = 7,
+    Sin = 8,
+    Cos = 9,
+    Tan = 10,
+    Asin = 11,
+    Acos = 12,
+    Atan = 13,
+    Sinh = 14,
+    Cosh = 15,
+    Tanh = 16,
+    Exp = 17,
+    Log = 18,
+    Log2 = 19,
+    Log10 = 20,
+}
+
+impl MathUnaryFn {
+    /// Map a `Math.<name>` member to its id, or `None` if it isn't a supported unary intrinsic.
+    pub fn from_name(name: &str) -> Option<MathUnaryFn> {
+        Some(match name {
+            "sqrt" => MathUnaryFn::Sqrt,
+            "cbrt" => MathUnaryFn::Cbrt,
+            "abs" => MathUnaryFn::Abs,
+            "floor" => MathUnaryFn::Floor,
+            "ceil" => MathUnaryFn::Ceil,
+            "round" => MathUnaryFn::Round,
+            "trunc" => MathUnaryFn::Trunc,
+            "sign" => MathUnaryFn::Sign,
+            "sin" => MathUnaryFn::Sin,
+            "cos" => MathUnaryFn::Cos,
+            "tan" => MathUnaryFn::Tan,
+            "asin" => MathUnaryFn::Asin,
+            "acos" => MathUnaryFn::Acos,
+            "atan" => MathUnaryFn::Atan,
+            "sinh" => MathUnaryFn::Sinh,
+            "cosh" => MathUnaryFn::Cosh,
+            "tanh" => MathUnaryFn::Tanh,
+            "exp" => MathUnaryFn::Exp,
+            "log" => MathUnaryFn::Log,
+            "log2" => MathUnaryFn::Log2,
+            "log10" => MathUnaryFn::Log10,
+            _ => return None,
+        })
+    }
+
+    /// Decode an opcode operand to the fn id.
+    pub fn from_u16(v: u16) -> Option<MathUnaryFn> {
+        if v <= 20 {
+            Some(unsafe { std::mem::transmute::<u16, MathUnaryFn>(v) })
+        } else {
+            None
+        }
+    }
+
+    /// Apply the intrinsic (the single source of truth for VM + JIT + interp result parity).
+    #[inline]
+    pub fn apply(self, x: f64) -> f64 {
+        match self {
+            MathUnaryFn::Sqrt => x.sqrt(),
+            MathUnaryFn::Cbrt => x.cbrt(),
+            MathUnaryFn::Abs => x.abs(),
+            MathUnaryFn::Floor => x.floor(),
+            MathUnaryFn::Ceil => x.ceil(),
+            // JS `Math.round`: ties toward +∞, `[-0.5, 0) → -0`; EXACTLY `tishlang_builtins::math::
+            // round_f64` (replicated here — this crate sits below builtins — so VM/JIT == interp).
+            MathUnaryFn::Round => {
+                if x.is_nan() || x.is_infinite() || x == 0.0 {
+                    x
+                } else if (-0.5..0.5).contains(&x) {
+                    if x < 0.0 {
+                        -0.0
+                    } else {
+                        0.0
+                    }
+                } else {
+                    (x + 0.5).floor()
+                }
+            }
+            MathUnaryFn::Trunc => x.trunc(),
+            // JS `Math.sign` (matches `tishlang_builtins::math::sign`): NaN→NaN, else ±1, and 0/-0→+0.
+            MathUnaryFn::Sign => {
+                if x.is_nan() {
+                    f64::NAN
+                } else if x > 0.0 {
+                    1.0
+                } else if x < 0.0 {
+                    -1.0
+                } else {
+                    0.0
+                }
+            }
+            MathUnaryFn::Sin => x.sin(),
+            MathUnaryFn::Cos => x.cos(),
+            MathUnaryFn::Tan => x.tan(),
+            MathUnaryFn::Asin => x.asin(),
+            MathUnaryFn::Acos => x.acos(),
+            MathUnaryFn::Atan => x.atan(),
+            MathUnaryFn::Sinh => x.sinh(),
+            MathUnaryFn::Cosh => x.cosh(),
+            MathUnaryFn::Tanh => x.tanh(),
+            MathUnaryFn::Exp => x.exp(),
+            MathUnaryFn::Log => x.ln(),
+            MathUnaryFn::Log2 => x.log2(),
+            MathUnaryFn::Log10 => x.log10(),
+        }
+    }
 }
 
 impl Opcode {
-    /// Decode byte to opcode. Safe for b in 0..=54 (matches #[repr(u8)] discriminants).
+    /// Decode byte to opcode. Safe for b in 0..=55 (matches #[repr(u8)] discriminants).
     #[inline]
     pub fn from_u8(b: u8) -> Option<Opcode> {
-        if b <= 54 {
+        if b <= 55 {
             Some(unsafe { std::mem::transmute::<u8, Opcode>(b) })
         } else {
             None

--- a/crates/tish_bytecode/tests/math_unary_intrinsic.rs
+++ b/crates/tish_bytecode/tests/math_unary_intrinsic.rs
@@ -1,0 +1,47 @@
+//! #186 — `Math.<unaryfn>(arg)` lowers to `MathUnary` ONLY when `Math` is the unshadowed global; a
+//! rebound `Math`, a 2-arg `Math.*`, or a non-math member must keep the general call path.
+
+use tishlang_bytecode::{compile, Chunk, Opcode};
+use tishlang_parser::parse;
+
+fn has_math_unary(chunk: &Chunk) -> bool {
+    if chunk.code.contains(&(Opcode::MathUnary as u8)) {
+        return true;
+    }
+    chunk.nested.iter().any(has_math_unary)
+}
+
+fn chunk_of(src: &str) -> Chunk {
+    let program = parse(src).expect("parse");
+    let optimized = tishlang_opt::optimize(&program);
+    compile(&optimized).expect("compile")
+}
+
+#[test]
+fn global_math_unary_emits_intrinsic() {
+    assert!(has_math_unary(&chunk_of("let x = Math.sqrt(4.0)\n")), "Math.sqrt → MathUnary");
+    assert!(has_math_unary(&chunk_of("let x = Math.sin(1.0) + Math.floor(2.5)\n")));
+}
+
+#[test]
+fn shadowed_math_keeps_general_call() {
+    // `Math` rebound as a local → the intrinsic would be a miscompile; must NOT emit MathUnary.
+    assert!(
+        !has_math_unary(&chunk_of("let Math = 5\nlet x = Math\n")),
+        "a program that rebinds `Math` must not intrinsify"
+    );
+    assert!(
+        !has_math_unary(&chunk_of(
+            "fn mysqrt(x) { return x }\nlet Math = { sqrt: mysqrt }\nlet x = Math.sqrt(4.0)\n"
+        )),
+        "a shadowed Math.sqrt must call the user's method"
+    );
+}
+
+#[test]
+fn non_unary_math_stays_a_call() {
+    // Math.max is 2-arg (not a unary intrinsic) → general call, no MathUnary.
+    assert!(!has_math_unary(&chunk_of("let x = Math.max(1.0, 2.0)\n")), "Math.max is not unary");
+    // Math.PI is a property, not a call.
+    assert!(!has_math_unary(&chunk_of("let x = Math.PI\n")), "Math.PI is a property");
+}

--- a/crates/tish_vm/src/jit.rs
+++ b/crates/tish_vm/src/jit.rs
@@ -32,7 +32,9 @@ use cranelift_jit::{JITBuilder, JITModule};
 use cranelift_module::{Linkage, Module};
 
 use tishlang_ast::{BinOp, UnaryOp};
-use tishlang_bytecode::{u8_to_binop, u8_to_unaryop, Chunk, Constant, Opcode, NO_REST_PARAM};
+use tishlang_bytecode::{
+    u8_to_binop, u8_to_unaryop, Chunk, Constant, MathUnaryFn, Opcode, NO_REST_PARAM,
+};
 
 /// A JIT-compiled hot LOOP REGION for on-stack replacement (#190). Unlike [`NumericFn`] (a whole
 /// function over register-`f64` params), this is native code over a chunk's **numeric slot frame**:
@@ -345,6 +347,9 @@ struct JitGlobal {
     /// whitelist is scanned once, not on every back-edge past the trigger threshold.
     osr_cache: HashMap<(usize, usize), (u64, Option<LoopFn>)>,
     counter: usize,
+    /// `FuncId` of the imported `tish_math_call` host fn (#186), declared once at module init and
+    /// re-imported into each compiled function via `declare_func_in_func`.
+    math_call_id: cranelift_module::FuncId,
 }
 
 // SAFETY: `JITModule` is `!Send`, but the single instance lives behind the
@@ -354,7 +359,19 @@ unsafe impl Send for JitGlobal {}
 
 static JIT: OnceLock<Option<Mutex<JitGlobal>>> = OnceLock::new();
 
-fn new_module() -> Option<JITModule> {
+/// Host entry point the JIT calls for `Math.<fn>` intrinsics it doesn't lower to a native op (#186):
+/// sin/cos/tan/exp/log/round/sign/… The single source of truth is [`MathUnaryFn::apply`], so JIT ≡
+/// VM ≡ interpreter bit-for-bit. `extern "C"` and registered as a JIT symbol; the id is the operand.
+#[cfg(not(target_arch = "wasm32"))]
+extern "C" fn tish_math_call(id: i32, x: f64) -> f64 {
+    match tishlang_bytecode::MathUnaryFn::from_u16(id as u16) {
+        Some(m) => m.apply(x),
+        None => f64::NAN,
+    }
+}
+
+/// Build the JIT module and declare the imported `tish_math_call` host function, returning both.
+fn new_module() -> Option<(JITModule, cranelift_module::FuncId)> {
     let mut flag_builder = settings::builder();
     // JIT code is loaded at a fixed address; no PIC / colocated libcalls needed.
     flag_builder.set("use_colocated_libcalls", "false").ok()?;
@@ -364,18 +381,29 @@ fn new_module() -> Option<JITModule> {
     let isa = isa_builder
         .finish(settings::Flags::new(flag_builder))
         .ok()?;
-    let builder = JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
-    Some(JITModule::new(builder))
+    let mut builder = JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
+    builder.symbol("tish_math_call", tish_math_call as *const u8);
+    let mut module = JITModule::new(builder);
+    // Import signature: `(i32 fn-id, f64 x) -> f64`.
+    let mut sig = module.make_signature();
+    sig.params.push(AbiParam::new(types::I32));
+    sig.params.push(AbiParam::new(types::F64));
+    sig.returns.push(AbiParam::new(types::F64));
+    let math_id = module
+        .declare_function("tish_math_call", Linkage::Import, &sig)
+        .ok()?;
+    Some((module, math_id))
 }
 
 fn jit() -> Option<&'static Mutex<JitGlobal>> {
     JIT.get_or_init(|| {
-        new_module().map(|module| {
+        new_module().map(|(module, math_call_id)| {
             Mutex::new(JitGlobal {
                 module,
                 cache: HashMap::new(),
                 osr_cache: HashMap::new(),
                 counter: 0,
+                math_call_id,
             })
         })
     })
@@ -532,7 +560,8 @@ fn compile_loop_region(
             | Opcode::ExitBlock
             | Opcode::LoopVarsEnd
             | Opcode::LoopVarsBegin
-            | Opcode::UnaryOp => {}
+            | Opcode::UnaryOp
+            | Opcode::MathUnary => {} // #186 — `Math.<fn>(x)`: 1 f64 in, 1 f64 out (like UnaryOp)
             Opcode::LoadLocal | Opcode::StoreLocal => {
                 used.insert(peek_u16(code, ip + 1)?);
             }
@@ -608,6 +637,7 @@ fn compile_loop_region(
 
     let mut ctx = g.module.make_context();
     ctx.func.signature = sig.clone();
+    let math_fref = g.module.declare_func_in_func(g.math_call_id, &mut ctx.func);
     let mut fbctx = FunctionBuilderContext::new();
     let built = build_loop_region_body(
         &mut ctx.func,
@@ -619,6 +649,7 @@ fn compile_loop_region(
         &used_slots,
         &buf_pos,
         &exit_id,
+        math_fref,
     );
     if !built {
         g.module.clear_context(&mut ctx);
@@ -656,6 +687,7 @@ fn build_loop_region_body(
     used_slots: &[u16],
     buf_pos: &HashMap<u16, usize>,
     exit_id: &HashMap<usize, usize>,
+    math_fref: cranelift::codegen::ir::FuncRef,
 ) -> bool {
     let code = &chunk.code;
     let num_slots = chunk.num_slots as usize;
@@ -837,6 +869,24 @@ fn build_loop_region_body(
                 terminated = true;
                 ip += 3;
             }
+            Opcode::MathUnary => {
+                // #186 — `Math.<fn>(x)`: pop the arg, emit the native op / host call, push the result.
+                let id = match peek_u16(code, ip + 1) {
+                    Some(v) => v,
+                    None => return false,
+                };
+                let mfn = match MathUnaryFn::from_u16(id) {
+                    Some(m) => m,
+                    None => return false,
+                };
+                let (x, _) = match stack.pop() {
+                    Some(v) => v,
+                    None => return false,
+                };
+                let r = emit_math_unary(&mut bcx, math_fref, mfn, x);
+                stack.push((r, false));
+                ip += 3;
+            }
             _ => match emit_simple_op(&mut bcx, chunk, code, &mut ip, &mut stack, &[], 0) {
                 SimpleOp::Handled(_) => {}
                 _ => return false, // LoadConst/BinOp/UnaryOp handled; anything else → keep interpreting
@@ -867,6 +917,31 @@ fn build_loop_region_body(
 /// `op_size` of the opcode at `off`, or `None` if the byte is not a known opcode.
 fn op_size_at(code: &[u8], off: usize) -> Option<usize> {
     op_size(Opcode::from_u8(*code.get(off)?)?)
+}
+
+/// Lower `Math.<mfn>(x)` (#186): a single native op for the ones bit-identical to Rust's `f64`
+/// methods (== the `tishlang_builtins::math` fns), else a call to the imported `tish_math_call` host
+/// fn (`math_fref`) which routes through [`MathUnaryFn::apply`] — so JIT ≡ VM ≡ interp exactly.
+fn emit_math_unary(
+    bcx: &mut FunctionBuilder,
+    math_fref: cranelift::codegen::ir::FuncRef,
+    mfn: MathUnaryFn,
+    x: ClifValue,
+) -> ClifValue {
+    match mfn {
+        MathUnaryFn::Sqrt => bcx.ins().sqrt(x),
+        MathUnaryFn::Floor => bcx.ins().floor(x),
+        MathUnaryFn::Ceil => bcx.ins().ceil(x),
+        MathUnaryFn::Trunc => bcx.ins().trunc(x),
+        MathUnaryFn::Abs => bcx.ins().fabs(x),
+        // `Round` (JS `-0` tie edge), `Sign`, and every transcendental go through the host call so
+        // the result is byte-identical to the interpreter (no native-op divergence).
+        _ => {
+            let id = bcx.ins().iconst(types::I32, mfn as i64);
+            let call = bcx.ins().call(math_fref, &[id, x]);
+            bcx.inst_results(call)[0]
+        }
+    }
 }
 
 /// Lower `f64` comparison to `1.0`/`0.0` (JS boolean-in-number form).
@@ -939,6 +1014,7 @@ fn compile_chunk(g: &mut JitGlobal, chunk: &Chunk) -> Option<NumericFn> {
     let mut ctx = g.module.make_context();
     ctx.func.signature = sig.clone();
     let self_ref = g.module.declare_func_in_func(id, &mut ctx.func);
+    let math_fref = g.module.declare_func_in_func(g.math_call_id, &mut ctx.func);
     let mut fbctx = FunctionBuilderContext::new();
     let result_bool = match build_body_cfg(
         &mut ctx.func,
@@ -948,6 +1024,7 @@ fn compile_chunk(g: &mut JitGlobal, chunk: &Chunk) -> Option<NumericFn> {
         Some(self_ref),
         0,
         recur_guard,
+        math_fref,
     ) {
         Some(b) => b,
         None => {
@@ -1078,9 +1155,11 @@ fn compile_chunk_arrays(g: &mut JitGlobal, chunk: &Chunk, arity: usize, mask: u8
 
     let mut ctx = g.module.make_context();
     ctx.func.signature = sig.clone();
+    let math_fref = g.module.declare_func_in_func(g.math_call_id, &mut ctx.func);
     let mut fbctx = FunctionBuilderContext::new();
     // No self-call in array mode (recursive call would need the array signature) → pass None.
-    if build_body_cfg(&mut ctx.func, &mut fbctx, chunk, arity, None, mask, false).is_none() {
+    if build_body_cfg(&mut ctx.func, &mut fbctx, chunk, arity, None, mask, false, math_fref).is_none()
+    {
         g.module.clear_context(&mut ctx);
         return None;
     }
@@ -1298,7 +1377,7 @@ fn op_size(op: Opcode) -> Option<usize> {
     Some(match op {
         Nop | Pop | Dup | Return | LoopVarsEnd | EnterBlock | ExitBlock | GetIndex => 1,
         LoadLocal | StoreLocal | LoadConst | BinOp | UnaryOp | Jump | JumpIfFalse | JumpBack
-        | LoopVarsBegin | SelfCall => 3,
+        | LoopVarsBegin | SelfCall | MathUnary => 3,
         _ => return None,
     })
 }
@@ -1357,6 +1436,8 @@ fn build_body_cfg(
     // `*mut RecurGuard` param, and the function entry emits a stack-pointer check that bails before
     // the native recursion overflows. `false` for array mode and every non-recursive function.
     recur_guard: bool,
+    // #186: the imported `tish_math_call` host fn, for lowering `Math.<fn>` (`MathUnary`) intrinsics.
+    math_fref: cranelift::codegen::ir::FuncRef,
 ) -> Option<bool> {
     let code = &chunk.code;
     let num_slots = chunk.num_slots as usize;
@@ -1655,6 +1736,15 @@ fn build_body_cfg(
                 stack.push((result, false));
                 ip += 3;
             }
+            Opcode::MathUnary => {
+                // #186 — `Math.<fn>(x)`: pop the arg, emit native op / host call, push the result.
+                let id = peek_u16(code, ip + 1)?;
+                let mfn = MathUnaryFn::from_u16(id)?;
+                let (x, _) = stack.pop()?;
+                let r = emit_math_unary(&mut bcx, math_fref, mfn, x);
+                stack.push((r, false));
+                ip += 3;
+            }
             _ => match emit_simple_op(&mut bcx, chunk, code, &mut ip, &mut stack, &params, arity) {
                 SimpleOp::Handled(_) => {}
                 _ => return None, // LoadConst/BinOp/UnaryOp handled; anything else → VM
@@ -1921,17 +2011,18 @@ mod tests {
         assert_eq!(got, vec![10.0, 45.0], "s=45 (sum 0..9), i=10 after the loop");
     }
 
-    /// #190 — a loop that touches a non-slot value (a call) is not pure-numeric slot math, so the
-    /// region must be rejected (negative-cached) and the VM keeps interpreting.
+    /// #190 — a loop that touches a non-slot value (a general call) is not pure-numeric slot math, so
+    /// the region must be rejected (negative-cached) and the VM keeps interpreting. `Math.max` is a
+    /// 2-arg call (NOT the #186 unary intrinsic), so it stays a `Call` the region must reject.
     #[test]
     fn osr_region_rejects_calls() {
         let chunk = top_chunk(
-            "let a = 0.0\nfor (let i = 0; i < 100; i = i + 1) { a = a + Math.floor(i / 2.0) }\n",
+            "let a = 0.0\nfor (let i = 0; i < 100; i = i + 1) { a = a + Math.max(i, 2.0) }\n",
         );
         let (header, end) = first_region(&chunk);
         assert!(
             try_compile_loop(&chunk, header, end).is_none(),
-            "a loop containing a call must not OSR-compile"
+            "a loop containing a general call must not OSR-compile"
         );
     }
 

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -1910,6 +1910,20 @@ impl Vm {
                     // Reserved for the linked-frame upvalue model (not emitted yet).
                     return Err("Upvalue opcodes not supported in this VM build".to_string());
                 }
+                Opcode::MathUnary => {
+                    // #186 — `Math.<fn>(x)` on a number. The compiler only emits this when `Math` is
+                    // the global builtin, so it is behaviour-identical to the general call: a number
+                    // maps through `MathUnaryFn::apply`, a non-number coerces to NaN (matching the
+                    // builtin's `extract_num(..).unwrap_or(NaN)`).
+                    let id = Self::read_u16(code, &mut ip);
+                    let x = match self.stack.pop() {
+                        Some(Value::Number(n)) => n,
+                        Some(_) | None => f64::NAN,
+                    };
+                    let mfn = tishlang_bytecode::MathUnaryFn::from_u16(id)
+                        .ok_or_else(|| format!("Bad MathUnary id: {}", id))?;
+                    self.stack.push(Value::Number(mfn.apply(x)));
+                }
                 Opcode::LoadConst => {
                     let idx = Self::read_u16(code, &mut ip);
                     let c = constants


### PR DESCRIPTION
## What & why

`Math.sqrt(i)` / `Math.sin(i)` / … in a hot loop compiled to `LoadVar Math; GetMember fn; <arg>; Call 1` — a member lookup + boxed native-fn call per element — and the call made the loop ineligible for the OSR region JIT (#190). math_trig ran **410ms (5.1× Node)**.

A new `MathUnary` opcode carries the intrinsic:

```
while (i < 3000000) { s = s + Math.sqrt(i) + Math.sin(i); i = i + 1 }
// 410ms → 18ms  (now 0.21× Node's 85ms — a WIN, from a 5.1× loss)
```

## Soundness

The compiler emits `<arg>; MathUnary(id)` for `Math.<unaryfn>(arg)` **only when `Math` is provably the unshadowed global builtin** — via the existing conservative `stmt_rebinds` scan (any rebind / destructure / `FunDecl` / unknown node → keep the general call). So a program with `let Math = {...}` uses the user's method, never the intrinsic (verified). The VM handler and the JIT both route through one `MathUnaryFn::apply` that replicates the exact `tishlang_builtins::math` semantics — including the JS `Math.round` `-0` tie edge and `Math.sign` — so **interp == vm == JIT == Node bit-for-bit**.

## JIT lowering

The numeric JIT lowers `MathUnary` to a native cranelift op for the ones bit-identical to Rust's f64 methods (`sqrt`/`floor`/`ceil`/`trunc`/`abs`) and to a call to an imported host fn (`tish_math_call`) for the rest (`sin`/`cos`/`exp`/`log`/`round`/`sign`/…) — **the first JIT host-libcall path, reusable for future intrinsics**. Wired into both `build_body_cfg` (functions) and `build_loop_region_body` (OSR regions).

The opcode alone (no JIT) already cuts math_trig to 300ms by dropping the member-lookup + call machinery, so **all `Math.*` numeric code benefits**, JIT or not.

## Validation

- **Cross-backend integration 25/25** (interp/vm/native/cranelift/wasi/js/node).
- **3 emission regression tests**: global `Math.sqrt` → `MathUnary`; a shadowed `let Math` and a 2-arg `Math.max` keep the general call.
- 7-fn correctness (`sqrt`/`sin`/`cos`/`floor`/`abs`/`round`/`sign`) identical across interp/vm/node; shadow soundness confirmed.
- OSR region + recursion unit tests green.

Closes the Math-intrinsic half of #186 (the string half landed in #409). It's also a prerequisite for JIT-ing `Math.sqrt`-using kernels (e.g. nbody, once its object-field access lands).