### PR TITLE
fix(interp): throw TypeError on null member/index access (interp≡vm parity)

### DIFF
--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -4057,6 +4057,11 @@ impl Evaluator {
                     _ => Ok(Value::Null),
                 }
             }
+            // Reading a property of the nullish value throws a catchable `TypeError`, matching the
+            // bytecode VM (`get_member`'s `_` arm), cranelift/wasi, and node — not a silent `null`.
+            // The tree-walker used to fall through to `_ => Ok(Value::Null)`, so `null.length` read
+            // back as `null` on interp while every other backend threw (a pure interp≠vm bug).
+            Value::Null => Err(format!("Cannot read property '{}' of null", key)),
             _ => Ok(Value::Null),
         }
     }
@@ -4091,6 +4096,9 @@ impl Evaluator {
                 };
                 self.get_prop(obj, key)
             }
+            // Indexing the nullish value throws a catchable `TypeError` (like `get_prop` above and
+            // the VM/cranelift/wasi/node) rather than silently reading back `null`.
+            Value::Null => Err(format!("Cannot read property '{}' of null", index)),
             _ => Ok(Value::Null),
         }
     }
@@ -4696,5 +4704,51 @@ mod recursion_limit_tests_381 {
     fn normal_recursion_is_unaffected() {
         let src = "fn fib(n) { if (n < 2) { return n } return fib(n - 1) + fib(n - 2) }\nfib(12)";
         assert_eq!(run_with_depth(src, 20000), "144");
+    }
+}
+
+#[cfg(test)]
+mod null_member_access_tests {
+    // Reading a property or index of the nullish value throws a catchable `TypeError`, matching the
+    // bytecode VM / cranelift / wasi / node. The tree-walker used to fall through to `Ok(Null)`, so
+    // `null.length` read back as `null` on interp while every other backend threw (a pure interp≠vm
+    // divergence). These lock the interpreter to the throwing behavior.
+    use super::Evaluator;
+    use tishlang_parser::parse;
+
+    fn run(src: &str) -> String {
+        let program = parse(src).unwrap();
+        let mut eval = Evaluator::new();
+        eval.eval_program(&program).unwrap().to_string()
+    }
+
+    #[test]
+    fn null_property_read_throws_type_error() {
+        let src = "let name = 'none'\n\
+                   try { let z = null; z.length } catch (e) { name = e.name }\n\
+                   name";
+        assert_eq!(run(src), "TypeError");
+    }
+
+    #[test]
+    fn null_index_read_throws_type_error() {
+        let src = "let name = 'none'\n\
+                   try { let z = null; z[0] } catch (e) { name = e.name }\n\
+                   name";
+        assert_eq!(run(src), "TypeError");
+    }
+
+    #[test]
+    fn object_missing_property_still_reads_null() {
+        // Guard against over-reach: a MISSING property of a real object is `null`, not a throw.
+        let src = "let o = { a: 1 }\nString(o.b === null)";
+        assert_eq!(run(src), "true");
+    }
+
+    #[test]
+    fn array_oob_index_still_reads_null() {
+        // Out-of-bounds array index stays nullish (only a null/undefined *receiver* throws).
+        let src = "let a = [1, 2, 3]\nString(a[9] === null)";
+        assert_eq!(run(src), "true");
     }
 }


### PR DESCRIPTION
## What

The tree-walking interpreter's `get_prop`/`get_index` fell through to `Ok(Value::Null)` for a **null receiver**, so `null.length` and `null[0]` read back as `null` on interp — while the bytecode VM, cranelift, wasi, and node all throw a catchable `TypeError`. A pure interp≠vm divergence (the internal parity invariant the cross-backend harness gates on).

Repro (before):
```
let z = null
console.log(z.length)   // interp: null   |   vm/cranelift/wasi/node: TypeError
```

## Fix

Align interp to the majority + JS: a property or index read on the nullish value returns `Err("Cannot read property '…' of null")`, which the interpreter's `try`/`catch` path already boxes as a catchable `{ name: "TypeError", message }` (eval.rs). Method calls on null (`null.foo()`) already threw — this closes the read paths.

Scope is exactly the null receiver — a **missing** property of a real object and an **out-of-bounds** array index still read back nullish (locked by tests).

## Tests

Added `null_member_access_tests` in `tish_eval`:
- `null.length` → `TypeError` ✓
- `null[0]` → `TypeError` ✓
- missing object property → `null` (no over-reach) ✓
- OOB array index → `null` (no over-reach) ✓

Full `test_mvp_programs_interpreter` integration suite green — no existing fixture relied on null-receiver access returning null.

## Not in this PR (tracked separately)

The **native (rust AOT)** backend has the same divergence — `null.length`/`null[0]` return `null`, and `null.foo()` **panics uncatchably** (`value.rs:1078`). Making native throw correctly is a hot-path change (fallible `get_prop`/`get_index`/`value_call`, or a pending-throw poll after each access) that also turns the panic into a catchable error — squarely the #381 "abort → catchable" umbrella. That lands as its own PR, together with the all-six-backend `tests/core` fixture (which can't pass until native throws too).

Relates to #247.
