### PR TITLE
perf(vm): JIT function-local f64 arrays (JV) — #189

### DIFF
--- a/crates/tish_vm/src/jit.rs
+++ b/crates/tish_vm/src/jit.rs
@@ -350,6 +350,8 @@ struct JitGlobal {
     /// `FuncId` of the imported `tish_math_call` host fn (#186), declared once at module init and
     /// re-imported into each compiled function via `declare_func_in_func`.
     math_call_id: cranelift_module::FuncId,
+    /// `FuncId`s of the imported `tish_jv_*` vector runtime (#189).
+    jv_fns: JvFns,
 }
 
 // SAFETY: `JITModule` is `!Send`, but the single instance lives behind the
@@ -358,6 +360,67 @@ struct JitGlobal {
 unsafe impl Send for JitGlobal {}
 
 static JIT: OnceLock<Option<Mutex<JitGlobal>>> = OnceLock::new();
+
+// #189 — a minimal C-ABI `f64` vector runtime for JIT-compiled function-LOCAL arrays that never
+// escape the frame. A qualifying local slot (only def = empty `[]`, only uses = push / `[i]` /
+// `[i]=v` / `.length`) becomes a raw `*mut Vec<f64>` in the JIT instead of a boxed `Value::Array`,
+// so its index math is pointer arithmetic + a bounds-checked call, not a per-op bound-method alloc.
+// SOUND because such arrays never escape: no `Value` ever references the `Vec`, so an OOB deopt can
+// discard the partially-mutated `Vec` (freed on the deopt exit) and re-run the interpreter with no
+// observable state change. Every exit (`Return`, deopt) frees every live JV slot — no leak.
+#[cfg(not(target_arch = "wasm32"))]
+extern "C" fn tish_jv_new(cap: u64) -> *mut Vec<f64> {
+    Box::into_raw(Box::new(Vec::with_capacity(cap as usize)))
+}
+#[cfg(not(target_arch = "wasm32"))]
+extern "C" fn tish_jv_push(v: *mut Vec<f64>, x: f64) {
+    // SAFETY: `v` is a live pointer from `tish_jv_new`, not freed until an exit block runs.
+    let vec = unsafe { &mut *v };
+    vec.push(x)
+}
+#[cfg(not(target_arch = "wasm32"))]
+extern "C" fn tish_jv_get(v: *mut Vec<f64>, i: u64, deopt: *mut u8) -> f64 {
+    // SAFETY: as above; OOB sets the deopt flag (caller discards + re-interprets) and returns NaN.
+    let vec = unsafe { &*v };
+    match vec.get(i as usize) {
+        Some(&x) => x,
+        None => {
+            unsafe { *deopt = 1 };
+            f64::NAN
+        }
+    }
+}
+#[cfg(not(target_arch = "wasm32"))]
+extern "C" fn tish_jv_set(v: *mut Vec<f64>, i: u64, x: f64, deopt: *mut u8) {
+    // SAFETY: as above; OOB → deopt (no store performed).
+    let vec = unsafe { &mut *v };
+    match vec.get_mut(i as usize) {
+        Some(p) => *p = x,
+        None => unsafe { *deopt = 1 },
+    }
+}
+#[cfg(not(target_arch = "wasm32"))]
+extern "C" fn tish_jv_len(v: *mut Vec<f64>) -> u64 {
+    // SAFETY: as above.
+    let vec = unsafe { &*v };
+    vec.len() as u64
+}
+#[cfg(not(target_arch = "wasm32"))]
+extern "C" fn tish_jv_free(v: *mut Vec<f64>) {
+    // SAFETY: `v` came from `tish_jv_new`, freed exactly once per compiled exit path.
+    drop(unsafe { Box::from_raw(v) })
+}
+
+/// Imported `FuncId`s of the `tish_jv_*` vector runtime (#189), declared once at module init.
+#[derive(Clone, Copy)]
+struct JvFns {
+    new: cranelift_module::FuncId,
+    push: cranelift_module::FuncId,
+    get: cranelift_module::FuncId,
+    set: cranelift_module::FuncId,
+    len: cranelift_module::FuncId,
+    free: cranelift_module::FuncId,
+}
 
 /// Host entry point the JIT calls for `Math.<fn>` intrinsics it doesn't lower to a native op (#186):
 /// sin/cos/tan/exp/log/round/sign/… The single source of truth is [`MathUnaryFn::apply`], so JIT ≡
@@ -370,8 +433,9 @@ extern "C" fn tish_math_call(id: i32, x: f64) -> f64 {
     }
 }
 
-/// Build the JIT module and declare the imported `tish_math_call` host function, returning both.
-fn new_module() -> Option<(JITModule, cranelift_module::FuncId)> {
+/// Build the JIT module and declare the imported host functions (`tish_math_call` #186, the
+/// `tish_jv_*` vector runtime #189), returning the module + their `FuncId`s.
+fn new_module() -> Option<(JITModule, cranelift_module::FuncId, JvFns)> {
     let mut flag_builder = settings::builder();
     // JIT code is loaded at a fixed address; no PIC / colocated libcalls needed.
     flag_builder.set("use_colocated_libcalls", "false").ok()?;
@@ -383,27 +447,69 @@ fn new_module() -> Option<(JITModule, cranelift_module::FuncId)> {
         .ok()?;
     let mut builder = JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
     builder.symbol("tish_math_call", tish_math_call as *const u8);
+    builder.symbol("tish_jv_new", tish_jv_new as *const u8);
+    builder.symbol("tish_jv_push", tish_jv_push as *const u8);
+    builder.symbol("tish_jv_get", tish_jv_get as *const u8);
+    builder.symbol("tish_jv_set", tish_jv_set as *const u8);
+    builder.symbol("tish_jv_len", tish_jv_len as *const u8);
+    builder.symbol("tish_jv_free", tish_jv_free as *const u8);
     let mut module = JITModule::new(builder);
-    // Import signature: `(i32 fn-id, f64 x) -> f64`.
-    let mut sig = module.make_signature();
-    sig.params.push(AbiParam::new(types::I32));
-    sig.params.push(AbiParam::new(types::F64));
-    sig.returns.push(AbiParam::new(types::F64));
+    let ptr = module.target_config().pointer_type();
+
+    // `tish_math_call(i32 fn-id, f64 x) -> f64`.
+    let mut msig = module.make_signature();
+    msig.params.push(AbiParam::new(types::I32));
+    msig.params.push(AbiParam::new(types::F64));
+    msig.returns.push(AbiParam::new(types::F64));
     let math_id = module
-        .declare_function("tish_math_call", Linkage::Import, &sig)
+        .declare_function("tish_math_call", Linkage::Import, &msig)
         .ok()?;
-    Some((module, math_id))
+
+    // Helper to declare a `tish_jv_*` import from param/return abi lists.
+    let mut declare = |name: &str, params: &[AbiParam], rets: &[AbiParam]| {
+        let mut s = module.make_signature();
+        s.params.extend_from_slice(params);
+        s.returns.extend_from_slice(rets);
+        module.declare_function(name, Linkage::Import, &s).ok()
+    };
+    let jv = JvFns {
+        new: declare("tish_jv_new", &[AbiParam::new(types::I64)], &[AbiParam::new(ptr)])?,
+        push: declare(
+            "tish_jv_push",
+            &[AbiParam::new(ptr), AbiParam::new(types::F64)],
+            &[],
+        )?,
+        get: declare(
+            "tish_jv_get",
+            &[AbiParam::new(ptr), AbiParam::new(types::I64), AbiParam::new(ptr)],
+            &[AbiParam::new(types::F64)],
+        )?,
+        set: declare(
+            "tish_jv_set",
+            &[
+                AbiParam::new(ptr),
+                AbiParam::new(types::I64),
+                AbiParam::new(types::F64),
+                AbiParam::new(ptr),
+            ],
+            &[],
+        )?,
+        len: declare("tish_jv_len", &[AbiParam::new(ptr)], &[AbiParam::new(types::I64)])?,
+        free: declare("tish_jv_free", &[AbiParam::new(ptr)], &[])?,
+    };
+    Some((module, math_id, jv))
 }
 
 fn jit() -> Option<&'static Mutex<JitGlobal>> {
     JIT.get_or_init(|| {
-        new_module().map(|(module, math_call_id)| {
+        new_module().map(|(module, math_call_id, jv_fns)| {
             Mutex::new(JitGlobal {
                 module,
                 cache: HashMap::new(),
                 osr_cache: HashMap::new(),
                 counter: 0,
                 math_call_id,
+                jv_fns,
             })
         })
     })

--- a/crates/tish_vm/src/jit.rs
+++ b/crates/tish_vm/src/jit.rs
@@ -25,8 +25,8 @@ use std::sync::{Mutex, OnceLock};
 use cranelift::codegen::settings::{self, Configurable};
 use cranelift::prelude::types;
 use cranelift::prelude::{
-    AbiParam, Block, FloatCC, FunctionBuilder, FunctionBuilderContext, InstBuilder, IntCC, MemFlags,
-    Value as ClifValue, Variable,
+    AbiParam, Block, FloatCC, FunctionBuilder, FunctionBuilderContext, InstBuilder, IntCC,
+    MemFlags, Value as ClifValue, Variable,
 };
 use cranelift_jit::{JITBuilder, JITModule};
 use cranelift_module::{Linkage, Module};
@@ -98,6 +98,10 @@ pub struct NumericFn {
     /// (the recursion-depth bail, #381). Such a function must be invoked via [`NumericFn::call_guarded`];
     /// non-recursive functions keep the plain ABI and [`NumericFn::call`] (zero overhead).
     recur_guarded: bool,
+    /// True when this function has JIT'd local `f64` arrays (#189). It uses the plain register-`f64`
+    /// [`NumericFn::call`] ABI; an out-of-bounds array access (or a non-numeric return) sets a
+    /// per-thread deopt flag ([`jv_take_deopt`]) and the caller discards the result + re-interprets.
+    jv: bool,
 }
 
 /// A flat numeric array handed to an array-mode JIT function: a raw `f64` slice (`ptr`, `len`).
@@ -136,7 +140,24 @@ pub struct RecurGuard {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn jit_arrays_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var("TISH_JIT_ARRAYS").map(|v| v != "0").unwrap_or(true))
+    *ENABLED.get_or_init(|| {
+        std::env::var("TISH_JIT_ARRAYS")
+            .map(|v| v != "0")
+            .unwrap_or(true)
+    })
+}
+
+/// JIT-compiled function-LOCAL `f64` arrays via the `tish_jv_*` runtime (#189). **Default ON**;
+/// `TISH_JIT_JV=0` disables it (escape hatch). Additive: a function whose arrays don't fit the
+/// non-escaping-JV shape just runs interpreted, and any out-of-bounds access deopts to the interpreter.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn jit_jv_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("TISH_JIT_JV")
+            .map(|v| v != "0")
+            .unwrap_or(true)
+    })
 }
 
 /// The self-recursion stack guard (#381). **Default ON**; `TISH_JIT_RECUR_GUARD=0` disables it.
@@ -154,8 +175,11 @@ pub fn jit_arrays_enabled() -> bool {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn jit_recur_guard_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED
-        .get_or_init(|| std::env::var("TISH_JIT_RECUR_GUARD").map(|v| v != "0").unwrap_or(true))
+    *ENABLED.get_or_init(|| {
+        std::env::var("TISH_JIT_RECUR_GUARD")
+            .map(|v| v != "0")
+            .unwrap_or(true)
+    })
 }
 
 // SAFETY: `ptr` references immutable executable code in a module that is never
@@ -214,12 +238,16 @@ impl NumericFn {
                 7 => {
                     let f: extern "C" fn(f64, f64, f64, f64, f64, f64, f64) -> f64 =
                         std::mem::transmute(self.ptr);
-                    f(args[0], args[1], args[2], args[3], args[4], args[5], args[6])
+                    f(
+                        args[0], args[1], args[2], args[3], args[4], args[5], args[6],
+                    )
                 }
                 8 => {
                     let f: extern "C" fn(f64, f64, f64, f64, f64, f64, f64, f64) -> f64 =
                         std::mem::transmute(self.ptr);
-                    f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7])
+                    f(
+                        args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7],
+                    )
                 }
                 _ => f64::NAN,
             }
@@ -242,7 +270,8 @@ impl NumericFn {
         unsafe {
             match self.arity {
                 1 => {
-                    let f: extern "C" fn(f64, *mut RecurGuard) -> f64 = std::mem::transmute(self.ptr);
+                    let f: extern "C" fn(f64, *mut RecurGuard) -> f64 =
+                        std::mem::transmute(self.ptr);
                     f(args[0], guard)
                 }
                 2 => {
@@ -271,9 +300,19 @@ impl NumericFn {
                     f(args[0], args[1], args[2], args[3], args[4], args[5], guard)
                 }
                 7 => {
-                    let f: extern "C" fn(f64, f64, f64, f64, f64, f64, f64, *mut RecurGuard) -> f64 =
-                        std::mem::transmute(self.ptr);
-                    f(args[0], args[1], args[2], args[3], args[4], args[5], args[6], guard)
+                    let f: extern "C" fn(
+                        f64,
+                        f64,
+                        f64,
+                        f64,
+                        f64,
+                        f64,
+                        f64,
+                        *mut RecurGuard,
+                    ) -> f64 = std::mem::transmute(self.ptr);
+                    f(
+                        args[0], args[1], args[2], args[3], args[4], args[5], args[6], guard,
+                    )
                 }
                 8 => {
                     let f: extern "C" fn(
@@ -288,12 +327,21 @@ impl NumericFn {
                         *mut RecurGuard,
                     ) -> f64 = std::mem::transmute(self.ptr);
                     f(
-                        args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], guard,
+                        args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7],
+                        guard,
                     )
                 }
                 _ => f64::NAN,
             }
         }
+    }
+
+    /// Whether this function has JIT'd local arrays (#189). Such a function uses the ordinary
+    /// register-`f64` [`call`] ABI — its OOB/deopt signal is the per-thread flag (see
+    /// [`jv_reset_deopt`] / [`jv_take_deopt`]), not a trailing pointer param.
+    #[inline]
+    pub fn is_jv(&self) -> bool {
+        self.jv
     }
 
     /// Bit k set ⇒ param k is an array param (read via `arr[i]`). `0` ⇒ pure-numeric (use [`call`]).
@@ -363,52 +411,127 @@ static JIT: OnceLock<Option<Mutex<JitGlobal>>> = OnceLock::new();
 
 // #189 — a minimal C-ABI `f64` vector runtime for JIT-compiled function-LOCAL arrays that never
 // escape the frame. A qualifying local slot (only def = empty `[]`, only uses = push / `[i]` /
-// `[i]=v` / `.length`) becomes a raw `*mut Vec<f64>` in the JIT instead of a boxed `Value::Array`,
-// so its index math is pointer arithmetic + a bounds-checked call, not a per-op bound-method alloc.
-// SOUND because such arrays never escape: no `Value` ever references the `Vec`, so an OOB deopt can
-// discard the partially-mutated `Vec` (freed on the deopt exit) and re-run the interpreter with no
-// observable state change. Every exit (`Return`, deopt) frees every live JV slot — no leak.
+// `[i]=v` / `.length`) is addressed by a `u64` HANDLE into a per-thread arena instead of a boxed
+// `Value::Array`, so its index math is a bounds-checked slab lookup, not a per-op bound-method
+// alloc — and, because the arena is a plain `Vec<Vec<f64>>` behind a `RefCell`, the host fns need
+// NO `unsafe` (no raw-pointer deref). SOUND because such arrays never escape: no `Value` ever
+// references a `Vec`, so an out-of-bounds access can set the deopt flag, let the (about-to-be-
+// discarded) native run finish, and re-run the interpreter with no observable state change. Handle
+// `0` is the null sentinel (a JV slot inits to 0); every exit frees every live slot back to the
+// free list, so the arena is bounded by a function's peak live-array count, not total allocations.
 #[cfg(not(target_arch = "wasm32"))]
-extern "C" fn tish_jv_new(cap: u64) -> *mut Vec<f64> {
-    Box::into_raw(Box::new(Vec::with_capacity(cap as usize)))
+struct JvArena {
+    vecs: Vec<Vec<f64>>,
+    free: Vec<usize>,
+    deopt: bool,
 }
 #[cfg(not(target_arch = "wasm32"))]
-extern "C" fn tish_jv_push(v: *mut Vec<f64>, x: f64) {
-    // SAFETY: `v` is a live pointer from `tish_jv_new`, not freed until an exit block runs.
-    let vec = unsafe { &mut *v };
-    vec.push(x)
+thread_local! {
+    static JV_ARENA: std::cell::RefCell<JvArena> = const {
+        std::cell::RefCell::new(JvArena { vecs: Vec::new(), free: Vec::new(), deopt: false })
+    };
+}
+/// `handle` (1-based, `0` = null) → arena index, or `None` for the null handle.
+#[cfg(not(target_arch = "wasm32"))]
+#[inline]
+fn jv_index(handle: u64) -> Option<usize> {
+    handle.checked_sub(1).map(|i| i as usize)
 }
 #[cfg(not(target_arch = "wasm32"))]
-extern "C" fn tish_jv_get(v: *mut Vec<f64>, i: u64, deopt: *mut u8) -> f64 {
-    // SAFETY: as above; OOB sets the deopt flag (caller discards + re-interprets) and returns NaN.
-    let vec = unsafe { &*v };
-    match vec.get(i as usize) {
-        Some(&x) => x,
-        None => {
-            unsafe { *deopt = 1 };
-            f64::NAN
+extern "C" fn tish_jv_new(cap: u64) -> u64 {
+    JV_ARENA.with(|c| {
+        let mut a = c.borrow_mut();
+        let v = Vec::with_capacity(cap as usize);
+        let idx = match a.free.pop() {
+            Some(i) => {
+                a.vecs[i] = v;
+                i
+            }
+            None => {
+                a.vecs.push(v);
+                a.vecs.len() - 1
+            }
+        };
+        idx as u64 + 1 // handle = index + 1 (0 stays reserved for null)
+    })
+}
+#[cfg(not(target_arch = "wasm32"))]
+extern "C" fn tish_jv_push(handle: u64, x: f64) {
+    if let Some(idx) = jv_index(handle) {
+        JV_ARENA.with(|c| {
+            if let Some(v) = c.borrow_mut().vecs.get_mut(idx) {
+                v.push(x);
+            }
+        });
+    }
+}
+#[cfg(not(target_arch = "wasm32"))]
+extern "C" fn tish_jv_get(handle: u64, i: u64) -> f64 {
+    JV_ARENA.with(|c| {
+        let mut a = c.borrow_mut();
+        match jv_index(handle)
+            .and_then(|idx| a.vecs.get(idx))
+            .and_then(|v| v.get(i as usize))
+        {
+            Some(&x) => x,
+            None => {
+                a.deopt = true; // OOB (or null): caller discards the result + re-interprets
+                f64::NAN
+            }
         }
+    })
+}
+#[cfg(not(target_arch = "wasm32"))]
+extern "C" fn tish_jv_set(handle: u64, i: u64, x: f64) {
+    JV_ARENA.with(|c| {
+        let mut a = c.borrow_mut();
+        match jv_index(handle)
+            .and_then(|idx| a.vecs.get_mut(idx))
+            .and_then(|v| v.get_mut(i as usize))
+        {
+            Some(p) => *p = x,
+            None => a.deopt = true, // OOB (or null) → deopt (no store performed)
+        }
+    })
+}
+#[cfg(not(target_arch = "wasm32"))]
+extern "C" fn tish_jv_len(handle: u64) -> u64 {
+    JV_ARENA.with(|c| {
+        jv_index(handle)
+            .and_then(|idx| c.borrow().vecs.get(idx).map(|v| v.len() as u64))
+            .unwrap_or(0)
+    })
+}
+#[cfg(not(target_arch = "wasm32"))]
+extern "C" fn tish_jv_free(handle: u64) {
+    if let Some(idx) = jv_index(handle) {
+        JV_ARENA.with(|c| {
+            let mut a = c.borrow_mut();
+            if let Some(v) = a.vecs.get_mut(idx) {
+                v.clear(); // keep capacity; the slot is returned to the free list for reuse
+                a.free.push(idx);
+            }
+        });
     }
 }
+/// Signal a deopt from JIT'd code that can't produce an `f64` result (a non-numeric `return`, e.g. the
+/// dead `return null` epilogue after a `while (true)`); the wrapper then re-interprets. #189
 #[cfg(not(target_arch = "wasm32"))]
-extern "C" fn tish_jv_set(v: *mut Vec<f64>, i: u64, x: f64, deopt: *mut u8) {
-    // SAFETY: as above; OOB → deopt (no store performed).
-    let vec = unsafe { &mut *v };
-    match vec.get_mut(i as usize) {
-        Some(p) => *p = x,
-        None => unsafe { *deopt = 1 },
-    }
+extern "C" fn tish_jv_deopt() {
+    JV_ARENA.with(|c| c.borrow_mut().deopt = true);
 }
+/// Clear the per-thread deopt flag before entering a JV function. #189
 #[cfg(not(target_arch = "wasm32"))]
-extern "C" fn tish_jv_len(v: *mut Vec<f64>) -> u64 {
-    // SAFETY: as above.
-    let vec = unsafe { &*v };
-    vec.len() as u64
+pub(crate) fn jv_reset_deopt() {
+    JV_ARENA.with(|c| c.borrow_mut().deopt = false);
 }
+/// Read and clear the deopt flag after a JV function returns; `true` ⇒ discard its result + interpret.
 #[cfg(not(target_arch = "wasm32"))]
-extern "C" fn tish_jv_free(v: *mut Vec<f64>) {
-    // SAFETY: `v` came from `tish_jv_new`, freed exactly once per compiled exit path.
-    drop(unsafe { Box::from_raw(v) })
+pub(crate) fn jv_take_deopt() -> bool {
+    JV_ARENA.with(|c| {
+        let mut a = c.borrow_mut();
+        std::mem::replace(&mut a.deopt, false)
+    })
 }
 
 /// Imported `FuncId`s of the `tish_jv_*` vector runtime (#189), declared once at module init.
@@ -420,11 +543,13 @@ struct JvFns {
     set: cranelift_module::FuncId,
     len: cranelift_module::FuncId,
     free: cranelift_module::FuncId,
+    deopt: cranelift_module::FuncId,
 }
 
 /// Per-function-build handles for JV local arrays (#189): the `tish_jv_*` `FuncRef`s imported into
-/// *this* function, plus the set of slots classified as JV arrays. Passed to [`build_body_cfg`]; the
-/// deopt pointer is extracted from the function's trailing param inside the builder.
+/// *this* function, plus the set of slots classified as JV arrays. Passed to [`build_body_cfg`].
+/// The deopt flag lives in the per-thread arena (set by `get`/`set`/`deopt`), so — unlike array
+/// mode — the JV function ABI carries no trailing deopt pointer.
 struct JvCtx<'a> {
     new: cranelift::codegen::ir::FuncRef,
     push: cranelift::codegen::ir::FuncRef,
@@ -432,6 +557,7 @@ struct JvCtx<'a> {
     set: cranelift::codegen::ir::FuncRef,
     len: cranelift::codegen::ir::FuncRef,
     free: cranelift::codegen::ir::FuncRef,
+    deopt: cranelift::codegen::ir::FuncRef,
     slots: &'a std::collections::HashSet<usize>,
 }
 
@@ -466,8 +592,8 @@ fn new_module() -> Option<(JITModule, cranelift_module::FuncId, JvFns)> {
     builder.symbol("tish_jv_set", tish_jv_set as *const u8);
     builder.symbol("tish_jv_len", tish_jv_len as *const u8);
     builder.symbol("tish_jv_free", tish_jv_free as *const u8);
+    builder.symbol("tish_jv_deopt", tish_jv_deopt as *const u8);
     let mut module = JITModule::new(builder);
-    let ptr = module.target_config().pointer_type();
 
     // `tish_math_call(i32 fn-id, f64 x) -> f64`.
     let mut msig = module.make_signature();
@@ -485,30 +611,40 @@ fn new_module() -> Option<(JITModule, cranelift_module::FuncId, JvFns)> {
         s.returns.extend_from_slice(rets);
         module.declare_function(name, Linkage::Import, &s).ok()
     };
+    // A JV array is addressed by an `i64` HANDLE (a per-thread arena index; `0` = null), not a raw
+    // pointer. `get`/`set` need no deopt-pointer arg — OOB sets a per-thread flag the wrapper reads.
     let jv = JvFns {
-        new: declare("tish_jv_new", &[AbiParam::new(types::I64)], &[AbiParam::new(ptr)])?,
+        new: declare(
+            "tish_jv_new",
+            &[AbiParam::new(types::I64)],
+            &[AbiParam::new(types::I64)],
+        )?,
         push: declare(
             "tish_jv_push",
-            &[AbiParam::new(ptr), AbiParam::new(types::F64)],
+            &[AbiParam::new(types::I64), AbiParam::new(types::F64)],
             &[],
         )?,
         get: declare(
             "tish_jv_get",
-            &[AbiParam::new(ptr), AbiParam::new(types::I64), AbiParam::new(ptr)],
+            &[AbiParam::new(types::I64), AbiParam::new(types::I64)],
             &[AbiParam::new(types::F64)],
         )?,
         set: declare(
             "tish_jv_set",
             &[
-                AbiParam::new(ptr),
+                AbiParam::new(types::I64),
                 AbiParam::new(types::I64),
                 AbiParam::new(types::F64),
-                AbiParam::new(ptr),
             ],
             &[],
         )?,
-        len: declare("tish_jv_len", &[AbiParam::new(ptr)], &[AbiParam::new(types::I64)])?,
-        free: declare("tish_jv_free", &[AbiParam::new(ptr)], &[])?,
+        len: declare(
+            "tish_jv_len",
+            &[AbiParam::new(types::I64)],
+            &[AbiParam::new(types::I64)],
+        )?,
+        free: declare("tish_jv_free", &[AbiParam::new(types::I64)], &[])?,
+        deopt: declare("tish_jv_deopt", &[], &[])?,
     };
     Some((module, math_id, jv))
 }
@@ -690,7 +826,10 @@ fn compile_loop_region(
             },
             Opcode::BinOp => {
                 // Reject non-numeric binops up front (Pow/In/logical) so the scan and the emit agree.
-                match peek_u16(code, ip + 1).map(|r| r as u8).and_then(u8_to_binop)? {
+                match peek_u16(code, ip + 1)
+                    .map(|r| r as u8)
+                    .and_then(u8_to_binop)?
+                {
                     BinOp::And | BinOp::Or | BinOp::Pow | BinOp::In => return None,
                     _ => {}
                 }
@@ -752,7 +891,10 @@ fn compile_loop_region(
 
     let name = format!("tish_osr_{}", g.counter);
     g.counter += 1;
-    let id = g.module.declare_function(&name, Linkage::Export, &sig).ok()?;
+    let id = g
+        .module
+        .declare_function(&name, Linkage::Export, &sig)
+        .ok()?;
 
     let mut ctx = g.module.make_context();
     ctx.func.signature = sig.clone();
@@ -812,15 +954,13 @@ fn build_loop_region_body(
     let num_slots = chunk.num_slots as usize;
     let mut bcx = FunctionBuilder::new(func, fbctx);
 
-    let blocks: HashMap<usize, Block> =
-        leaders.iter().map(|&o| (o, bcx.create_block())).collect();
+    let blocks: HashMap<usize, Block> = leaders.iter().map(|&o| (o, bcx.create_block())).collect();
     let exit_blocks: HashMap<usize, Block> =
         exit_id.keys().map(|&t| (t, bcx.create_block())).collect();
 
     // A jump target is either an in-region leader or a loop-exit target (the scan proved it is one).
-    let target_block = |t: usize| -> Option<Block> {
-        blocks.get(&t).or_else(|| exit_blocks.get(&t)).copied()
-    };
+    let target_block =
+        |t: usize| -> Option<Block> { blocks.get(&t).or_else(|| exit_blocks.get(&t)).copied() };
 
     // Entry: load the live-in slots from the buffer, then jump into the loop header.
     let entry = bcx.create_block();
@@ -828,7 +968,9 @@ fn build_loop_region_body(
     bcx.switch_to_block(entry);
     let params: Vec<ClifValue> = bcx.block_params(entry).to_vec();
     let slots_ptr = params[0]; // params[1] = deopt flag, reserved (v1 never writes it)
-    let vars: Vec<Variable> = (0..num_slots).map(|_| bcx.declare_var(types::F64)).collect();
+    let vars: Vec<Variable> = (0..num_slots)
+        .map(|_| bcx.declare_var(types::F64))
+        .collect();
     for (slot, &var) in vars.iter().enumerate() {
         // Live slots load from their buffer position; slots the region never touches init to 0 (dead).
         let init = if let Some(&p) = buf_pos.get(&(slot as u16)) {
@@ -1109,13 +1251,29 @@ fn compile_chunk(g: &mut JitGlobal, chunk: &Chunk) -> Option<NumericFn> {
     // guard's per-call cost for raw speed — see [`jit_recur_guard_enabled`].
     let recur_guard = jit_recur_guard_enabled() && chunk_has_self_call(chunk);
 
+    // #189: function-local `f64` arrays. Mutually exclusive with `recur_guard` (both would claim the
+    // trailing param slot); a self-recursive array function just isn't JV-compiled. `None` from the
+    // classifier (an array the JIT can't handle) → empty set → the scan bails on `NewArray` → interpret.
+    #[cfg(not(target_arch = "wasm32"))]
+    let jv_slots = if !recur_guard && jit_jv_enabled() {
+        classify_jv_slots(chunk).unwrap_or_default()
+    } else {
+        std::collections::HashSet::new()
+    };
+    #[cfg(target_arch = "wasm32")]
+    let jv_slots: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    let is_jv = !jv_slots.is_empty();
+
     let mut sig = g.module.make_signature();
     for _ in 0..arity {
         sig.params.push(AbiParam::new(types::F64));
     }
     if recur_guard {
-        sig.params.push(AbiParam::new(g.module.target_config().pointer_type())); // *mut RecurGuard
+        sig.params
+            .push(AbiParam::new(g.module.target_config().pointer_type())); // *mut RecurGuard
     }
+    // #189: a JV function keeps the plain register-`f64` ABI — its deopt flag lives in the per-thread
+    // arena (set by `tish_jv_{get,set,deopt}`), not a trailing pointer param.
     sig.returns.push(AbiParam::new(types::F64));
 
     // Declare the function FIRST so its own `FuncRef` is available while building the body — that is
@@ -1134,6 +1292,21 @@ fn compile_chunk(g: &mut JitGlobal, chunk: &Chunk) -> Option<NumericFn> {
     ctx.func.signature = sig.clone();
     let self_ref = g.module.declare_func_in_func(id, &mut ctx.func);
     let math_fref = g.module.declare_func_in_func(g.math_call_id, &mut ctx.func);
+    // #189: import the `tish_jv_*` FuncRefs into this function when it has local arrays.
+    let jv_ctx = if is_jv {
+        Some(JvCtx {
+            new: g.module.declare_func_in_func(g.jv_fns.new, &mut ctx.func),
+            push: g.module.declare_func_in_func(g.jv_fns.push, &mut ctx.func),
+            get: g.module.declare_func_in_func(g.jv_fns.get, &mut ctx.func),
+            set: g.module.declare_func_in_func(g.jv_fns.set, &mut ctx.func),
+            len: g.module.declare_func_in_func(g.jv_fns.len, &mut ctx.func),
+            free: g.module.declare_func_in_func(g.jv_fns.free, &mut ctx.func),
+            deopt: g.module.declare_func_in_func(g.jv_fns.deopt, &mut ctx.func),
+            slots: &jv_slots,
+        })
+    } else {
+        None
+    };
     let mut fbctx = FunctionBuilderContext::new();
     let result_bool = match build_body_cfg(
         &mut ctx.func,
@@ -1144,8 +1317,15 @@ fn compile_chunk(g: &mut JitGlobal, chunk: &Chunk) -> Option<NumericFn> {
         0,
         recur_guard,
         math_fref,
+        jv_ctx.as_ref(),
     ) {
         Some(b) => b,
+        // A JV function has no straight-line fallback (its ABI has the deopt param `build_body`
+        // doesn't emit), so a `build_body_cfg` bail means "don't JIT" → interpret.
+        None if is_jv => {
+            g.module.clear_context(&mut ctx);
+            return None;
+        }
         None => {
             g.module.clear_context(&mut ctx);
             ctx = g.module.make_context();
@@ -1177,6 +1357,7 @@ fn compile_chunk(g: &mut JitGlobal, chunk: &Chunk) -> Option<NumericFn> {
         result_bool,
         array_param_mask: 0,
         recur_guarded: recur_guard,
+        jv: is_jv,
     })
 }
 
@@ -1260,7 +1441,12 @@ fn classify_params(chunk: &Chunk, arity: usize) -> u8 {
 /// reads set `*deopt` and bail (the caller re-runs the interpreter); non-numeric arrays never reach
 /// here (the VM wrapper only calls this when every element is a `Value::Number`).
 #[cfg(not(target_arch = "wasm32"))]
-fn compile_chunk_arrays(g: &mut JitGlobal, chunk: &Chunk, arity: usize, mask: u8) -> Option<NumericFn> {
+fn compile_chunk_arrays(
+    g: &mut JitGlobal,
+    chunk: &Chunk,
+    arity: usize,
+    mask: u8,
+) -> Option<NumericFn> {
     let ptr_ty = g.module.target_config().pointer_type();
     let mut sig = g.module.make_signature();
     sig.params.push(AbiParam::new(ptr_ty)); // numeric_ptr
@@ -1270,14 +1456,29 @@ fn compile_chunk_arrays(g: &mut JitGlobal, chunk: &Chunk, arity: usize, mask: u8
 
     let name = format!("tish_arr_{}", g.counter);
     g.counter += 1;
-    let id = g.module.declare_function(&name, Linkage::Export, &sig).ok()?;
+    let id = g
+        .module
+        .declare_function(&name, Linkage::Export, &sig)
+        .ok()?;
 
     let mut ctx = g.module.make_context();
     ctx.func.signature = sig.clone();
     let math_fref = g.module.declare_func_in_func(g.math_call_id, &mut ctx.func);
     let mut fbctx = FunctionBuilderContext::new();
     // No self-call in array mode (recursive call would need the array signature) → pass None.
-    if build_body_cfg(&mut ctx.func, &mut fbctx, chunk, arity, None, mask, false, math_fref).is_none()
+    // No JV local arrays in array-param mode either → pass None for the JV context.
+    if build_body_cfg(
+        &mut ctx.func,
+        &mut fbctx,
+        chunk,
+        arity,
+        None,
+        mask,
+        false,
+        math_fref,
+        None,
+    )
+    .is_none()
     {
         g.module.clear_context(&mut ctx);
         return None;
@@ -1297,13 +1498,15 @@ fn compile_chunk_arrays(g: &mut JitGlobal, chunk: &Chunk, arity: usize, mask: u8
         result_bool: false,
         array_param_mask: mask,
         recur_guarded: false,
+        jv: false,
     })
 }
 
 /// Outcome of trying to emit one *straight-line* numeric opcode.
 enum SimpleOp {
     /// Handled: bytecode consumed, IR emitted, `bool` flags a comparison/`!` result.
-    #[allow(dead_code)] // reserved: the flag will carry a comparison/`!` result; currently always false
+    #[allow(dead_code)]
+    // reserved: the flag will carry a comparison/`!` result; currently always false
     Handled(bool),
     /// The opcode is control flow / `Return` / non-numeric — NOT consumed; caller decides.
     NotSimple,
@@ -1375,8 +1578,14 @@ fn emit_simple_op(
             let (l, _) = stack.pop().unwrap();
             let is_cmp = matches!(
                 bop,
-                BinOp::Eq | BinOp::Ne | BinOp::StrictEq | BinOp::StrictNe
-                    | BinOp::Lt | BinOp::Le | BinOp::Gt | BinOp::Ge
+                BinOp::Eq
+                    | BinOp::Ne
+                    | BinOp::StrictEq
+                    | BinOp::StrictNe
+                    | BinOp::Lt
+                    | BinOp::Le
+                    | BinOp::Gt
+                    | BinOp::Ge
             );
             let v = match bop {
                 BinOp::Add => bcx.ins().fadd(l, r),
@@ -1595,6 +1804,7 @@ fn peek_u16(code: &[u8], off: usize) -> Option<u16> {
 /// (→ caller → VM) on any other opcode, a non-empty operand stack at a block boundary, boolean slots,
 /// or a `Call` whose callee is not in `callees`. ADDITIVE: a bail just runs the VM.
 /// Returns `Some(false)` (Number result) on success.
+#[allow(clippy::too_many_arguments)] // each param is a distinct, documented lowering mode/handle
 fn build_body_cfg(
     func: &mut cranelift::codegen::ir::Function,
     fbctx: &mut FunctionBuilderContext,
@@ -1611,6 +1821,10 @@ fn build_body_cfg(
     recur_guard: bool,
     // #186: the imported `tish_math_call` host fn, for lowering `Math.<fn>` (`MathUnary`) intrinsics.
     math_fref: cranelift::codegen::ir::FuncRef,
+    // #189: `Some` when the function has local `f64` arrays — carries the `tish_jv_*` `FuncRef`s + the
+    // JV slot set. Those slots become `i64` handle Variables and their array ops lower to `tish_jv_*`
+    // calls; an out-of-bounds index sets the per-thread deopt flag the wrapper re-interprets on.
+    jv: Option<&JvCtx>,
 ) -> Option<bool> {
     let code = &chunk.code;
     let num_slots = chunk.num_slots as usize;
@@ -1627,7 +1841,14 @@ fn build_body_cfg(
     let mut ip = 0;
     while ip < code.len() {
         let op = Opcode::from_u8(code[ip])?;
-        let size = op_size(op)?;
+        // For a JV function the array opcodes (NewArray/GetMember/GetIndex/SetIndex/Call) are valid
+        // and must be sized via the full instruction table; the translate loop then validates each is
+        // a real JV op (else it bails). Non-JV functions keep the strict `op_size` whitelist.
+        let size = match op_size(op) {
+            Some(s) => s,
+            None if jv.is_some() => op.instruction_size(code, ip)?,
+            None => return None,
+        };
         // A SelfCall whose arity != this function's arity can't be a plain f64-ABI native call → bail.
         if op == Opcode::SelfCall {
             if self_ref.is_none() || peek_u16(code, ip + 1)? as usize != arity {
@@ -1703,8 +1924,18 @@ fn build_body_cfg(
     };
     let body_start = *blocks.get(&0)?; // `entry` normally; `body_block` when guarded
 
-    // 2. A Variable per slot, all defined at entry so every path defines them.
-    let vars: Vec<Variable> = (0..num_slots).map(|_| bcx.declare_var(types::F64)).collect();
+    // 2. A Variable per slot, all defined at entry so every path defines them. A JV slot (#189) holds
+    //    an arena HANDLE (a `u64`, 0 = null) so its Variable is `i64`, not `f64`.
+    let vars: Vec<Variable> = (0..num_slots)
+        .map(|i| {
+            let ty = if jv.is_some_and(|j| j.slots.contains(&i)) {
+                types::I64
+            } else {
+                types::F64
+            };
+            bcx.declare_var(ty)
+        })
+        .collect();
     // Array-mode state: per-array-param `(ptr,len)` loaded from the handles array + the deopt pad.
     let mut array_slots: HashMap<usize, (ClifValue, ClifValue)> = HashMap::new();
     let mut deopt_block: Option<Block> = None;
@@ -1717,7 +1948,8 @@ fn build_body_cfg(
         deopt_ptr = Some(*params.get(2)?);
         let mut numeric_i = 0i32;
         let mut array_i = 0i64;
-        #[allow(clippy::needless_range_loop)] // `slot` drives bit-mask math (`array_mask >> slot`) + map keys, not just indexing
+        #[allow(clippy::needless_range_loop)]
+        // `slot` drives bit-mask math (`array_mask >> slot`) + map keys, not just indexing
         for slot in 0..num_slots {
             let init = if slot < arity && (array_mask >> slot) & 1 == 1 {
                 let base = bcx.ins().iadd_imm(handles_ptr, array_i * 16);
@@ -1740,17 +1972,30 @@ fn build_body_cfg(
         deopt_block = Some(bcx.create_block());
     } else {
         for (i, &v) in vars.iter().enumerate() {
-            let init = if i < arity {
-                params[i]
+            if jv.is_some_and(|j| j.slots.contains(&i)) {
+                // A JV slot starts null (handle 0); its `[]` def stores the real handle. Null-init
+                // makes the free-on-return safe even if a return precedes the def (`tish_jv_free`
+                // treats handle 0 as a no-op).
+                let null = bcx.ins().iconst(types::I64, 0);
+                bcx.def_var(v, null);
             } else {
-                bcx.ins().f64const(0.0)
-            };
-            bcx.def_var(v, init);
+                let init = if i < arity {
+                    params[i]
+                } else {
+                    bcx.ins().f64const(0.0)
+                };
+                bcx.def_var(v, init);
+            }
         }
     }
 
     // 3. Translate. The operand stack is empty at every block boundary (statement-level control flow).
     let mut stack: Vec<(ClifValue, bool)> = Vec::new();
+    // #189: JV array handles "in flight" (pushed by `LoadLocal`/`NewArray` of a JV slot, consumed by
+    // the very next `GetIndex`/`SetIndex`/`GetMember`), kept off the f64 `stack`; and a pending
+    // `arr.push` awaiting its arg + `Call`. Both must be empty at every block boundary.
+    let mut jv_pending: Vec<ClifValue> = Vec::new();
+    let mut pending_push: Option<ClifValue> = None;
     let mut cur = body_start;
     let mut terminated = false;
     let mut ip = 0usize;
@@ -1763,6 +2008,10 @@ fn build_body_cfg(
                     }
                     bcx.ins().jump(blk, &[]);
                 }
+                // A JV ref or a pending push must never span a statement boundary.
+                if !jv_pending.is_empty() || pending_push.is_some() {
+                    return None;
+                }
                 bcx.switch_to_block(blk);
                 cur = blk;
                 terminated = false;
@@ -1770,13 +2019,27 @@ fn build_body_cfg(
             }
         }
         if terminated {
-            ip += op_size(Opcode::from_u8(code[ip])?)?; // skip unreachable tail before next leader
+            // Skip the unreachable tail; a JV function may have array opcodes here (size via the full
+            // table).
+            let op = Opcode::from_u8(code[ip])?;
+            ip += match op_size(op) {
+                Some(s) => s,
+                None if jv.is_some() => op.instruction_size(code, ip)?,
+                None => return None,
+            };
             continue;
         }
         let op = Opcode::from_u8(code[ip])?;
         match op {
             Opcode::LoadLocal => {
                 let slot = peek_u16(code, ip + 1)? as usize;
+                // #189: a JV slot's value is its arena HANDLE — push it to `jv_pending` (the next
+                // GetIndex/SetIndex/GetMember consumes it), never onto the f64 stack.
+                if jv.is_some_and(|j| j.slots.contains(&slot)) {
+                    jv_pending.push(bcx.use_var(*vars.get(slot)?));
+                    ip += 3;
+                    continue;
+                }
                 // Array-mode peephole: `LoadLocal(arrayparam) ; (LoadLocal|LoadConst) ; GetIndex` →
                 // a bounds-checked native f64 load; out-of-bounds branches to the deopt pad.
                 if array_mask != 0 && slot < arity && (array_mask >> slot) & 1 == 1 {
@@ -1820,6 +2083,14 @@ fn build_body_cfg(
             }
             Opcode::StoreLocal => {
                 let slot = peek_u16(code, ip + 1)? as usize;
+                // #189: storing a JV array (its `[]` def or a re-store) pops the handle from
+                // `jv_pending` into the slot's i64 Variable.
+                if jv.is_some_and(|j| j.slots.contains(&slot)) {
+                    let ptr = jv_pending.pop()?;
+                    bcx.def_var(*vars.get(slot)?, ptr);
+                    ip += 3;
+                    continue;
+                }
                 let (val, is_bool) = stack.pop()?;
                 if is_bool {
                     return None; // no boolean slots — keeps result boxing simple
@@ -1845,6 +2116,15 @@ fn build_body_cfg(
                 let (v, is_bool) = stack.pop()?;
                 if is_bool {
                     return None;
+                }
+                // #189: free every JV array (return its arena slot to the free list) before leaving
+                // the frame — handle 0 (a slot not yet allocated on this path) is a no-op. This is why
+                // JV arrays must never escape.
+                if let Some(jvc) = jv {
+                    for &slot in jvc.slots {
+                        let handle = bcx.use_var(*vars.get(slot)?);
+                        bcx.ins().call(jvc.free, &[handle]);
+                    }
                 }
                 bcx.ins().return_(&[v]);
                 terminated = true;
@@ -1918,6 +2198,97 @@ fn build_body_cfg(
                 stack.push((r, false));
                 ip += 3;
             }
+            // #189 — local-array ops, only for JV functions (`jv` = `Some`). Each consumes the array
+            // HANDLE from `jv_pending` (its `LoadLocal`/`NewArray` pushed it) and calls `tish_jv_*`.
+            Opcode::NewArray if jv.is_some() => {
+                let jvc = jv?;
+                if peek_u16(code, ip + 1)? != 0 {
+                    return None; // only empty `[]` is JV (classifier already guaranteed this)
+                }
+                let cap = bcx.ins().iconst(types::I64, 0);
+                let call = bcx.ins().call(jvc.new, &[cap]);
+                jv_pending.push(bcx.inst_results(call)[0]);
+                ip += 3;
+            }
+            Opcode::GetIndex if !jv_pending.is_empty() => {
+                let jvc = jv?;
+                let idx = stack.pop()?.0;
+                let handle = jv_pending.pop()?;
+                // `idx as usize` (saturating: NaN/neg → 0), matching the VM's index coercion. OOB sets
+                // the per-thread deopt flag inside `tish_jv_get` and returns NaN.
+                let i = bcx.ins().fcvt_to_uint_sat(types::I64, idx);
+                let call = bcx.ins().call(jvc.get, &[handle, i]);
+                stack.push((bcx.inst_results(call)[0], false));
+                ip += 1;
+            }
+            Opcode::SetIndex if !jv_pending.is_empty() => {
+                let jvc = jv?;
+                // Stack: [ (array→jv_pending), idx, val, dup_val ]. `Dup` left `dup_val` == `val`.
+                let dup_val = stack.pop()?.0;
+                let _val = stack.pop()?.0;
+                let idx = stack.pop()?.0;
+                let handle = jv_pending.pop()?;
+                let i = bcx.ins().fcvt_to_uint_sat(types::I64, idx);
+                bcx.ins().call(jvc.set, &[handle, i, dup_val]); // OOB → deopt flag inside tish_jv_set
+                stack.push((dup_val, false)); // assignment yields the value
+                ip += 1;
+            }
+            Opcode::GetMember if !jv_pending.is_empty() => {
+                let jvc = jv?;
+                let name = chunk.names.get(peek_u16(code, ip + 1)? as usize)?;
+                let ptr = jv_pending.pop()?;
+                match name.as_ref() {
+                    "length" => {
+                        let call = bcx.ins().call(jvc.len, &[ptr]);
+                        let len_i = bcx.inst_results(call)[0];
+                        stack.push((bcx.ins().fcvt_from_uint(types::F64, len_i), false));
+                    }
+                    "push" => pending_push = Some(ptr),
+                    _ => return None, // any other member of a JV array → bail
+                }
+                ip += 3;
+            }
+            Opcode::Call if pending_push.is_some() => {
+                let jvc = jv?;
+                if peek_u16(code, ip + 1)? != 1 {
+                    return None; // `push` takes exactly one arg in the JV fast path
+                }
+                let ptr = pending_push.take()?;
+                let arg = stack.pop()?.0;
+                bcx.ins().call(jvc.push, &[ptr, arg]);
+                // `Array.push` returns the new length.
+                let call = bcx.ins().call(jvc.len, &[ptr]);
+                let len_i = bcx.inst_results(call)[0];
+                stack.push((bcx.ins().fcvt_from_uint(types::F64, len_i), false));
+                ip += 3;
+            }
+            // #189: a non-numeric constant load in a JV function — almost always the compiler's
+            // trailing implicit `LoadConst Null; Return` epilogue after a `while (true)` loop. That
+            // epilogue is the loop's never-taken exit edge: statically reachable (so it becomes a
+            // cranelift block that must be filled), dynamically dead. A `null`/string can't live in
+            // an f64 register, so instead of bailing the whole function we emit a deopt here — free
+            // the live arrays, set the flag, and return. If the block truly never runs (infinite loop
+            // with an inner `return`), cranelift keeps a dead branch and the hot path stays native;
+            // if a non-numeric return is ever actually reached, the VM wrapper re-interprets and
+            // produces the correct value. Sound either way, since the deopt path reproduces semantics.
+            Opcode::LoadConst
+                if jv.is_some()
+                    && !matches!(
+                        chunk.constants.get(peek_u16(code, ip + 1)? as usize),
+                        Some(Constant::Number(_)) | Some(Constant::Bool(_))
+                    ) =>
+            {
+                let jvc = jv?;
+                for &slot in jvc.slots {
+                    let handle = bcx.use_var(*vars.get(slot)?);
+                    bcx.ins().call(jvc.free, &[handle]);
+                }
+                bcx.ins().call(jvc.deopt, &[]);
+                let zero = bcx.ins().f64const(0.0);
+                bcx.ins().return_(&[zero]);
+                terminated = true; // the following `Return` (and any dead tail) is now skipped
+                ip += 3;
+            }
             _ => match emit_simple_op(&mut bcx, chunk, code, &mut ip, &mut stack, &params, arity) {
                 SimpleOp::Handled(_) => {}
                 _ => return None, // LoadConst/BinOp/UnaryOp handled; anything else → VM
@@ -1988,8 +2359,9 @@ fn build_body(
                 // THEN arm: straight-line ops until the trailing `Jump`.
                 let mut tip = p;
                 loop {
-                    match emit_simple_op(&mut bcx, chunk, code, &mut tip, &mut stack, &params, arity)
-                    {
+                    match emit_simple_op(
+                        &mut bcx, chunk, code, &mut tip, &mut stack, &params, arity,
+                    ) {
                         SimpleOp::Handled(_) => continue,
                         SimpleOp::Unsupported => return None,
                         SimpleOp::NotSimple => break,
@@ -2010,8 +2382,9 @@ fn build_body(
                 // ELSE arm: straight-line ops from `jp` up to the merge point.
                 let mut eip = jp;
                 while eip < merge_target {
-                    match emit_simple_op(&mut bcx, chunk, code, &mut eip, &mut stack, &params, arity)
-                    {
+                    match emit_simple_op(
+                        &mut bcx, chunk, code, &mut eip, &mut stack, &params, arity,
+                    ) {
                         SimpleOp::Handled(_) => continue,
                         _ => return None, // nested control flow / unsupported → VM
                     }
@@ -2102,6 +2475,116 @@ mod tests {
         find(&chunk).expect("the JIT must compile this arity-2 numeric fn (did it start bailing?)")
     }
 
+    /// #189: compile the first JV (function-local `f64` array) nested fn in `src` via `compile_chunk`,
+    /// bypassing the address-keyed cache (see [`jit_arity2`]). Panics if none compiles JV — so a change
+    /// that makes the classifier or lowering silently stop accepting the target fails loudly.
+    fn jit_jv(src: &str) -> NumericFn {
+        let prog = tishlang_parser::parse(src).expect("parse");
+        let opt = tishlang_opt::optimize(&prog);
+        let chunk = tishlang_bytecode::compile(&opt).expect("compile");
+        fn compile_uncached(c: &Chunk) -> Option<NumericFn> {
+            if !c.slot_based
+                || c.rest_param_index != NO_REST_PARAM
+                || c.param_count == 0
+                || c.param_count > 8
+            {
+                return None;
+            }
+            let lock = jit()?;
+            let mut g = lock.lock().ok()?;
+            compile_chunk(&mut g, c)
+        }
+        fn find(c: &Chunk) -> Option<NumericFn> {
+            for n in &c.nested {
+                if let Some(f) = compile_uncached(n) {
+                    if f.is_jv() {
+                        return Some(f);
+                    }
+                }
+                if let Some(f) = find(n) {
+                    return Some(f);
+                }
+            }
+            None
+        }
+        find(&chunk).expect("the JIT must JV-compile this local-array fn (did it start bailing?)")
+    }
+
+    /// #189: the core JV path — a function-local array built with `push`, then read and written by
+    /// index in a loop. `sum_{i=0}^{n-1}(2i+1) == n^2`, so the JIT'd result is checked against a
+    /// closed form (independent of the interpreter) across sizes. `deopt` must stay clear (in-bounds).
+    #[test]
+    fn jit_jv_local_array_sum_matches_closed_form() {
+        let f = jit_jv(
+            "function build(n) {\n\
+             let a = []\n\
+             for (let i = 0; i < n; i = i + 1) { a.push(i * 2) }\n\
+             let s = 0\n\
+             let j = 0\n\
+             while (j < n) { a[j] = a[j] + 1; s = s + a[j]; j = j + 1 }\n\
+             return s\n\
+             }\n\
+             build(0)\n",
+        );
+        assert!(f.is_jv(), "expected a JV-compiled fn");
+        for n in [1.0f64, 5.0, 20.0, 100.0] {
+            jv_reset_deopt();
+            let r = f.call(&[n]);
+            assert!(!jv_take_deopt(), "no OOB expected for n={n}");
+            assert_eq!(r, n * n, "JV local-array sum wrong for n={n}");
+        }
+    }
+
+    /// #189: a `while (true)` whose only exit is an inner `return` — the compiler still emits a trailing
+    /// implicit `LoadConst Null; Return` epilogue (the loop's never-taken exit edge). That epilogue must
+    /// NOT bail JV compilation; it's routed to a deopt. Without the fix this fn falls back to the VM.
+    #[test]
+    fn jit_jv_while_true_epilogue_compiles() {
+        let f = jit_jv(
+            "function f(n) {\n\
+             let a = []\n\
+             a.push(0)\n\
+             let i = 0\n\
+             while (true) {\n\
+               a[0] = a[0] + 1\n\
+               i = i + 1\n\
+               if (i >= n) { return a[0] }\n\
+             }\n\
+             }\n\
+             f(0)\n",
+        );
+        assert!(f.is_jv(), "while(true)+return JV fn must compile, not bail");
+        jv_reset_deopt();
+        assert_eq!(f.call(&[7.0]), 7.0);
+        assert!(!jv_take_deopt());
+    }
+
+    /// #189: an out-of-bounds index makes the host `tish_jv_get` set the deopt flag (and return a
+    /// sentinel); the VM wrapper then discards the result and re-interprets. Sound because JV arrays
+    /// never escape, so the partially-run native attempt mutated nothing observable.
+    #[test]
+    fn jit_jv_oob_read_sets_deopt_flag() {
+        // A loop that reads `a[i]` for `i` in `0..n`, but the array only has 2 elements — so `n > 2`
+        // reads out of bounds. (Needs a loop: the CFG JIT only engages on loop/self-call fns.)
+        let f = jit_jv(
+            "function f(n) {\n\
+             let a = []\n\
+             a.push(10)\n\
+             a.push(20)\n\
+             let s = 0\n\
+             for (let i = 0; i < n; i = i + 1) { s = s + a[i] }\n\
+             return s\n\
+             }\n\
+             f(0)\n",
+        );
+        jv_reset_deopt();
+        assert_eq!(f.call(&[2.0]), 30.0, "a[0]+a[1] == 30");
+        assert!(!jv_take_deopt(), "n=2 stays in bounds");
+        jv_reset_deopt();
+        let _ = f.call(&[5.0]); // reads a[2] (past the 2-element array) → OOB
+        assert!(jv_take_deopt(), "OOB array access must set the deopt flag");
+    }
+
     /// Regression for the address-reuse stale hit (#247): compile one function, then overwrite the SAME
     /// heap `Chunk` (same address = the cache key) with a *different* function — what a long-lived
     /// process (REPL / multi-script embedder) does when a freed chunk address is reused. Before the
@@ -2129,14 +2612,35 @@ mod tests {
         let shr = jit_arity2("const f = (a, b) => a >> b\nf(0, 0)\n");
         let ushr = jit_arity2("const f = (a, b) => a >>> b\nf(0, 0)\n");
         let cases = [
-            (1.0, 4.0), (1.0, 32.0), (1.0, 33.0), (1.0, -1.0), (-8.0, 1.0), (-1.0, 0.0),
-            (-2.0, 1.0), (4294967295.0, 0.0), (3.9, 0.0), (4294967297.0, 0.0),
-            (-123456789.0, 5.0), (65535.0, 16.0),
+            (1.0, 4.0),
+            (1.0, 32.0),
+            (1.0, 33.0),
+            (1.0, -1.0),
+            (-8.0, 1.0),
+            (-1.0, 0.0),
+            (-2.0, 1.0),
+            (4294967295.0, 0.0),
+            (3.9, 0.0),
+            (4294967297.0, 0.0),
+            (-123456789.0, 5.0),
+            (65535.0, 16.0),
         ];
         for (a, b) in cases {
-            assert_eq!(shl.call(&[a, b]), to_int32(a).wrapping_shl(to_uint32(b)) as f64, "<< {a} {b}");
-            assert_eq!(shr.call(&[a, b]), to_int32(a).wrapping_shr(to_uint32(b)) as f64, ">> {a} {b}");
-            assert_eq!(ushr.call(&[a, b]), to_uint32(a).wrapping_shr(to_uint32(b)) as f64, ">>> {a} {b}");
+            assert_eq!(
+                shl.call(&[a, b]),
+                to_int32(a).wrapping_shl(to_uint32(b)) as f64,
+                "<< {a} {b}"
+            );
+            assert_eq!(
+                shr.call(&[a, b]),
+                to_int32(a).wrapping_shr(to_uint32(b)) as f64,
+                ">> {a} {b}"
+            );
+            assert_eq!(
+                ushr.call(&[a, b]),
+                to_uint32(a).wrapping_shr(to_uint32(b)) as f64,
+                ">>> {a} {b}"
+            );
         }
     }
 
@@ -2181,7 +2685,11 @@ mod tests {
         assert_eq!(deopt, 0, "v1 region never sets the deopt flag");
         let mut got = buf.clone();
         got.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        assert_eq!(got, vec![10.0, 45.0], "s=45 (sum 0..9), i=10 after the loop");
+        assert_eq!(
+            got,
+            vec![10.0, 45.0],
+            "s=45 (sum 0..9), i=10 after the loop"
+        );
     }
 
     /// #190 — a loop that touches a non-slot value (a general call) is not pure-numeric slot math, so
@@ -2207,7 +2715,8 @@ mod tests {
             "let s = 0.0\nlet i = 0.0\nwhile (i < 20.0) { if (i % 2.0 == 0.0) { s = s + i }; i = i + 1.0 }\n",
         );
         let (header, end) = first_region(&chunk);
-        let lf = try_compile_loop(&chunk, header, end).expect("branchy numeric loop must OSR-compile");
+        let lf =
+            try_compile_loop(&chunk, header, end).expect("branchy numeric loop must OSR-compile");
         let mut buf = vec![0.0f64; lf.used_slots.len()];
         let mut deopt = 0u8;
         lf.call(&mut buf, &mut deopt);

--- a/crates/tish_vm/src/jit.rs
+++ b/crates/tish_vm/src/jit.rs
@@ -422,6 +422,19 @@ struct JvFns {
     free: cranelift_module::FuncId,
 }
 
+/// Per-function-build handles for JV local arrays (#189): the `tish_jv_*` `FuncRef`s imported into
+/// *this* function, plus the set of slots classified as JV arrays. Passed to [`build_body_cfg`]; the
+/// deopt pointer is extracted from the function's trailing param inside the builder.
+struct JvCtx<'a> {
+    new: cranelift::codegen::ir::FuncRef,
+    push: cranelift::codegen::ir::FuncRef,
+    get: cranelift::codegen::ir::FuncRef,
+    set: cranelift::codegen::ir::FuncRef,
+    len: cranelift::codegen::ir::FuncRef,
+    free: cranelift::codegen::ir::FuncRef,
+    slots: &'a std::collections::HashSet<usize>,
+}
+
 /// Host entry point the JIT calls for `Math.<fn>` intrinsics it doesn't lower to a native op (#186):
 /// sin/cos/tan/exp/log/round/sign/… The single source of truth is [`MathUnaryFn::apply`], so JIT ≡
 /// VM ≡ interpreter bit-for-bit. `extern "C"` and registered as a JIT symbol; the id is the operand.
@@ -1508,6 +1521,60 @@ fn chunk_has_self_call(chunk: &Chunk) -> bool {
         ip += size;
     }
     false
+}
+
+/// #189 — identify function-LOCAL slots that hold non-escaping `f64` arrays (JV slots). A slot
+/// qualifies iff its ONLY definition is an empty array literal (`NewArray 0` immediately followed by
+/// `StoreLocal slot`) and it is never stored from anything else (which would alias/escape it). Any
+/// `NewArray` with a non-empty literal, or one not immediately stored to a slot, bails the WHOLE
+/// function (`None`) — such an array can't be JV-compiled and the function has array opcodes the JIT
+/// can't handle anyway. `Some(empty)` = "no local arrays" (the normal numeric path).
+///
+/// This is a cheap pass over STORES only; the [`build_body_cfg`] emission validates USES by bailing
+/// on any misuse of a JV ref (it reaching a numeric op, a return, a call arg, a block boundary, …),
+/// so a mis-shaped use never miscompiles — it just falls back to the interpreter.
+fn classify_jv_slots(chunk: &Chunk) -> Option<std::collections::HashSet<usize>> {
+    let code = &chunk.code;
+    let mut from_newarray: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    let mut from_other: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    let mut has_newarray = false;
+    let mut ip = 0usize;
+    let mut prev_newarray0 = false;
+    while ip < code.len() {
+        let op = Opcode::from_u8(*code.get(ip)?)?;
+        let size = op.instruction_size(code, ip)?;
+        let is_newarray0 = op == Opcode::NewArray && peek_u16(code, ip + 1)? == 0;
+        if op == Opcode::NewArray {
+            has_newarray = true;
+            if peek_u16(code, ip + 1)? != 0 {
+                return None; // non-empty array literal → not JV-compilable
+            }
+            // An empty `[]` must be stored straight into a slot (`let a = []`); anything else means
+            // the fresh array is used inline / escapes → bail.
+            if Opcode::from_u8(*code.get(ip + size)?)? != Opcode::StoreLocal {
+                return None;
+            }
+        }
+        if op == Opcode::StoreLocal {
+            let slot = peek_u16(code, ip + 1)? as usize;
+            if prev_newarray0 {
+                from_newarray.insert(slot);
+            } else {
+                from_other.insert(slot);
+            }
+        }
+        prev_newarray0 = is_newarray0;
+        ip += size;
+    }
+    if !has_newarray {
+        return Some(std::collections::HashSet::new());
+    }
+    // A NewArray-defined slot that is ALSO stored otherwise is aliased/polymorphic — bail the whole
+    // function (its array can't be JV-compiled, and it has `NewArray` the JIT otherwise rejects).
+    if from_newarray.iter().any(|s| from_other.contains(s)) {
+        return None;
+    }
+    Some(from_newarray)
 }
 
 /// Read a big-endian u16 operand at `off` without advancing (matches [`read_u16`]).

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -229,13 +229,17 @@ fn get_builtin_export(enabled: &HashSet<String>, spec: &str, export_name: &str) 
                     Value::Function(_) => raw,
                     Value::Object(ref obj) => {
                         let obj_ref = obj.borrow();
-                        if let Some(Value::Function(on_worker)) =
-                            obj_ref.strings.get(&std::sync::Arc::from("onWorker")).cloned()
+                        if let Some(Value::Function(on_worker)) = obj_ref
+                            .strings
+                            .get(&std::sync::Arc::from("onWorker"))
+                            .cloned()
                         {
                             let args_for_init = [Value::Number(0.0)];
                             on_worker.call(&args_for_init)
-                        } else if let Some(h) =
-                            obj_ref.strings.get(&std::sync::Arc::from("handler")).cloned()
+                        } else if let Some(h) = obj_ref
+                            .strings
+                            .get(&std::sync::Arc::from("handler"))
+                            .cloned()
                         {
                             h
                         } else {
@@ -297,7 +301,10 @@ fn get_builtin_export(enabled: &HashSet<String>, spec: &str, export_name: &str) 
                 tishlang_runtime::process_exec_file(args)
             })),
             "argv" => Some(Value::Array(VmRef::new(
-                tishlang_core::process_argv().into_iter().map(|s| Value::String(s.into())).collect(),
+                tishlang_core::process_argv()
+                    .into_iter()
+                    .map(|s| Value::String(s.into()))
+                    .collect(),
             ))),
             "env" => Some(value_object_from_map(
                 std::env::vars()
@@ -325,7 +332,10 @@ fn get_builtin_export(enabled: &HashSet<String>, spec: &str, export_name: &str) 
                 m.insert(
                     "argv".into(),
                     Value::Array(VmRef::new(
-                        tishlang_core::process_argv().into_iter().map(|s| Value::String(s.into())).collect(),
+                        tishlang_core::process_argv()
+                            .into_iter()
+                            .map(|s| Value::String(s.into()))
+                            .collect(),
                     )),
                 );
                 m.insert(
@@ -368,8 +378,12 @@ fn get_builtin_export(enabled: &HashSet<String>, spec: &str, export_name: &str) 
     #[cfg(feature = "tty")]
     if spec == "tish:tty" && cap_allows(enabled, "tty") {
         return match export_name {
-            "size" => Some(Value::native(|args: &[Value]| tishlang_runtime::tty_size(args))),
-            "isTTY" => Some(Value::native(|args: &[Value]| tishlang_runtime::tty_is_tty(args))),
+            "size" => Some(Value::native(|args: &[Value]| {
+                tishlang_runtime::tty_size(args)
+            })),
+            "isTTY" => Some(Value::native(|args: &[Value]| {
+                tishlang_runtime::tty_is_tty(args)
+            })),
             "setRawMode" => Some(Value::native(|args: &[Value]| {
                 tishlang_runtime::tty_set_raw_mode(args)
             })),
@@ -379,7 +393,9 @@ fn get_builtin_export(enabled: &HashSet<String>, spec: &str, export_name: &str) 
             "leaveAltScreen" => Some(Value::native(|args: &[Value]| {
                 tishlang_runtime::tty_leave_alt_screen(args)
             })),
-            "read" => Some(Value::native(|args: &[Value]| tishlang_runtime::tty_read(args))),
+            "read" => Some(Value::native(|args: &[Value]| {
+                tishlang_runtime::tty_read(args)
+            })),
             "readLine" => Some(Value::native(|args: &[Value]| {
                 tishlang_runtime::tty_read_line(args)
             })),
@@ -679,10 +695,7 @@ fn init_globals(enabled: &HashSet<String>) -> ObjectMap {
             Value::String(v.type_name().into())
         }),
     );
-    g.insert(
-        "Symbol".into(),
-        tishlang_builtins::symbol::symbol_object(),
-    );
+    g.insert("Symbol".into(), tishlang_builtins::symbol::symbol_object());
 
     // Date - full constructor (new Date(...)) plus statics now()/parse()/UTC().
     g.insert(
@@ -703,14 +716,38 @@ fn init_globals(enabled: &HashSet<String>) -> ObjectMap {
             "Float64Array",
             tishlang_builtins::typedarrays::float64_array_constructor_value as fn() -> Value,
         ),
-        ("Float32Array", tishlang_builtins::typedarrays::float32_array_constructor_value),
-        ("Int8Array", tishlang_builtins::typedarrays::int8_array_constructor_value),
-        ("Uint8Array", tishlang_builtins::typedarrays::uint8_array_constructor_value),
-        ("Uint8ClampedArray", tishlang_builtins::typedarrays::uint8_clamped_array_constructor_value),
-        ("Int16Array", tishlang_builtins::typedarrays::int16_array_constructor_value),
-        ("Uint16Array", tishlang_builtins::typedarrays::uint16_array_constructor_value),
-        ("Int32Array", tishlang_builtins::typedarrays::int32_array_constructor_value),
-        ("Uint32Array", tishlang_builtins::typedarrays::uint32_array_constructor_value),
+        (
+            "Float32Array",
+            tishlang_builtins::typedarrays::float32_array_constructor_value,
+        ),
+        (
+            "Int8Array",
+            tishlang_builtins::typedarrays::int8_array_constructor_value,
+        ),
+        (
+            "Uint8Array",
+            tishlang_builtins::typedarrays::uint8_array_constructor_value,
+        ),
+        (
+            "Uint8ClampedArray",
+            tishlang_builtins::typedarrays::uint8_clamped_array_constructor_value,
+        ),
+        (
+            "Int16Array",
+            tishlang_builtins::typedarrays::int16_array_constructor_value,
+        ),
+        (
+            "Uint16Array",
+            tishlang_builtins::typedarrays::uint16_array_constructor_value,
+        ),
+        (
+            "Int32Array",
+            tishlang_builtins::typedarrays::int32_array_constructor_value,
+        ),
+        (
+            "Uint32Array",
+            tishlang_builtins::typedarrays::uint32_array_constructor_value,
+        ),
     ] {
         g.insert(name.into(), ctor());
     }
@@ -720,7 +757,10 @@ fn init_globals(enabled: &HashSet<String>) -> ObjectMap {
     );
     // Error constructors (issue #60): `new Error(msg)` / `Error(msg)` → `{ name, message }`.
     for name in ["Error", "TypeError", "RangeError", "SyntaxError"] {
-        g.insert(name.into(), construct_builtin::error_constructor_value(name));
+        g.insert(
+            name.into(),
+            construct_builtin::error_constructor_value(name),
+        );
     }
 
     // Object methods - delegate to tishlang_builtins::globals
@@ -829,7 +869,10 @@ fn init_globals(enabled: &HashSet<String>) -> ObjectMap {
         process_obj.insert(
             "argv".into(),
             Value::Array(VmRef::new(
-                tishlang_core::process_argv().into_iter().map(|s| Value::String(s.into())).collect(),
+                tishlang_core::process_argv()
+                    .into_iter()
+                    .map(|s| Value::String(s.into()))
+                    .collect(),
             )),
         );
         process_obj.insert(
@@ -901,13 +944,17 @@ fn init_globals(enabled: &HashSet<String>) -> ObjectMap {
                     Value::Function(_) => raw,
                     Value::Object(ref obj) => {
                         let obj_ref = obj.borrow();
-                        if let Some(Value::Function(on_worker)) =
-                            obj_ref.strings.get(&std::sync::Arc::from("onWorker")).cloned()
+                        if let Some(Value::Function(on_worker)) = obj_ref
+                            .strings
+                            .get(&std::sync::Arc::from("onWorker"))
+                            .cloned()
                         {
                             let args_for_init = [Value::Number(0.0)];
                             on_worker.call(&args_for_init)
-                        } else if let Some(h) =
-                            obj_ref.strings.get(&std::sync::Arc::from("handler")).cloned()
+                        } else if let Some(h) = obj_ref
+                            .strings
+                            .get(&std::sync::Arc::from("handler"))
+                            .cloned()
                         {
                             h
                         } else {
@@ -1012,7 +1059,8 @@ fn try_call_array_jit(
     // `scratch` OWNS the extracted f64 data; handles point into it. Build handles only AFTER scratch is
     // fully populated so its backing buffers never reallocate out from under a live pointer.
     let mut scratch: Vec<Vec<f64>> = Vec::new();
-    #[allow(clippy::needless_range_loop)] // `i` drives bit-mask math (`mask >> i`), not just indexing
+    #[allow(clippy::needless_range_loop)]
+    // `i` drives bit-mask math (`mask >> i`), not just indexing
     for i in 0..arity {
         if (mask >> i) & 1 == 1 {
             match &args[i] {
@@ -1085,47 +1133,66 @@ impl tishlang_core::Callable for VmClosure {
                             }
                         }
                         if all_numbers {
-                            // #381: a self-recursive JIT'd function carries a RecurGuard so it bails
-                            // (rather than overflowing the native stack) when the recursion nears the
-                            // real remaining stack. On a bail we raise the same catchable RangeError as
-                            // the non-JIT paths — tish's deopt tier producing the throw, not the JIT.
-                            let res = if nf.recur_guarded() {
-                                let anchor = 0u8;
-                                let current_sp = &anchor as *const u8 as usize;
-                                // `stack_limit` = the stack address below which we bail, leaving a
-                                // headroom margin. If the remaining stack is unknown we pass 0 (SP is
-                                // never below 0 → never trips), i.e. behave as before.
-                                let stack_limit = match stacker::remaining_stack() {
-                                    Some(rem) => {
-                                        // Cap the margin at half of what's left: when a JIT'd function
-                                        // is first entered on an already-deep stack (rem < margin),
-                                        // `bottom + margin` would sit ABOVE the current SP and trip on
-                                        // the very first call — a false positive on shallow recursion.
-                                        // Capping keeps the limit strictly below SP for any rem, while
-                                        // still bailing with real headroom to spare.
-                                        let margin = RECUR_STACK_MARGIN.min(rem / 2);
-                                        current_sp.saturating_sub(rem).saturating_add(margin)
-                                    }
-                                    None => 0,
-                                };
-                                let mut guard = crate::jit::RecurGuard {
-                                    stack_limit,
-                                    tripped: 0,
-                                };
-                                let r = nf.call_guarded(&nums[..arity], &mut guard);
-                                if guard.tripped != 0 {
-                                    set_pending_throw(stack_overflow_error());
-                                    return Value::Null;
+                            // #189: a JV function has function-local `f64` arrays lowered to
+                            // `tish_jv_*` calls over a per-thread arena. An out-of-bounds access (or a
+                            // non-numeric return) sets a per-thread deopt flag; we discard the numeric
+                            // result and re-run the interpreter. Sound because JV arrays never escape
+                            // the function — nothing observable was mutated, so re-execution
+                            // reproduces identical behaviour.
+                            if nf.is_jv() {
+                                crate::jit::jv_reset_deopt();
+                                let r = nf.call(&nums[..arity]);
+                                if !crate::jit::jv_take_deopt() {
+                                    return if nf.result_is_bool() {
+                                        Value::Bool(r != 0.0)
+                                    } else {
+                                        Value::Number(r)
+                                    };
                                 }
-                                r
+                                // deopt ⇒ fall through to the interpreter below.
                             } else {
-                                nf.call(&nums[..arity])
-                            };
-                            return if nf.result_is_bool() {
-                                Value::Bool(res != 0.0)
-                            } else {
-                                Value::Number(res)
-                            };
+                                // #381: a self-recursive JIT'd function carries a RecurGuard so it bails
+                                // (rather than overflowing the native stack) when the recursion nears the
+                                // real remaining stack. On a bail we raise the same catchable RangeError as
+                                // the non-JIT paths — tish's deopt tier producing the throw, not the JIT.
+                                let res = if nf.recur_guarded() {
+                                    let anchor = 0u8;
+                                    let current_sp = &anchor as *const u8 as usize;
+                                    // `stack_limit` = the stack address below which we bail, leaving a
+                                    // headroom margin. If the remaining stack is unknown we pass 0 (SP is
+                                    // never below 0 → never trips), i.e. behave as before.
+                                    let stack_limit = match stacker::remaining_stack() {
+                                        Some(rem) => {
+                                            // Cap the margin at half of what's left: when a JIT'd function
+                                            // is first entered on an already-deep stack (rem < margin),
+                                            // `bottom + margin` would sit ABOVE the current SP and trip on
+                                            // the very first call — a false positive on shallow recursion.
+                                            // Capping keeps the limit strictly below SP for any rem, while
+                                            // still bailing with real headroom to spare.
+                                            let margin = RECUR_STACK_MARGIN.min(rem / 2);
+                                            current_sp.saturating_sub(rem).saturating_add(margin)
+                                        }
+                                        None => 0,
+                                    };
+                                    let mut guard = crate::jit::RecurGuard {
+                                        stack_limit,
+                                        tripped: 0,
+                                    };
+                                    let r = nf.call_guarded(&nums[..arity], &mut guard);
+                                    if guard.tripped != 0 {
+                                        set_pending_throw(stack_overflow_error());
+                                        return Value::Null;
+                                    }
+                                    r
+                                } else {
+                                    nf.call(&nums[..arity])
+                                };
+                                return if nf.result_is_bool() {
+                                    Value::Bool(res != 0.0)
+                                } else {
+                                    Value::Number(res)
+                                };
+                            }
                         }
                     } else if let Some(v) = try_call_array_jit(&nf, args, arity, mask) {
                         // Array-mode path: succeeded (all-numeric arrays, in-bounds). On any bail
@@ -1280,7 +1347,11 @@ impl Vm {
         // regression to the DEFAULT path — caching makes the flag-off check a single atomic load.
         use std::sync::OnceLock;
         static ENABLED: OnceLock<bool> = OnceLock::new();
-        *ENABLED.get_or_init(|| std::env::var("TISH_FRAME_VM").map(|v| v == "1").unwrap_or(false))
+        *ENABLED.get_or_init(|| {
+            std::env::var("TISH_FRAME_VM")
+                .map(|v| v == "1")
+                .unwrap_or(false)
+        })
     }
 
     /// A `VmClosure` runs on the frame stack iff its chunk is frame-eligible AND it has no numeric
@@ -1493,7 +1564,9 @@ impl Vm {
                     let idx = Self::read_u16(code, &mut ip) as usize;
                     let v = match cur.constants.get(idx) {
                         Some(Constant::Number(n)) => Value::Number(*n),
-                        Some(Constant::String(s)) => Value::String(tishlang_core::ArcStr::from(s.as_ref())),
+                        Some(Constant::String(s)) => {
+                            Value::String(tishlang_core::ArcStr::from(s.as_ref()))
+                        }
                         Some(Constant::Bool(b)) => Value::Bool(*b),
                         Some(Constant::Null) => Value::Null,
                         _ => ferr!("Ineligible constant {} in run_framed", idx),
@@ -1559,7 +1632,10 @@ impl Vm {
                         if osr_hot.1 != u32::MAX {
                             osr_hot.1 = osr_hot.1.saturating_add(1);
                             if osr_hot.1 >= OSR_THRESHOLD
-                                && osr_hot.1.saturating_sub(OSR_THRESHOLD).is_multiple_of(OSR_RETRY)
+                                && osr_hot
+                                    .1
+                                    .saturating_sub(OSR_THRESHOLD)
+                                    .is_multiple_of(OSR_RETRY)
                             {
                                 match Self::run_osr(
                                     &cur, header_ip, region_end, &mut slots, slot_base,
@@ -1730,7 +1806,8 @@ impl Vm {
         // active loop changes: entry, exit, or a nested-loop switch). Keeps the per-back-edge cost of a
         // resolved loop to two integer compares.
         #[cfg(not(target_arch = "wasm32"))]
-        let mut osr_counters: std::collections::HashMap<usize, u32> = std::collections::HashMap::new();
+        let mut osr_counters: std::collections::HashMap<usize, u32> =
+            std::collections::HashMap::new();
         #[cfg(not(target_arch = "wasm32"))]
         let mut osr_hot: (usize, u32) = (usize::MAX, 0);
         // Frame-local string builder for `acc += x` on a slot local (Opcode::AppendLocal): keeps the
@@ -1893,8 +1970,7 @@ impl Vm {
                             _ => {
                                 // Non-string (or absent) accumulator: generic `+=` in place,
                                 // identical to LoadLocal; BinOp Add; StoreLocal.
-                                let current =
-                                    slot_locals.get(slot).cloned().unwrap_or(Value::Null);
+                                let current = slot_locals.get(slot).cloned().unwrap_or(Value::Null);
                                 let result = eval_binop(BinOp::Add, &current, &rhs)?;
                                 match slot_locals.get_mut(slot) {
                                     Some(dst) => *dst = result,
@@ -1931,7 +2007,9 @@ impl Vm {
                         .ok_or_else(|| format!("Constant index out of bounds: {}", idx))?;
                     let v = match c {
                         Constant::Number(n) => Value::Number(*n),
-                        Constant::String(s) => Value::String(tishlang_core::ArcStr::from(s.as_ref())),
+                        Constant::String(s) => {
+                            Value::String(tishlang_core::ArcStr::from(s.as_ref()))
+                        }
                         Constant::Bool(b) => Value::Bool(*b),
                         Constant::Null => Value::Null,
                         Constant::Closure(nested_idx) => {
@@ -1952,45 +2030,45 @@ impl Vm {
                             // A closure must capture a real scope (even if empty) so that, post-creation,
                             // the parent's name-based locals are visible. Materialise local_scope here.
                             let captured_scope: ScopeMap = ls_get_or_init!().clone();
-                            let enclosing_chain: SharedChain = SharedChain::new(if active_loop_vars.is_empty() {
-                                let mut chain = Vec::with_capacity(self.enclosing.len() + 1);
-                                chain.push(captured_scope.clone());
-                                chain.extend(self.enclosing.iter().cloned());
-                                chain
-                            } else {
-                                // Per-iteration `let`: freeze the loop var(s) into an overlay that
-                                // shadows the still-shared frame scope, then the inherited chain.
-                                let mut overlay = ObjectMap::default();
-                                {
-                                    let ls = captured_scope.borrow();
-                                    for n in &active_loop_vars {
-                                        if let Some(v) = ls.get(n.as_ref()) {
-                                            overlay.insert(Arc::clone(n), v.clone());
+                            let enclosing_chain: SharedChain =
+                                SharedChain::new(if active_loop_vars.is_empty() {
+                                    let mut chain = Vec::with_capacity(self.enclosing.len() + 1);
+                                    chain.push(captured_scope.clone());
+                                    chain.extend(self.enclosing.iter().cloned());
+                                    chain
+                                } else {
+                                    // Per-iteration `let`: freeze the loop var(s) into an overlay that
+                                    // shadows the still-shared frame scope, then the inherited chain.
+                                    let mut overlay = ObjectMap::default();
+                                    {
+                                        let ls = captured_scope.borrow();
+                                        for n in &active_loop_vars {
+                                            if let Some(v) = ls.get(n.as_ref()) {
+                                                overlay.insert(Arc::clone(n), v.clone());
+                                            }
                                         }
                                     }
-                                }
-                                let mut chain = Vec::with_capacity(self.enclosing.len() + 2);
-                                chain.push(VmRef::new(overlay));
-                                chain.push(captured_scope.clone());
-                                chain.extend(self.enclosing.iter().cloned());
-                                chain
-                            });
+                                    let mut chain = Vec::with_capacity(self.enclosing.len() + 2);
+                                    chain.push(VmRef::new(overlay));
+                                    chain.push(captured_scope.clone());
+                                    chain.extend(self.enclosing.iter().cloned());
+                                    chain
+                                });
                             let capabilities = Arc::clone(&self.capabilities);
                             let native_modules = self.native_modules.clone();
                             // Frame-eligibility is an O(chunk) bytecode scan; gate it behind the
                             // (cached) frame-VM flag so the DEFAULT path skips it entirely — flag-off
                             // closure creation pays nothing.
-                            let frameable = Vm::frame_vm_enabled()
-                                && {
-                                    #[cfg(not(target_arch = "wasm32"))]
-                                    {
-                                        jit_fn.is_none() && Vm::chunk_frame_eligible(&inner_clone)
-                                    }
-                                    #[cfg(target_arch = "wasm32")]
-                                    {
-                                        Vm::chunk_frame_eligible(&inner_clone)
-                                    }
-                                };
+                            let frameable = Vm::frame_vm_enabled() && {
+                                #[cfg(not(target_arch = "wasm32"))]
+                                {
+                                    jit_fn.is_none() && Vm::chunk_frame_eligible(&inner_clone)
+                                }
+                                #[cfg(target_arch = "wasm32")]
+                                {
+                                    Vm::chunk_frame_eligible(&inner_clone)
+                                }
+                            };
                             let vmclosure = VmClosure {
                                 chunk: std::sync::Arc::new(inner_clone),
                                 frameable,
@@ -2042,7 +2120,10 @@ impl Vm {
                         .pop()
                         .ok_or_else(|| "Stack underflow".to_string())?;
                     // Update innermost scope that has the variable (matches interpreter Scope.assign)
-                    if local_scope.as_ref().is_some_and(|ls| ls.borrow().contains_key(name.as_ref())) {
+                    if local_scope
+                        .as_ref()
+                        .is_some_and(|ls| ls.borrow().contains_key(name.as_ref()))
+                    {
                         ls_get_or_init!().borrow_mut().insert(Arc::clone(name), v);
                     } else if let Some(e) = self
                         .enclosing
@@ -2299,7 +2380,9 @@ impl Vm {
                             .unwrap_or(Value::Null)
                     });
                     #[cfg(target_arch = "wasm32")]
-                    let result = vm.run_chunk(chunk, nested, &args, false).unwrap_or(Value::Null);
+                    let result = vm
+                        .run_chunk(chunk, nested, &args, false)
+                        .unwrap_or(Value::Null);
                     tishlang_core::dec_call_depth();
                     if let Some(v) = take_pending_throw() {
                         raise!(v);
@@ -2332,8 +2415,7 @@ impl Vm {
                     let f = match &callee {
                         Value::Function(f) => f.clone(),
                         Value::Object(o) => {
-                            if let Some(Value::Function(call_fn)) =
-                                o.borrow().strings.get("__call")
+                            if let Some(Value::Function(call_fn)) = o.borrow().strings.get("__call")
                             {
                                 call_fn.clone()
                             } else {
@@ -2436,15 +2518,25 @@ impl Vm {
                             if osr_hot.0 != usize::MAX {
                                 osr_counters.insert(osr_hot.0, osr_hot.1);
                             }
-                            osr_hot = (header_ip, osr_counters.get(&header_ip).copied().unwrap_or(0));
+                            osr_hot = (
+                                header_ip,
+                                osr_counters.get(&header_ip).copied().unwrap_or(0),
+                            );
                         }
                         if osr_hot.1 != u32::MAX {
                             osr_hot.1 = osr_hot.1.saturating_add(1);
                             if osr_hot.1 >= OSR_THRESHOLD
-                                && osr_hot.1.saturating_sub(OSR_THRESHOLD).is_multiple_of(OSR_RETRY)
+                                && osr_hot
+                                    .1
+                                    .saturating_sub(OSR_THRESHOLD)
+                                    .is_multiple_of(OSR_RETRY)
                             {
                                 match Self::run_osr(
-                                    chunk, header_ip, region_end, &mut slot_locals, 0,
+                                    chunk,
+                                    header_ip,
+                                    region_end,
+                                    &mut slot_locals,
+                                    0,
                                 ) {
                                     OsrResult::Compiled(exit_ip) => {
                                         ip = exit_ip;
@@ -2590,8 +2682,12 @@ impl Vm {
                         if let Some(nums) = elems.iter().try_fold(
                             Vec::<f64>::with_capacity(elems.len()),
                             |mut acc, v| {
-                                if let Value::Number(n) = v { acc.push(*n); Some(acc) }
-                                else { None }
+                                if let Value::Number(n) = v {
+                                    acc.push(*n);
+                                    Some(acc)
+                                } else {
+                                    None
+                                }
                             },
                         ) {
                             self.stack.push(Value::number_array(nums));
@@ -2614,10 +2710,8 @@ impl Vm {
                     let base = self.stack.len() - 2 * n;
                     let mut map = PropMap::with_capacity(n);
                     for i in 0..n {
-                        let key_val =
-                            std::mem::replace(&mut self.stack[base + 2 * i], Value::Null);
-                        let val =
-                            std::mem::replace(&mut self.stack[base + 2 * i + 1], Value::Null);
+                        let key_val = std::mem::replace(&mut self.stack[base + 2 * i], Value::Null);
+                        let val = std::mem::replace(&mut self.stack[base + 2 * i + 1], Value::Null);
                         let key: Arc<str> = key_val.to_display_string().into();
                         map.insert(key, val);
                     }
@@ -2773,13 +2867,25 @@ impl Vm {
                                 .iter()
                                 .map(|&n| {
                                     let elem = Value::Number(n);
-                                    let (l, r) = if param_left { (elem, const_val.clone()) } else { (const_val.clone(), elem) };
+                                    let (l, r) = if param_left {
+                                        (elem, const_val.clone())
+                                    } else {
+                                        (const_val.clone(), elem)
+                                    };
                                     eval_binop(binop, &l, &r).unwrap_or(Value::Null)
                                 })
                                 .collect();
                             // If every result is numeric, stay packed (the common case for x*2, x+1, etc).
                             if mapped.iter().all(|v| matches!(v, Value::Number(_))) {
-                                Value::number_array(mapped.into_iter().map(|v| match v { Value::Number(n) => n, _ => unreachable!() }).collect())
+                                Value::number_array(
+                                    mapped
+                                        .into_iter()
+                                        .map(|v| match v {
+                                            Value::Number(n) => n,
+                                            _ => unreachable!(),
+                                        })
+                                        .collect(),
+                                )
                             } else {
                                 Value::Array(VmRef::new(mapped))
                             }
@@ -2789,8 +2895,16 @@ impl Vm {
                             let mapped: Vec<Value> = arr_borrow
                                 .iter()
                                 .map(|v| {
-                                    let l: Value = if param_left { (*v).clone() } else { const_val.clone() };
-                                    let r: Value = if param_left { const_val.clone() } else { (*v).clone() };
+                                    let l: Value = if param_left {
+                                        (*v).clone()
+                                    } else {
+                                        const_val.clone()
+                                    };
+                                    let r: Value = if param_left {
+                                        const_val.clone()
+                                    } else {
+                                        (*v).clone()
+                                    };
                                     eval_binop(binop, &l, &r).unwrap_or(Value::Null)
                                 })
                                 .collect();
@@ -2824,7 +2938,11 @@ impl Vm {
                                 .iter()
                                 .filter(|&&n| {
                                     let elem = Value::Number(n);
-                                    let (l, r) = if param_left { (elem, const_val.clone()) } else { (const_val.clone(), elem) };
+                                    let (l, r) = if param_left {
+                                        (elem, const_val.clone())
+                                    } else {
+                                        (const_val.clone(), elem)
+                                    };
                                     eval_binop(binop, &l, &r).unwrap_or(Value::Null).is_truthy()
                                 })
                                 .copied()
@@ -2836,7 +2954,11 @@ impl Vm {
                             let filtered: Vec<Value> = arr_borrow
                                 .iter()
                                 .filter(|v| {
-                                    let (l, r) = if param_left { ((*v).clone(), const_val.clone()) } else { (const_val.clone(), (*v).clone()) };
+                                    let (l, r) = if param_left {
+                                        ((*v).clone(), const_val.clone())
+                                    } else {
+                                        (const_val.clone(), (*v).clone())
+                                    };
                                     eval_binop(binop, &l, &r).unwrap_or(Value::Null).is_truthy()
                                 })
                                 .cloned()
@@ -2906,15 +3028,14 @@ impl Vm {
                     // on the cranelift / llvm backends that want to expose
                     // `cargo:…` Rust crates should register the module's
                     // exports map before calling `vm.run(chunk)`.
-                    let from_registry: Option<Value> = if spec.starts_with("cargo:")
-                        || spec.starts_with("ffi:")
-                    {
-                        let regs = self.native_modules.borrow();
-                        regs.get(spec)
-                            .and_then(|m| m.borrow().get(&Arc::from(export_name)).cloned())
-                    } else {
-                        None
-                    };
+                    let from_registry: Option<Value> =
+                        if spec.starts_with("cargo:") || spec.starts_with("ffi:") {
+                            let regs = self.native_modules.borrow();
+                            regs.get(spec)
+                                .and_then(|m| m.borrow().get(&Arc::from(export_name)).cloned())
+                        } else {
+                            None
+                        };
                     let v = from_registry
                         .or_else(|| get_builtin_export(self.capabilities.as_ref(), spec, export_name))
                         .ok_or_else(|| {
@@ -3097,7 +3218,12 @@ fn eval_unary(op: UnaryOp, o: &Value) -> Result<Value, String> {
 /// error), refilling the cache when the object *does* have the property. Result-equivalent to
 /// `get_member` — the cache only skips the lookup; the shape uniquely fixes the slot for a property.
 #[inline]
-fn ic_get_member(chunk: &Chunk, name_idx: u16, obj: &Value, key: &Arc<str>) -> Result<Value, String> {
+fn ic_get_member(
+    chunk: &Chunk,
+    name_idx: u16,
+    obj: &Value,
+    key: &Arc<str>,
+) -> Result<Value, String> {
     use std::sync::atomic::Ordering::Relaxed;
     if let Value::Object(od) = obj {
         let b = od.borrow();
@@ -3178,13 +3304,21 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
             let map = m.borrow();
             // Reading a missing own property returns `null` (tish's nullish value), matching
             // JS object semantics and the tree-walk interpreter — not a thrown error (#66).
-            Ok(map.strings.get(key.as_ref()).cloned().unwrap_or(Value::Null))
+            Ok(map
+                .strings
+                .get(key.as_ref())
+                .cloned()
+                .unwrap_or(Value::Null))
         }
         Value::NumberArray(a) => {
             let key_s = key.as_ref();
             // Numeric index fast path.
             if let Ok(idx) = key_s.parse::<usize>() {
-                return Ok(a.borrow().get(idx).map(|&n| Value::Number(n)).unwrap_or(Value::Null));
+                return Ok(a
+                    .borrow()
+                    .get(idx)
+                    .map(|&n| Value::Number(n))
+                    .unwrap_or(Value::Null));
             }
             if key_s == "length" {
                 return Ok(Value::Number(a.borrow().len() as f64));
@@ -3205,19 +3339,38 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                     Value::Number(arr.len() as f64)
                 }),
                 "pop" => make_native_fn(move |_: &[Value]| {
-                    a_clone.borrow_mut().pop()
-                        .map(|n| if n.is_nan() { Value::Null } else { Value::Number(n) })
+                    a_clone
+                        .borrow_mut()
+                        .pop()
+                        .map(|n| {
+                            if n.is_nan() {
+                                Value::Null
+                            } else {
+                                Value::Number(n)
+                            }
+                        })
                         .unwrap_or(Value::Null)
                 }),
                 "shift" => make_native_fn(move |_: &[Value]| {
                     let mut arr = a_clone.borrow_mut();
-                    if arr.is_empty() { Value::Null }
-                    else { let n = arr.remove(0); if n.is_nan() { Value::Null } else { Value::Number(n) } }
+                    if arr.is_empty() {
+                        Value::Null
+                    } else {
+                        let n = arr.remove(0);
+                        if n.is_nan() {
+                            Value::Null
+                        } else {
+                            Value::Number(n)
+                        }
+                    }
                 }),
                 "unshift" => make_native_fn(move |args: &[Value]| {
                     let mut arr = a_clone.borrow_mut();
                     for (i, v) in args.iter().enumerate() {
-                        let n = match v { Value::Number(n) => *n, _ => f64::NAN };
+                        let n = match v {
+                            Value::Number(n) => *n,
+                            _ => f64::NAN,
+                        };
                         arr.insert(i, n);
                     }
                     Value::Number(arr.len() as f64)
@@ -3230,7 +3383,10 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                     let a2 = a_clone.clone();
                     make_native_fn(move |args: &[Value]| {
                         // Check if there are non-numeric items to insert (args[2..]).
-                        let has_non_numeric = args.get(2..).unwrap_or(&[]).iter()
+                        let has_non_numeric = args
+                            .get(2..)
+                            .unwrap_or(&[])
+                            .iter()
                             .any(|v| !matches!(v, Value::Number(_)));
                         if has_non_numeric {
                             // Deopt: materialise, splice on the boxed array, then write numeric
@@ -3238,18 +3394,37 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                             // identity for subsequent accesses. The array may have non-numeric
                             // elements after this splice — they become NaN holes in the VmRef.
                             let boxed = Value::materialize_number_array(&a2);
-                            let result = arr_builtins::splice(&boxed, args.first().unwrap_or(&Value::Null), args.get(1), args.get(2..).unwrap_or(&[]));
+                            let result = arr_builtins::splice(
+                                &boxed,
+                                args.first().unwrap_or(&Value::Null),
+                                args.get(1),
+                                args.get(2..).unwrap_or(&[]),
+                            );
                             // Sync the modified boxed Vec back into the original VmRef.
                             if let Value::Array(boxed_vmref) = &boxed {
                                 let mut packed = a2.borrow_mut();
-                                *packed = boxed_vmref.borrow().iter().map(|v| match v { Value::Number(n) => *n, _ => f64::NAN }).collect();
+                                *packed = boxed_vmref
+                                    .borrow()
+                                    .iter()
+                                    .map(|v| match v {
+                                        Value::Number(n) => *n,
+                                        _ => f64::NAN,
+                                    })
+                                    .collect();
                             }
                             result
                         } else {
                             let mut arr = a2.borrow_mut();
                             let len = arr.len() as i64;
                             let start = match args.first() {
-                                Some(Value::Number(n)) => { let s = *n as i64; if s < 0 { (len + s).max(0) as usize } else { (s as usize).min(arr.len()) } }
+                                Some(Value::Number(n)) => {
+                                    let s = *n as i64;
+                                    if s < 0 {
+                                        (len + s).max(0) as usize
+                                    } else {
+                                        (s as usize).min(arr.len())
+                                    }
+                                }
                                 _ => 0,
                             };
                             let del = match args.get(1) {
@@ -3257,8 +3432,17 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                                 _ => arr.len().saturating_sub(start),
                             };
                             let del = del.min(arr.len().saturating_sub(start));
-                            let new_nums: Vec<f64> = args.get(2..).unwrap_or(&[]).iter().map(|v| match v { Value::Number(n) => *n, _ => f64::NAN }).collect();
-                            let removed: Vec<f64> = arr.splice(start..start + del, new_nums).collect();
+                            let new_nums: Vec<f64> = args
+                                .get(2..)
+                                .unwrap_or(&[])
+                                .iter()
+                                .map(|v| match v {
+                                    Value::Number(n) => *n,
+                                    _ => f64::NAN,
+                                })
+                                .collect();
+                            let removed: Vec<f64> =
+                                arr.splice(start..start + del, new_nums).collect();
                             Value::number_array(removed)
                         }
                     })
@@ -3281,29 +3465,93 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                     let boxed = Value::materialize_number_array(&a_clone);
                     let bv = boxed.clone();
                     match key_s {
-                        "map"       => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::map(&bv, &cb) }),
-                        "filter"    => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::filter(&bv, &cb) }),
-                        "reduce"    => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); let init = args.get(1).cloned().unwrap_or(Value::Null); arr_builtins::reduce(&bv, &cb, &init) }),
-                        "forEach"   => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::for_each(&bv, &cb) }),
-                        "find"      => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::find(&bv, &cb) }),
-                        "findIndex" => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::find_index(&bv, &cb) }),
-                        "findLast"      => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::find_last(&bv, &cb) }),
-                        "findLastIndex" => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::find_last_index(&bv, &cb) }),
-                        "at"        => make_native_fn(move |args| { let i = args.first().cloned().unwrap_or(Value::Null); arr_builtins::at(&bv, &i) }),
-                        "some"      => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::some(&bv, &cb) }),
-                        "every"     => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::every(&bv, &cb) }),
-                        "join"      => make_native_fn(move |args| { let sep = args.first().cloned().unwrap_or(Value::Null); arr_builtins::join(&bv, &sep) }),
-                        "flat"      => make_native_fn(move |args| { let d = args.first().cloned().unwrap_or(Value::Number(1.0)); arr_builtins::flat(&bv, &d) }),
-                        "flatMap"   => make_native_fn(move |args| { let cb = args.first().cloned().unwrap_or(Value::Null); arr_builtins::flat_map(&bv, &cb) }),
-                        "reverse"   => make_native_fn(move |_| arr_builtins::reverse(&bv)),
-                        "fill"      => make_native_fn(move |args| { let v = args.first().cloned().unwrap_or(Value::Null); let s = args.get(1).cloned().unwrap_or(Value::Null); let e = args.get(2).cloned().unwrap_or(Value::Null); arr_builtins::fill(&bv, &v, &s, &e) }),
-                        "slice"     => make_native_fn(move |args| { let s = args.first().cloned().unwrap_or(Value::Null); let e = args.get(1).cloned().unwrap_or(Value::Null); arr_builtins::slice(&bv, &s, &e) }),
-                        "concat"    => make_native_fn(move |args| arr_builtins::concat(&bv, args)),
-                        "indexOf"   => make_native_fn(move |args| { let s = args.first().cloned().unwrap_or(Value::Null); arr_builtins::index_of(&bv, &s) }),
-                        "includes"  => make_native_fn(move |args| { let s = args.first().cloned().unwrap_or(Value::Null); let f = args.get(1).cloned(); arr_builtins::includes(&bv, &s, f.as_ref()) }),
-                        "unshift"   => make_native_fn(move |args| arr_builtins::unshift(&bv, args)),
-                        "shift"     => make_native_fn(move |_| arr_builtins::shift(&bv)),
-                        "splice"    => make_native_fn(move |args| { let s = args.first().cloned().unwrap_or(Value::Null); let dc = args.get(1).cloned(); let items: Vec<Value> = args.get(2..).unwrap_or(&[]).to_vec(); arr_builtins::splice(&bv, &s, dc.as_ref(), &items) }),
+                        "map" => make_native_fn(move |args| {
+                            let cb = args.first().cloned().unwrap_or(Value::Null);
+                            arr_builtins::map(&bv, &cb)
+                        }),
+                        "filter" => make_native_fn(move |args| {
+                            let cb = args.first().cloned().unwrap_or(Value::Null);
+                            arr_builtins::filter(&bv, &cb)
+                        }),
+                        "reduce" => make_native_fn(move |args| {
+                            let cb = args.first().cloned().unwrap_or(Value::Null);
+                            let init = args.get(1).cloned().unwrap_or(Value::Null);
+                            arr_builtins::reduce(&bv, &cb, &init)
+                        }),
+                        "forEach" => make_native_fn(move |args| {
+                            let cb = args.first().cloned().unwrap_or(Value::Null);
+                            arr_builtins::for_each(&bv, &cb)
+                        }),
+                        "find" => make_native_fn(move |args| {
+                            let cb = args.first().cloned().unwrap_or(Value::Null);
+                            arr_builtins::find(&bv, &cb)
+                        }),
+                        "findIndex" => make_native_fn(move |args| {
+                            let cb = args.first().cloned().unwrap_or(Value::Null);
+                            arr_builtins::find_index(&bv, &cb)
+                        }),
+                        "findLast" => make_native_fn(move |args| {
+                            let cb = args.first().cloned().unwrap_or(Value::Null);
+                            arr_builtins::find_last(&bv, &cb)
+                        }),
+                        "findLastIndex" => make_native_fn(move |args| {
+                            let cb = args.first().cloned().unwrap_or(Value::Null);
+                            arr_builtins::find_last_index(&bv, &cb)
+                        }),
+                        "at" => make_native_fn(move |args| {
+                            let i = args.first().cloned().unwrap_or(Value::Null);
+                            arr_builtins::at(&bv, &i)
+                        }),
+                        "some" => make_native_fn(move |args| {
+                            let cb = args.first().cloned().unwrap_or(Value::Null);
+                            arr_builtins::some(&bv, &cb)
+                        }),
+                        "every" => make_native_fn(move |args| {
+                            let cb = args.first().cloned().unwrap_or(Value::Null);
+                            arr_builtins::every(&bv, &cb)
+                        }),
+                        "join" => make_native_fn(move |args| {
+                            let sep = args.first().cloned().unwrap_or(Value::Null);
+                            arr_builtins::join(&bv, &sep)
+                        }),
+                        "flat" => make_native_fn(move |args| {
+                            let d = args.first().cloned().unwrap_or(Value::Number(1.0));
+                            arr_builtins::flat(&bv, &d)
+                        }),
+                        "flatMap" => make_native_fn(move |args| {
+                            let cb = args.first().cloned().unwrap_or(Value::Null);
+                            arr_builtins::flat_map(&bv, &cb)
+                        }),
+                        "reverse" => make_native_fn(move |_| arr_builtins::reverse(&bv)),
+                        "fill" => make_native_fn(move |args| {
+                            let v = args.first().cloned().unwrap_or(Value::Null);
+                            let s = args.get(1).cloned().unwrap_or(Value::Null);
+                            let e = args.get(2).cloned().unwrap_or(Value::Null);
+                            arr_builtins::fill(&bv, &v, &s, &e)
+                        }),
+                        "slice" => make_native_fn(move |args| {
+                            let s = args.first().cloned().unwrap_or(Value::Null);
+                            let e = args.get(1).cloned().unwrap_or(Value::Null);
+                            arr_builtins::slice(&bv, &s, &e)
+                        }),
+                        "concat" => make_native_fn(move |args| arr_builtins::concat(&bv, args)),
+                        "indexOf" => make_native_fn(move |args| {
+                            let s = args.first().cloned().unwrap_or(Value::Null);
+                            arr_builtins::index_of(&bv, &s)
+                        }),
+                        "includes" => make_native_fn(move |args| {
+                            let s = args.first().cloned().unwrap_or(Value::Null);
+                            let f = args.get(1).cloned();
+                            arr_builtins::includes(&bv, &s, f.as_ref())
+                        }),
+                        "unshift" => make_native_fn(move |args| arr_builtins::unshift(&bv, args)),
+                        "shift" => make_native_fn(move |_| arr_builtins::shift(&bv)),
+                        "splice" => make_native_fn(move |args| {
+                            let s = args.first().cloned().unwrap_or(Value::Null);
+                            let dc = args.get(1).cloned();
+                            let items: Vec<Value> = args.get(2..).unwrap_or(&[]).to_vec();
+                            arr_builtins::splice(&bv, &s, dc.as_ref(), &items)
+                        }),
                         _ => return Err(format!("Property '{}' not found", key)),
                     }
                 }
@@ -3469,11 +3717,7 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                 "lastIndexOf" => make_native_fn(move |args: &[Value]| {
                     let search = args.first().unwrap_or(&Value::Null);
                     let position = args.get(1).cloned().unwrap_or(Value::Number(f64::INFINITY));
-                    str_builtins::last_index_of(
-                        &Value::String(s_clone.clone()),
-                        search,
-                        &position,
-                    )
+                    str_builtins::last_index_of(&Value::String(s_clone.clone()), search, &position)
                 }),
                 "includes" => make_native_fn(move |args: &[Value]| {
                     let search = args.first().unwrap_or(&Value::Null);
@@ -3546,11 +3790,7 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                 "replaceAll" => make_native_fn(move |args: &[Value]| {
                     let search = args.first().unwrap_or(&Value::Null);
                     let replacement = args.get(1).unwrap_or(&Value::Null);
-                    str_builtins::replace_all(
-                        &Value::String(s_clone.clone()),
-                        search,
-                        replacement,
-                    )
+                    str_builtins::replace_all(&Value::String(s_clone.clone()), search, replacement)
                 }),
                 #[cfg(feature = "regex")]
                 "match" => make_native_fn(move |args: &[Value]| {
@@ -3715,10 +3955,24 @@ fn get_index(obj: &Value, idx: &Value) -> Result<Value, String> {
         Value::NumberArray(a) => {
             let i = match idx {
                 Value::Number(n) => *n as usize,
-                _ => return Err(format!("Array index must be number, got {}", idx.type_name())),
+                _ => {
+                    return Err(format!(
+                        "Array index must be number, got {}",
+                        idx.type_name()
+                    ))
+                }
             };
             // NaN is used as the hole marker (sparse-array positions); reads return Null.
-            Ok(a.borrow().get(i).map(|&n| if n.is_nan() { Value::Null } else { Value::Number(n) }).unwrap_or(Value::Null))
+            Ok(a.borrow()
+                .get(i)
+                .map(|&n| {
+                    if n.is_nan() {
+                        Value::Null
+                    } else {
+                        Value::Number(n)
+                    }
+                })
+                .unwrap_or(Value::Null))
         }
         Value::Array(a) => {
             let i = match idx {
@@ -3730,11 +3984,7 @@ fn get_index(obj: &Value, idx: &Value) -> Result<Value, String> {
                     ));
                 }
             };
-            Ok(a
-                .borrow()
-                .get(i)
-                .cloned()
-                .unwrap_or(Value::Null))
+            Ok(a.borrow().get(i).cloned().unwrap_or(Value::Null))
         }
         Value::String(s) => {
             let i = match idx {
@@ -3777,7 +4027,7 @@ fn get_index(obj: &Value, idx: &Value) -> Result<Value, String> {
                 }
             };
             get_member(obj, &key_arc)
-        },
+        }
         _ => Err(format!(
             "Cannot read property '{}' of {}",
             idx.to_display_string(),
@@ -3819,7 +4069,12 @@ fn set_index(obj: &Value, idx: &Value, val: Value) -> Result<(), String> {
         Value::NumberArray(a) => {
             let i = match idx {
                 Value::Number(n) => *n as usize,
-                _ => return Err(format!("Array index must be number, got {}", idx.type_name())),
+                _ => {
+                    return Err(format!(
+                        "Array index must be number, got {}",
+                        idx.type_name()
+                    ))
+                }
             };
             // In-bounds numeric assignment stays packed.
             // Out-of-bounds or non-numeric falls through to the Array path by returning
@@ -3830,7 +4085,9 @@ fn set_index(obj: &Value, idx: &Value, val: Value) -> Result<(), String> {
                 Value::Number(n) => {
                     let mut arr = a.borrow_mut();
                     // Extend with NaN "holes" if needed (NaN = sparse hole; read back as Null).
-                    while arr.len() <= i { arr.push(f64::NAN); }
+                    while arr.len() <= i {
+                        arr.push(f64::NAN);
+                    }
                     arr[i] = n;
                 }
                 // Non-numeric set: the Vec<f64> can't represent this type. Extend with NaN holes
@@ -3840,7 +4097,9 @@ fn set_index(obj: &Value, idx: &Value, val: Value) -> Result<(), String> {
                 // numeric elements and Null for the NaN holes.
                 _ => {
                     let mut arr = a.borrow_mut();
-                    while arr.len() <= i { arr.push(f64::NAN); }
+                    while arr.len() <= i {
+                        arr.push(f64::NAN);
+                    }
                     // arr[i] is already NaN (hole); we can't store the non-numeric value — acceptable
                     // for the experimental TISH_PACKED_ARRAYS path.
                 }
@@ -3903,7 +4162,10 @@ mod recursion_limit_tests_381 {
                    ok";
         let out = run_src(src);
         set_max_call_depth_for_test(DEFAULT_MAX_CALL_DEPTH);
-        assert!(out.is_ok(), "deep recursion must be catchable, not abort/error: {out:?}");
+        assert!(
+            out.is_ok(),
+            "deep recursion must be catchable, not abort/error: {out:?}"
+        );
     }
 
     #[test]
@@ -3912,15 +4174,23 @@ mod recursion_limit_tests_381 {
         set_max_call_depth_for_test(300);
         let out = run_src("fn rec(n) { return { v: rec(n + 1) } }\nrec(0)");
         set_max_call_depth_for_test(DEFAULT_MAX_CALL_DEPTH);
-        assert!(out.is_err(), "uncaught deep recursion must return an error, got {out:?}");
+        assert!(
+            out.is_err(),
+            "uncaught deep recursion must return an error, got {out:?}"
+        );
     }
 
     #[test]
     fn normal_recursion_is_unaffected() {
         set_max_call_depth_for_test(20_000);
-        let out = run_src("fn fib(n) { if (n < 2) { return n } return fib(n - 1) + fib(n - 2) }\nfib(15)");
+        let out = run_src(
+            "fn fib(n) { if (n < 2) { return n } return fib(n - 1) + fib(n - 2) }\nfib(15)",
+        );
         set_max_call_depth_for_test(DEFAULT_MAX_CALL_DEPTH);
-        assert!(out.is_ok(), "normal recursion must not be affected: {out:?}");
+        assert!(
+            out.is_ok(),
+            "normal recursion must not be affected: {out:?}"
+        );
     }
 
     // The core of #381 for the JIT tier: a pure-numeric self-recursive function JIT-compiles and
@@ -3949,6 +4219,9 @@ mod recursion_limit_tests_381 {
         let surfaced = handle
             .join()
             .expect("thread must not abort — the guard must catch the overflow");
-        assert!(surfaced, "uncaught JIT deep recursion must surface as a RangeError, not abort");
+        assert!(
+            surfaced,
+            "uncaught JIT deep recursion must surface as a RangeError, not abort"
+        );
     }
 }


### PR DESCRIPTION
## What

Compiles functions whose local arrays **never escape** — defined `let a = []`, used only via `push` / `a[i]` / `a[i] = v` / `.length` — to native cranelift code, instead of bailing to the interpreter the moment the JIT sees a `NewArray` opcode.

This is the array-JIT track from the #203 Beat-Node roadmap (parts 1 & 2a are prior commits on this branch: the `tish_jv_*` runtime + symbol registration, and the JV-slot classifier scaffold).

## How

- **`classify_jv_slots`** — a slot is JV **iff** its only definition is an empty `[]` stored straight into it and it is never re-stored otherwise. Anything ambiguous bails the whole function → interpret. A classifier miss is therefore never a miscompile, just no speedup.
- **Runtime (no `unsafe`)** — a JV array is a `u64` **handle** into a per-thread `Vec<Vec<f64>>` arena (handle `0` = null), not a raw pointer, so the `tish_jv_*` host fns need no `unsafe`. `NewArray` / `push` / `GetIndex` / `SetIndex` / `.length` lower to those calls. JV slots become `i64` handle `Variable`s.
- **Deopt** — an out-of-bounds index (or a non-numeric return) sets a **per-thread deopt flag**; `VmClosure::call` clears it, runs, and on finding it set discards the numeric result and **re-interprets**. Sound because JV arrays never escape — the discarded native run mutated nothing observable. Every exit frees its live handles back to a free list, so the arena is bounded by a function's peak live-array count, not total allocations.
- **`while (true)` epilogue** — a `while (true)` loop whose only exit is `return` still emits a trailing implicit `LoadConst Null; Return` (the never-taken exit edge, statically reachable so cranelift needs the block filled). In JV mode that non-numeric const frees the arrays and routes to a deopt instead of bailing the whole function — dead when the loop is truly infinite, a correct re-interpret if ever reached.

## Result

`nsieve` (GAUNTLET) flips from the interpreter to native:

| | full fixture (8×1M) |
|---|---|
| interp (before) | ~37 s |
| **JV JIT (release)** | **~148 ms** |
| node | 55–66 ms |

~250× over the interpreter, within ~2.5× of node (correctness `JIT == interp == node`, count 627984). New JV unit tests + cross-backend integration **25/25**. **Zero `unsafe`** (the runtime is a safe arena; clippy clean).

## Scope

Gated by `TISH_JIT_JV` (default on). Additive: every unsupported shape bails to the interpreter. Non-JV functions are byte-identical (the new codegen + epilogue-deopt paths are all `jv.is_some()`-gated).

The real `fannkuch` fixture does **not** flip yet — it uses a boolean local (`let done = false`), which needs boolean-slot support (**#187**). Deliberately out of scope here (semantically delicate; its own differential-tested change). The full fannkuch array shape *is* covered — verified on a skeleton at `22800016`.