### PR TITLE
fix(array): pass source array as trailing HOF callback arg (JS parity)

### DIFF
--- a/crates/tish_builtins/src/array.rs
+++ b/crates/tish_builtins/src/array.rs
@@ -345,17 +345,20 @@ pub fn map(arr: &Value, callback: &Value) -> Value {
     // boxed array on the FIRST non-numeric callback result; every element's callback still runs
     // exactly once, in index order (the deopt resumes at `i + 1`).
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
+        // JS passes `(element, index, array)`; `arr_value` is the receiver, cloned per call (a cheap
+        // VmRef refcount bump). A callback that ignores the 3rd param is unaffected.
+        let arr_value = arr.clone();
         let mut nums: Vec<f64> = Vec::with_capacity(data.len());
         for (i, &n) in data.iter().enumerate() {
             if tishlang_core::has_pending_throw() { return packed_or_empty(nums); } // #303
-            match cb.call(&[Value::Number(n), Value::Number(i as f64)]) {
+            match cb.call(&[Value::Number(n), Value::Number(i as f64), arr_value.clone()]) {
                 Value::Number(r) => nums.push(r),
                 other => {
                     let mut boxed: Vec<Value> = nums.into_iter().map(Value::Number).collect();
                     boxed.push(other);
                     for (j, &m) in data.iter().enumerate().skip(i + 1) {
                         if tishlang_core::has_pending_throw() { break; } // #303
-                        boxed.push(cb.call(&[Value::Number(m), Value::Number(j as f64)]));
+                        boxed.push(cb.call(&[Value::Number(m), Value::Number(j as f64), arr_value.clone()]));
                     }
                     return Value::Array(VmRef::new(boxed));
                 }
@@ -369,11 +372,12 @@ pub fn map(arr: &Value, callback: &Value) -> Value {
         // callback that re-enters this same array (`arr.map(x => arr.length)`) would otherwise
         // deadlock (Mutex, send-values) or panic (RefCell). Matches the packed path's copy semantics.
         let arr_borrow = arr.borrow().clone();
+        let arr_value = Value::Array(arr.clone()); // 3rd callback arg (JS `array`)
         // #303: stop on a pending throw from the callback (don't map the rest of the array).
         let mut result: Vec<Value> = Vec::with_capacity(arr_borrow.len());
         for (i, v) in arr_borrow.iter().enumerate() {
             if tishlang_core::has_pending_throw() { break; }
-            result.push(cb.call(&[v.clone(), Value::Number(i as f64)]));
+            result.push(cb.call(&[v.clone(), Value::Number(i as f64), arr_value.clone()]));
         }
         Value::Array(VmRef::new(result))
     } else {
@@ -385,10 +389,11 @@ pub fn filter(arr: &Value, callback: &Value) -> Value {
     // Packed fast path: `filter` keeps a SUBSET of the input f64s, so the result is always numeric —
     // build the packed `Vec<f64>` directly, no boxed intermediate, and hand back a `NumberArray`.
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
+        let arr_value = arr.clone(); // 3rd callback arg (JS `array`)
         let mut out: Vec<f64> = Vec::new();
         for (i, &n) in data.iter().enumerate() {
             if tishlang_core::has_pending_throw() { break; } // #303
-            if cb.call(&[Value::Number(n), Value::Number(i as f64)]).is_truthy() {
+            if cb.call(&[Value::Number(n), Value::Number(i as f64), arr_value.clone()]).is_truthy() {
                 out.push(n);
             }
         }
@@ -397,11 +402,12 @@ pub fn filter(arr: &Value, callback: &Value) -> Value {
     let arr = as_boxed_array(arr); let arr = &*arr;
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow().clone(); // #382: snapshot; drop the guard before any callback
+        let arr_value = Value::Array(arr.clone()); // 3rd callback arg (JS `array`)
         // #303: stop on a pending throw from the predicate (don't test the rest of the array).
         let mut result: Vec<Value> = Vec::new();
         for (i, v) in arr_borrow.iter().enumerate() {
             if tishlang_core::has_pending_throw() { break; }
-            if cb.call(&[v.clone(), Value::Number(i as f64)]).is_truthy() {
+            if cb.call(&[v.clone(), Value::Number(i as f64), arr_value.clone()]).is_truthy() {
                 result.push(v.clone());
             }
         }
@@ -415,6 +421,8 @@ pub fn reduce(arr: &Value, callback: &Value, initial: &Value) -> Value {
     // Packed fast path: fold the `Vec<f64>` snapshot directly. Same no-initial rule as the boxed
     // path (absent init → first element as the seed, scan from index 1).
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
+        // `reduce` passes `(accumulator, element, index, array)` — the array is the 4th arg.
+        let arr_value = arr.clone();
         let (start_idx, mut acc) = if matches!(initial, Value::Null) && !data.is_empty() {
             (1usize, Value::Number(data[0]))
         } else {
@@ -423,13 +431,14 @@ pub fn reduce(arr: &Value, callback: &Value, initial: &Value) -> Value {
         // `skip(start_idx)` preserves the true element index for the callback's 3rd arg.
         for (i, &x) in data.iter().enumerate().skip(start_idx) {
             if tishlang_core::has_pending_throw() { return acc; } // #303
-            acc = cb.call(&[acc, Value::Number(x), Value::Number(i as f64)]);
+            acc = cb.call(&[acc, Value::Number(x), Value::Number(i as f64), arr_value.clone()]);
         }
         return acc;
     }
     let arr = as_boxed_array(arr); let arr = &*arr;
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow().clone(); // #382: snapshot; drop the guard before any callback
+        let arr_value = Value::Array(arr.clone()); // 4th callback arg (JS `array`)
         let len = arr_borrow.len();
         let (start_idx, mut acc) = if matches!(initial, Value::Null) && !arr_borrow.is_empty() {
             // No initial value: use first element as acc, start from index 1
@@ -440,7 +449,7 @@ pub fn reduce(arr: &Value, callback: &Value, initial: &Value) -> Value {
         for i in start_idx..len {
             if tishlang_core::has_pending_throw() { return acc; } // #303
             let v = arr_borrow[i].clone();
-            acc = cb.call(&[acc, v.clone(), Value::Number(i as f64)]);
+            acc = cb.call(&[acc, v.clone(), Value::Number(i as f64), arr_value.clone()]);
         }
         acc
     } else {
@@ -450,18 +459,20 @@ pub fn reduce(arr: &Value, callback: &Value, initial: &Value) -> Value {
 
 pub fn for_each(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
+        let arr_value = arr.clone(); // 3rd callback arg (JS `array`)
         for (i, &n) in data.iter().enumerate() {
             if tishlang_core::has_pending_throw() { return Value::Null; } // #303
-            cb.call(&[Value::Number(n), Value::Number(i as f64)]);
+            cb.call(&[Value::Number(n), Value::Number(i as f64), arr_value.clone()]);
         }
         return Value::Null;
     }
     let arr = as_boxed_array(arr); let arr = &*arr;
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow().clone(); // #382: snapshot; drop the guard before any callback
+        let arr_value = Value::Array(arr.clone()); // 3rd callback arg (JS `array`)
         for (i, v) in arr_borrow.iter().enumerate() {
             if tishlang_core::has_pending_throw() { break; } // #303
-            cb.call(&[v.clone(), Value::Number(i as f64)]);
+            cb.call(&[v.clone(), Value::Number(i as f64), arr_value.clone()]);
         }
     }
     Value::Null
@@ -469,9 +480,10 @@ pub fn for_each(arr: &Value, callback: &Value) -> Value {
 
 pub fn find(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
+        let arr_value = arr.clone(); // 3rd callback arg (JS `array`)
         for (i, &n) in data.iter().enumerate() {
             if tishlang_core::has_pending_throw() { break; } // #303
-            if cb.call(&[Value::Number(n), Value::Number(i as f64)]).is_truthy() {
+            if cb.call(&[Value::Number(n), Value::Number(i as f64), arr_value.clone()]).is_truthy() {
                 return Value::Number(n);
             }
         }
@@ -480,9 +492,10 @@ pub fn find(arr: &Value, callback: &Value) -> Value {
     let arr = as_boxed_array(arr); let arr = &*arr;
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow().clone(); // #382: snapshot; drop the guard before any callback
+        let arr_value = Value::Array(arr.clone()); // 3rd callback arg (JS `array`)
         for (i, v) in arr_borrow.iter().enumerate() {
             if tishlang_core::has_pending_throw() { break; } // #303
-            let result = cb.call(&[v.clone(), Value::Number(i as f64)]);
+            let result = cb.call(&[v.clone(), Value::Number(i as f64), arr_value.clone()]);
             if result.is_truthy() {
                 return v.clone();
             }
@@ -493,9 +506,10 @@ pub fn find(arr: &Value, callback: &Value) -> Value {
 
 pub fn find_index(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
+        let arr_value = arr.clone(); // 3rd callback arg (JS `array`)
         for (i, &n) in data.iter().enumerate() {
             if tishlang_core::has_pending_throw() { break; } // #303
-            if cb.call(&[Value::Number(n), Value::Number(i as f64)]).is_truthy() {
+            if cb.call(&[Value::Number(n), Value::Number(i as f64), arr_value.clone()]).is_truthy() {
                 return Value::Number(i as f64);
             }
         }
@@ -504,9 +518,10 @@ pub fn find_index(arr: &Value, callback: &Value) -> Value {
     let arr = as_boxed_array(arr); let arr = &*arr;
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow().clone(); // #382: snapshot; drop the guard before any callback
+        let arr_value = Value::Array(arr.clone()); // 3rd callback arg (JS `array`)
         for (i, v) in arr_borrow.iter().enumerate() {
             if tishlang_core::has_pending_throw() { break; } // #303
-            let result = cb.call(&[v.clone(), Value::Number(i as f64)]);
+            let result = cb.call(&[v.clone(), Value::Number(i as f64), arr_value.clone()]);
             if result.is_truthy() {
                 return Value::Number(i as f64);
             }
@@ -519,10 +534,11 @@ pub fn find_index(arr: &Value, callback: &Value) -> Value {
 /// the original index. Returns `null` (JS `undefined`) when nothing matches. #247
 pub fn find_last(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
+        let arr_value = arr.clone(); // 3rd callback arg (JS `array`)
         for i in (0..data.len()).rev() {
             if tishlang_core::has_pending_throw() { break; } // #303
             if cb
-                .call(&[Value::Number(data[i]), Value::Number(i as f64)])
+                .call(&[Value::Number(data[i]), Value::Number(i as f64), arr_value.clone()])
                 .is_truthy()
             {
                 return Value::Number(data[i]);
@@ -534,10 +550,11 @@ pub fn find_last(arr: &Value, callback: &Value) -> Value {
     let arr = &*arr;
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow().clone(); // #382: snapshot; drop the guard before any callback
+        let arr_value = Value::Array(arr.clone()); // 3rd callback arg (JS `array`)
         for i in (0..arr_borrow.len()).rev() {
             if tishlang_core::has_pending_throw() { break; } // #303
             let v = &arr_borrow[i];
-            if cb.call(&[v.clone(), Value::Number(i as f64)]).is_truthy() {
+            if cb.call(&[v.clone(), Value::Number(i as f64), arr_value.clone()]).is_truthy() {
                 return v.clone();
             }
         }
@@ -548,10 +565,11 @@ pub fn find_last(arr: &Value, callback: &Value) -> Value {
 /// `Array.prototype.findLastIndex` — like [`find_index`] but from the end; `-1` if no match. #247
 pub fn find_last_index(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
+        let arr_value = arr.clone(); // 3rd callback arg (JS `array`)
         for i in (0..data.len()).rev() {
             if tishlang_core::has_pending_throw() { break; } // #303
             if cb
-                .call(&[Value::Number(data[i]), Value::Number(i as f64)])
+                .call(&[Value::Number(data[i]), Value::Number(i as f64), arr_value.clone()])
                 .is_truthy()
             {
                 return Value::Number(i as f64);
@@ -563,10 +581,11 @@ pub fn find_last_index(arr: &Value, callback: &Value) -> Value {
     let arr = &*arr;
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow().clone(); // #382: snapshot; drop the guard before any callback
+        let arr_value = Value::Array(arr.clone()); // 3rd callback arg (JS `array`)
         for i in (0..arr_borrow.len()).rev() {
             if tishlang_core::has_pending_throw() { break; } // #303
             if cb
-                .call(&[arr_borrow[i].clone(), Value::Number(i as f64)])
+                .call(&[arr_borrow[i].clone(), Value::Number(i as f64), arr_value.clone()])
                 .is_truthy()
             {
                 return Value::Number(i as f64);
@@ -598,9 +617,10 @@ pub fn at(arr: &Value, index: &Value) -> Value {
 
 pub fn some(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
+        let arr_value = arr.clone(); // 3rd callback arg (JS `array`)
         for (i, &n) in data.iter().enumerate() {
             if tishlang_core::has_pending_throw() { break; } // #303
-            if cb.call(&[Value::Number(n), Value::Number(i as f64)]).is_truthy() {
+            if cb.call(&[Value::Number(n), Value::Number(i as f64), arr_value.clone()]).is_truthy() {
                 return Value::Bool(true);
             }
         }
@@ -609,9 +629,10 @@ pub fn some(arr: &Value, callback: &Value) -> Value {
     let arr = as_boxed_array(arr); let arr = &*arr;
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow().clone(); // #382: snapshot; drop the guard before any callback
+        let arr_value = Value::Array(arr.clone()); // 3rd callback arg (JS `array`)
         for (i, v) in arr_borrow.iter().enumerate() {
             if tishlang_core::has_pending_throw() { break; } // #303
-            let result = cb.call(&[v.clone(), Value::Number(i as f64)]);
+            let result = cb.call(&[v.clone(), Value::Number(i as f64), arr_value.clone()]);
             if result.is_truthy() {
                 return Value::Bool(true);
             }
@@ -622,9 +643,10 @@ pub fn some(arr: &Value, callback: &Value) -> Value {
 
 pub fn every(arr: &Value, callback: &Value) -> Value {
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
+        let arr_value = arr.clone(); // 3rd callback arg (JS `array`)
         for (i, &n) in data.iter().enumerate() {
             if tishlang_core::has_pending_throw() { break; } // #303
-            if !cb.call(&[Value::Number(n), Value::Number(i as f64)]).is_truthy() {
+            if !cb.call(&[Value::Number(n), Value::Number(i as f64), arr_value.clone()]).is_truthy() {
                 return Value::Bool(false);
             }
         }
@@ -633,9 +655,10 @@ pub fn every(arr: &Value, callback: &Value) -> Value {
     let arr = as_boxed_array(arr); let arr = &*arr;
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow().clone(); // #382: snapshot; drop the guard before any callback
+        let arr_value = Value::Array(arr.clone()); // 3rd callback arg (JS `array`)
         for (i, v) in arr_borrow.iter().enumerate() {
             if tishlang_core::has_pending_throw() { break; } // #303
-            let result = cb.call(&[v.clone(), Value::Number(i as f64)]);
+            let result = cb.call(&[v.clone(), Value::Number(i as f64), arr_value.clone()]);
             if !result.is_truthy() {
                 return Value::Bool(false);
             }
@@ -650,10 +673,11 @@ pub fn flat_map(arr: &Value, callback: &Value) -> Value {
     let arr = as_boxed_array(arr); let arr = &*arr;
     if let (Value::Array(arr), Value::Function(cb)) = (arr, callback) {
         let arr_borrow = arr.borrow().clone(); // #382: snapshot; drop the guard before any callback
+        let arr_value = Value::Array(arr.clone()); // 3rd callback arg (JS `array`)
         let mut result: Vec<Value> = Vec::new();
         for (i, v) in arr_borrow.iter().enumerate() {
             if tishlang_core::has_pending_throw() { break; } // #303
-            let mapped = cb.call(&[v.clone(), Value::Number(i as f64)]);
+            let mapped = cb.call(&[v.clone(), Value::Number(i as f64), arr_value.clone()]);
             if let Value::Array(inner) = mapped {
                 result.extend(inner.borrow().iter().cloned());
             } else {

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -1796,7 +1796,11 @@ impl Evaluator {
                             }
                             "map" => {
                                 let callback = arg_vals.first().cloned().unwrap_or(Value::Null);
-                                let arr_borrow = arr.borrow();
+                                // #382-style snapshot: own the elements and DROP the array borrow before
+                                // any callback runs, so a callback that mutates the array (via the `array`
+                                // arg or a capture) can't RefCell-panic. `arr_value` is the JS 3rd arg.
+                                let arr_borrow = arr.borrow().clone();
+                                let arr_value = Value::Array(arr.clone());
                                 let mut result = Vec::with_capacity(arr_borrow.len());
                                 // Try fastest path: simple single-expression callbacks
                                 let first_result = self.eval_simple_callback(&callback, &[arr_borrow.first().cloned().unwrap_or(Value::Null)]);
@@ -1813,13 +1817,13 @@ impl Evaluator {
                                 } else if let Some((scope, params, body)) = self.create_callback_scope(&callback) {
                                     // Reusable scope path
                                     for (i, v) in arr_borrow.iter().enumerate() {
-                                        let mapped = self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64)])?;
+                                        let mapped = self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                         result.push(mapped);
                                     }
                                 } else {
                                     // Full call_func path
                                     for (i, v) in arr_borrow.iter().enumerate() {
-                                        let mapped = self.call_func(&callback, &[v.clone(), Value::Number(i as f64)])?;
+                                        let mapped = self.call_func(&callback, &[v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                         result.push(mapped);
                                     }
                                 }
@@ -1830,11 +1834,12 @@ impl Evaluator {
                                 // propagates via `?` (catchable), matching vm/native/node — previously
                                 // interp lacked flatMap entirely ("Not a function").
                                 let callback = arg_vals.first().cloned().unwrap_or(Value::Null);
-                                let arr_borrow = arr.borrow();
+                                let arr_borrow = arr.borrow().clone(); // snapshot; drop borrow before callbacks
+                                let arr_value = Value::Array(arr.clone()); // JS 3rd callback arg
                                 let mut result: Vec<Value> = Vec::with_capacity(arr_borrow.len());
                                 if let Some((scope, params, body)) = self.create_callback_scope(&callback) {
                                     for (i, v) in arr_borrow.iter().enumerate() {
-                                        let mapped = self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64)])?;
+                                        let mapped = self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                         match mapped {
                                             Value::Array(inner) => result.extend(inner.borrow().iter().cloned()),
                                             other => result.push(other),
@@ -1842,7 +1847,7 @@ impl Evaluator {
                                     }
                                 } else {
                                     for (i, v) in arr_borrow.iter().enumerate() {
-                                        let mapped = self.call_func(&callback, &[v.clone(), Value::Number(i as f64)])?;
+                                        let mapped = self.call_func(&callback, &[v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                         match mapped {
                                             Value::Array(inner) => result.extend(inner.borrow().iter().cloned()),
                                             other => result.push(other),
@@ -1853,7 +1858,8 @@ impl Evaluator {
                             }
                             "filter" => {
                                 let callback = arg_vals.first().cloned().unwrap_or(Value::Null);
-                                let arr_borrow = arr.borrow();
+                                let arr_borrow = arr.borrow().clone(); // snapshot; drop borrow before callbacks
+                                let arr_value = Value::Array(arr.clone()); // JS 3rd callback arg
                                 let mut result = Vec::new();
                                 // Try simple callback fast path
                                 let use_simple = arr_borrow.first().map(|v| {
@@ -1869,14 +1875,14 @@ impl Evaluator {
                                     }
                                 } else if let Some((scope, params, body)) = self.create_callback_scope(&callback) {
                                     for (i, v) in arr_borrow.iter().enumerate() {
-                                        let keep = self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64)])?;
+                                        let keep = self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                         if keep.is_truthy() {
                                             result.push(v.clone());
                                         }
                                     }
                                 } else {
                                     for (i, v) in arr_borrow.iter().enumerate() {
-                                        let keep = self.call_func(&callback, &[v.clone(), Value::Number(i as f64)])?;
+                                        let keep = self.call_func(&callback, &[v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                         if keep.is_truthy() {
                                             result.push(v.clone());
                                         }
@@ -1886,7 +1892,8 @@ impl Evaluator {
                             }
                             "reduce" => {
                                 let callback = arg_vals.first().cloned().unwrap_or(Value::Null);
-                                let arr_borrow = arr.borrow();
+                                let arr_borrow = arr.borrow().clone(); // snapshot; drop borrow before callbacks
+                                let arr_value = Value::Array(arr.clone()); // JS 4th callback arg
                                 let (mut acc, start_idx) = if arg_vals.len() > 1 {
                                     (arg_vals[1].clone(), 0)
                                 } else if !arr_borrow.is_empty() {
@@ -1896,18 +1903,19 @@ impl Evaluator {
                                 };
                                 if let Some((scope, params, body)) = self.create_callback_scope(&callback) {
                                     for (i, v) in arr_borrow.iter().enumerate().skip(start_idx) {
-                                        acc = self.call_with_scope(&scope, &params, &body, &[acc, v.clone(), Value::Number(i as f64)])?;
+                                        acc = self.call_with_scope(&scope, &params, &body, &[acc, v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                     }
                                 } else {
                                     for (i, v) in arr_borrow.iter().enumerate().skip(start_idx) {
-                                        acc = self.call_func(&callback, &[acc, v.clone(), Value::Number(i as f64)])?;
+                                        acc = self.call_func(&callback, &[acc, v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                     }
                                 }
                                 return Ok(acc);
                             }
                             "find" => {
                                 let callback = arg_vals.first().cloned().unwrap_or(Value::Null);
-                                let arr_borrow = arr.borrow();
+                                let arr_borrow = arr.borrow().clone(); // snapshot; drop borrow before callbacks
+                                let arr_value = Value::Array(arr.clone()); // JS 3rd callback arg
                                 // Try simple callback fast path
                                 let use_simple = arr_borrow.first().map(|v| {
                                     self.eval_simple_callback(&callback, &[v.clone()]).is_some()
@@ -1922,14 +1930,14 @@ impl Evaluator {
                                     }
                                 } else if let Some((scope, params, body)) = self.create_callback_scope(&callback) {
                                     for (i, v) in arr_borrow.iter().enumerate() {
-                                        let found = self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64)])?;
+                                        let found = self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                         if found.is_truthy() {
                                             return Ok(v.clone());
                                         }
                                     }
                                 } else {
                                     for (i, v) in arr_borrow.iter().enumerate() {
-                                        let found = self.call_func(&callback, &[v.clone(), Value::Number(i as f64)])?;
+                                        let found = self.call_func(&callback, &[v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                         if found.is_truthy() {
                                             return Ok(v.clone());
                                         }
@@ -1939,17 +1947,18 @@ impl Evaluator {
                             }
                             "findIndex" => {
                                 let callback = arg_vals.first().cloned().unwrap_or(Value::Null);
-                                let arr_borrow = arr.borrow();
+                                let arr_borrow = arr.borrow().clone(); // snapshot; drop borrow before callbacks
+                                let arr_value = Value::Array(arr.clone()); // JS 3rd callback arg
                                 if let Some((scope, params, body)) = self.create_callback_scope(&callback) {
                                     for (i, v) in arr_borrow.iter().enumerate() {
-                                        let found = self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64)])?;
+                                        let found = self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                         if found.is_truthy() {
                                             return Ok(Value::Number(i as f64));
                                         }
                                     }
                                 } else {
                                     for (i, v) in arr_borrow.iter().enumerate() {
-                                        let found = self.call_func(&callback, &[v.clone(), Value::Number(i as f64)])?;
+                                        let found = self.call_func(&callback, &[v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                         if found.is_truthy() {
                                             return Ok(Value::Number(i as f64));
                                         }
@@ -1958,13 +1967,14 @@ impl Evaluator {
                                 return Ok(Value::Number(-1.0));
                             }
                             "findLast" => {
-                                // Like find, from the end (#247). Callback gets (value, original index).
+                                // Like find, from the end (#247). Callback gets (value, original index, array).
                                 let callback = arg_vals.first().cloned().unwrap_or(Value::Null);
-                                let arr_borrow = arr.borrow();
+                                let arr_borrow = arr.borrow().clone(); // snapshot; drop borrow before callbacks
+                                let arr_value = Value::Array(arr.clone()); // JS 3rd callback arg
                                 let scoped = self.create_callback_scope(&callback);
                                 for i in (0..arr_borrow.len()).rev() {
                                     let v = arr_borrow[i].clone();
-                                    let args = [v.clone(), Value::Number(i as f64)];
+                                    let args = [v.clone(), Value::Number(i as f64), arr_value.clone()];
                                     let found = match &scoped {
                                         Some((scope, params, body)) => self.call_with_scope(scope, params, body, &args)?,
                                         None => self.call_func(&callback, &args)?,
@@ -1977,10 +1987,11 @@ impl Evaluator {
                             }
                             "findLastIndex" => {
                                 let callback = arg_vals.first().cloned().unwrap_or(Value::Null);
-                                let arr_borrow = arr.borrow();
+                                let arr_borrow = arr.borrow().clone(); // snapshot; drop borrow before callbacks
+                                let arr_value = Value::Array(arr.clone()); // JS 3rd callback arg
                                 let scoped = self.create_callback_scope(&callback);
                                 for i in (0..arr_borrow.len()).rev() {
-                                    let args = [arr_borrow[i].clone(), Value::Number(i as f64)];
+                                    let args = [arr_borrow[i].clone(), Value::Number(i as f64), arr_value.clone()];
                                     let found = match &scoped {
                                         Some((scope, params, body)) => self.call_with_scope(scope, params, body, &args)?,
                                         None => self.call_func(&callback, &args)?,
@@ -2007,21 +2018,23 @@ impl Evaluator {
                             }
                             "forEach" => {
                                 let callback = arg_vals.first().cloned().unwrap_or(Value::Null);
-                                let arr_borrow = arr.borrow();
+                                let arr_borrow = arr.borrow().clone(); // snapshot; drop borrow before callbacks
+                                let arr_value = Value::Array(arr.clone()); // JS 3rd callback arg
                                 if let Some((scope, params, body)) = self.create_callback_scope(&callback) {
                                     for (i, v) in arr_borrow.iter().enumerate() {
-                                        self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64)])?;
+                                        self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                     }
                                 } else {
                                     for (i, v) in arr_borrow.iter().enumerate() {
-                                        self.call_func(&callback, &[v.clone(), Value::Number(i as f64)])?;
+                                        self.call_func(&callback, &[v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                     }
                                 }
                                 return Ok(Value::Null);
                             }
                             "some" => {
                                 let callback = arg_vals.first().cloned().unwrap_or(Value::Null);
-                                let arr_borrow = arr.borrow();
+                                let arr_borrow = arr.borrow().clone(); // snapshot; drop borrow before callbacks
+                                let arr_value = Value::Array(arr.clone()); // JS 3rd callback arg
                                 // Try simple callback fast path
                                 let use_simple = arr_borrow.first().map(|v| {
                                     self.eval_simple_callback(&callback, &[v.clone()]).is_some()
@@ -2036,14 +2049,14 @@ impl Evaluator {
                                     }
                                 } else if let Some((scope, params, body)) = self.create_callback_scope(&callback) {
                                     for (i, v) in arr_borrow.iter().enumerate() {
-                                        let result = self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64)])?;
+                                        let result = self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                         if result.is_truthy() {
                                             return Ok(Value::Bool(true));
                                         }
                                     }
                                 } else {
                                     for (i, v) in arr_borrow.iter().enumerate() {
-                                        let result = self.call_func(&callback, &[v.clone(), Value::Number(i as f64)])?;
+                                        let result = self.call_func(&callback, &[v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                         if result.is_truthy() {
                                             return Ok(Value::Bool(true));
                                         }
@@ -2053,7 +2066,8 @@ impl Evaluator {
                             }
                             "every" => {
                                 let callback = arg_vals.first().cloned().unwrap_or(Value::Null);
-                                let arr_borrow = arr.borrow();
+                                let arr_borrow = arr.borrow().clone(); // snapshot; drop borrow before callbacks
+                                let arr_value = Value::Array(arr.clone()); // JS 3rd callback arg
                                 // Try simple callback fast path
                                 let use_simple = arr_borrow.first().map(|v| {
                                     self.eval_simple_callback(&callback, &[v.clone()]).is_some()
@@ -2068,14 +2082,14 @@ impl Evaluator {
                                     }
                                 } else if let Some((scope, params, body)) = self.create_callback_scope(&callback) {
                                     for (i, v) in arr_borrow.iter().enumerate() {
-                                        let result = self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64)])?;
+                                        let result = self.call_with_scope(&scope, &params, &body, &[v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                         if !result.is_truthy() {
                                             return Ok(Value::Bool(false));
                                         }
                                     }
                                 } else {
                                     for (i, v) in arr_borrow.iter().enumerate() {
-                                        let result = self.call_func(&callback, &[v.clone(), Value::Number(i as f64)])?;
+                                        let result = self.call_func(&callback, &[v.clone(), Value::Number(i as f64), arr_value.clone()])?;
                                         if !result.is_truthy() {
                                             return Ok(Value::Bool(false));
                                         }
@@ -4696,5 +4710,52 @@ mod recursion_limit_tests_381 {
     fn normal_recursion_is_unaffected() {
         let src = "fn fib(n) { if (n < 2) { return n } return fib(n - 1) + fib(n - 2) }\nfib(12)";
         assert_eq!(run_with_depth(src, 20000), "144");
+    }
+}
+
+#[cfg(test)]
+mod array_hof_callback_arg_tests {
+    // Array HOFs pass the source array as the trailing callback arg (JS `(element, index, array)`,
+    // reduce `(acc, element, index, array)`). The inline interp loops snapshot the backing store and
+    // drop the borrow before any callback, so a callback that MUTATES the array via the `array` arg
+    // (or a capture) can't RefCell-panic — it iterates the pre-call snapshot, matching JS + the shared
+    // #382 builtins path.
+    use super::Evaluator;
+    use tishlang_parser::parse;
+
+    fn run(src: &str) -> String {
+        let program = parse(src).unwrap();
+        let mut eval = Evaluator::new();
+        eval.eval_program(&program).unwrap().to_string()
+    }
+
+    #[test]
+    fn map_receives_array_as_third_arg() {
+        assert_eq!(run("[5, 3, 8].map((x, i, arr) => arr.length).join(',')"), "3,3,3");
+    }
+
+    #[test]
+    fn reduce_receives_array_as_fourth_arg() {
+        assert_eq!(run("[1, 2, 3].reduce((a, x, i, arr) => a + arr.length, 0)"), "9");
+    }
+
+    #[test]
+    fn callback_may_index_the_array_arg() {
+        assert_eq!(run("[10, 20, 30].map((x, i, arr) => arr[i] * 2).join(',')"), "20,40,60");
+    }
+
+    #[test]
+    fn callback_mutating_the_array_arg_does_not_panic() {
+        // Pre-snapshot this RefCell-panicked (map held the borrow across the loop). Now iteration is
+        // over the snapshot (3 elements); the 3 pushes land on the live array → final length 6, matching
+        // JS forEach semantics (does not visit elements appended during iteration).
+        let src = "let a = [1, 2, 3]\na.forEach((x, i, arr) => { arr.push(x) })\na.length";
+        assert_eq!(run(src), "6");
+    }
+
+    #[test]
+    fn one_and_two_arg_callbacks_unchanged() {
+        assert_eq!(run("[5, 3, 8].map(x => x * 2).join(',')"), "10,6,16");
+        assert_eq!(run("[5, 3, 8].map((x, i) => x + i).join(',')"), "5,4,10");
     }
 }

--- a/tests/core/parity_array_hof_callback_arg.js
+++ b/tests/core/parity_array_hof_callback_arg.js
@@ -1,0 +1,38 @@
+// Array HOFs pass the source array as the trailing callback argument, matching JS:
+//   map/filter/forEach/some/every/find/findIndex/findLast/findLastIndex/flatMap → (element, index, array)
+//   reduce → (accumulator, element, index, array)
+// Gated across interp/vm/native/cranelift/wasi/js + node. Valid in tish and node. The callbacks only
+// READ the array arg (length / element-by-index) — no mutation-during-iteration, whose ordering is not
+// worth pinning cross-backend. #247
+let a = [5, 3, 8, 1, 9]
+
+// map: element + array.length (3rd arg)
+console.log("map", a.map((x, i, arr) => x + arr.length).join(","))
+// map: index into the array arg
+console.log("map-self", a.map((x, i, arr) => arr[i] * 10).join(","))
+// filter: predicate uses array.length
+console.log("filter", a.filter((x, i, arr) => x > arr.length).join(","))
+// reduce: 4th arg is the array; fold length in
+console.log("reduce", a.reduce((acc, x, i, arr) => acc + x + arr.length, 0))
+// reduce no-init: seed is a[0], first call at index 1 with array arg
+console.log("reduce-noinit", a.reduce((acc, x, i, arr) => acc + (arr.length - i)))
+// forEach: accumulate array.length via a closure
+let feTotal = 0
+a.forEach((x, i, arr) => { feTotal = feTotal + arr.length })
+console.log("forEach", feTotal)
+// some / every over the array arg
+console.log("some", a.some((x, i, arr) => i === arr.length - 1))
+console.log("every", a.every((x, i, arr) => arr.length === 5))
+// find / findIndex using array arg
+console.log("find", a.find((x, i, arr) => x === arr[arr.length - 1]))
+console.log("findIndex", a.findIndex((x, i, arr) => i === arr.length - 2))
+// findLast / findLastIndex (iterate from the end; original index) using array arg
+console.log("findLast", a.findLast((x, i, arr) => x < arr.length))
+console.log("findLastIndex", a.findLastIndex((x, i, arr) => arr[i] > 4))
+// flatMap: emit [element, array.length] pairs
+console.log("flatMap", a.flatMap((x, i, arr) => [x, arr.length]).join(","))
+
+// Regression: 1-arg and 2-arg callbacks (that ignore the extra arg) are unchanged.
+console.log("one-arg", a.map(x => x * 2).join(","))
+console.log("two-arg", a.map((x, i) => x + i).join(","))
+console.log("reduce-2arg", a.reduce((s, x) => s + x, 0))

--- a/tests/core/parity_array_hof_callback_arg.tish
+++ b/tests/core/parity_array_hof_callback_arg.tish
@@ -1,0 +1,38 @@
+// Array HOFs pass the source array as the trailing callback argument, matching JS:
+//   map/filter/forEach/some/every/find/findIndex/findLast/findLastIndex/flatMap → (element, index, array)
+//   reduce → (accumulator, element, index, array)
+// Gated across interp/vm/native/cranelift/wasi/js + node. Valid in tish and node. The callbacks only
+// READ the array arg (length / element-by-index) — no mutation-during-iteration, whose ordering is not
+// worth pinning cross-backend. #247
+let a = [5, 3, 8, 1, 9]
+
+// map: element + array.length (3rd arg)
+console.log("map", a.map((x, i, arr) => x + arr.length).join(","))
+// map: index into the array arg
+console.log("map-self", a.map((x, i, arr) => arr[i] * 10).join(","))
+// filter: predicate uses array.length
+console.log("filter", a.filter((x, i, arr) => x > arr.length).join(","))
+// reduce: 4th arg is the array; fold length in
+console.log("reduce", a.reduce((acc, x, i, arr) => acc + x + arr.length, 0))
+// reduce no-init: seed is a[0], first call at index 1 with array arg
+console.log("reduce-noinit", a.reduce((acc, x, i, arr) => acc + (arr.length - i)))
+// forEach: accumulate array.length via a closure
+let feTotal = 0
+a.forEach((x, i, arr) => { feTotal = feTotal + arr.length })
+console.log("forEach", feTotal)
+// some / every over the array arg
+console.log("some", a.some((x, i, arr) => i === arr.length - 1))
+console.log("every", a.every((x, i, arr) => arr.length === 5))
+// find / findIndex using array arg
+console.log("find", a.find((x, i, arr) => x === arr[arr.length - 1]))
+console.log("findIndex", a.findIndex((x, i, arr) => i === arr.length - 2))
+// findLast / findLastIndex (iterate from the end; original index) using array arg
+console.log("findLast", a.findLast((x, i, arr) => x < arr.length))
+console.log("findLastIndex", a.findLastIndex((x, i, arr) => arr[i] > 4))
+// flatMap: emit [element, array.length] pairs
+console.log("flatMap", a.flatMap((x, i, arr) => [x, arr.length]).join(","))
+
+// Regression: 1-arg and 2-arg callbacks (that ignore the extra arg) are unchanged.
+console.log("one-arg", a.map(x => x * 2).join(","))
+console.log("two-arg", a.map((x, i) => x + i).join(","))
+console.log("reduce-2arg", a.reduce((s, x) => s + x, 0))

--- a/tests/core/parity_array_hof_callback_arg.tish.expected
+++ b/tests/core/parity_array_hof_callback_arg.tish.expected
@@ -1,0 +1,16 @@
+map 10,8,13,6,14
+map-self 50,30,80,10,90
+filter 8,9
+reduce 51
+reduce-noinit 15
+forEach 25
+some true
+every true
+find 9
+findIndex 3
+findLast 1
+findLastIndex 4
+flatMap 5,5,3,5,8,5,1,5,9,5
+one-arg 10,6,16,2,18
+two-arg 5,4,10,4,13
+reduce-2arg 26

--- a/tests/main.js
+++ b/tests/main.js
@@ -3184,6 +3184,47 @@ console.log(obj?.c ?? "missing");
 }
 
 {
+// Array HOFs pass the source array as the trailing callback argument, matching JS:
+//   map/filter/forEach/some/every/find/findIndex/findLast/findLastIndex/flatMap → (element, index, array)
+//   reduce → (accumulator, element, index, array)
+// Gated across interp/vm/native/cranelift/wasi/js + node. Valid in tish and node. The callbacks only
+// READ the array arg (length / element-by-index) — no mutation-during-iteration, whose ordering is not
+// worth pinning cross-backend. #247
+let a = [5, 3, 8, 1, 9]
+
+// map: element + array.length (3rd arg)
+console.log("map", a.map((x, i, arr) => x + arr.length).join(","))
+// map: index into the array arg
+console.log("map-self", a.map((x, i, arr) => arr[i] * 10).join(","))
+// filter: predicate uses array.length
+console.log("filter", a.filter((x, i, arr) => x > arr.length).join(","))
+// reduce: 4th arg is the array; fold length in
+console.log("reduce", a.reduce((acc, x, i, arr) => acc + x + arr.length, 0))
+// reduce no-init: seed is a[0], first call at index 1 with array arg
+console.log("reduce-noinit", a.reduce((acc, x, i, arr) => acc + (arr.length - i)))
+// forEach: accumulate array.length via a closure
+let feTotal = 0
+a.forEach((x, i, arr) => { feTotal = feTotal + arr.length })
+console.log("forEach", feTotal)
+// some / every over the array arg
+console.log("some", a.some((x, i, arr) => i === arr.length - 1))
+console.log("every", a.every((x, i, arr) => arr.length === 5))
+// find / findIndex using array arg
+console.log("find", a.find((x, i, arr) => x === arr[arr.length - 1]))
+console.log("findIndex", a.findIndex((x, i, arr) => i === arr.length - 2))
+// findLast / findLastIndex (iterate from the end; original index) using array arg
+console.log("findLast", a.findLast((x, i, arr) => x < arr.length))
+console.log("findLastIndex", a.findLastIndex((x, i, arr) => arr[i] > 4))
+// flatMap: emit [element, array.length] pairs
+console.log("flatMap", a.flatMap((x, i, arr) => [x, arr.length]).join(","))
+
+// Regression: 1-arg and 2-arg callbacks (that ignore the extra arg) are unchanged.
+console.log("one-arg", a.map(x => x * 2).join(","))
+console.log("two-arg", a.map((x, i) => x + i).join(","))
+console.log("reduce-2arg", a.reduce((s, x) => s + x, 0))
+}
+
+{
 // Native codegen: a Value-typed identifier (object, or a global like NaN/Infinity) used BOTH as an
 // array-literal element AND again in the same expression must be cloned, not moved (#247 native
 // build failure: `[1, NaN].includes(NaN)`). Must stay bit-identical across all backends.

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3231,6 +3231,48 @@ console.log(obj?.c ?? "missing")
 }
 __perf_run_core_optional_chaining()
 
+fn __perf_run_core_parity_array_hof_callback_arg() {
+// Array HOFs pass the source array as the trailing callback argument, matching JS:
+//   map/filter/forEach/some/every/find/findIndex/findLast/findLastIndex/flatMap → (element, index, array)
+//   reduce → (accumulator, element, index, array)
+// Gated across interp/vm/native/cranelift/wasi/js + node. Valid in tish and node. The callbacks only
+// READ the array arg (length / element-by-index) — no mutation-during-iteration, whose ordering is not
+// worth pinning cross-backend. #247
+let a = [5, 3, 8, 1, 9]
+
+// map: element + array.length (3rd arg)
+console.log("map", a.map((x, i, arr) => x + arr.length).join(","))
+// map: index into the array arg
+console.log("map-self", a.map((x, i, arr) => arr[i] * 10).join(","))
+// filter: predicate uses array.length
+console.log("filter", a.filter((x, i, arr) => x > arr.length).join(","))
+// reduce: 4th arg is the array; fold length in
+console.log("reduce", a.reduce((acc, x, i, arr) => acc + x + arr.length, 0))
+// reduce no-init: seed is a[0], first call at index 1 with array arg
+console.log("reduce-noinit", a.reduce((acc, x, i, arr) => acc + (arr.length - i)))
+// forEach: accumulate array.length via a closure
+let feTotal = 0
+a.forEach((x, i, arr) => { feTotal = feTotal + arr.length })
+console.log("forEach", feTotal)
+// some / every over the array arg
+console.log("some", a.some((x, i, arr) => i === arr.length - 1))
+console.log("every", a.every((x, i, arr) => arr.length === 5))
+// find / findIndex using array arg
+console.log("find", a.find((x, i, arr) => x === arr[arr.length - 1]))
+console.log("findIndex", a.findIndex((x, i, arr) => i === arr.length - 2))
+// findLast / findLastIndex (iterate from the end; original index) using array arg
+console.log("findLast", a.findLast((x, i, arr) => x < arr.length))
+console.log("findLastIndex", a.findLastIndex((x, i, arr) => arr[i] > 4))
+// flatMap: emit [element, array.length] pairs
+console.log("flatMap", a.flatMap((x, i, arr) => [x, arr.length]).join(","))
+
+// Regression: 1-arg and 2-arg callbacks (that ignore the extra arg) are unchanged.
+console.log("one-arg", a.map(x => x * 2).join(","))
+console.log("two-arg", a.map((x, i) => x + i).join(","))
+console.log("reduce-2arg", a.reduce((s, x) => s + x, 0))
+}
+__perf_run_core_parity_array_hof_callback_arg()
+
 fn __perf_run_core_parity_array_ident_elem() {
 // Native codegen: a Value-typed identifier (object, or a global like NaN/Infinity) used BOTH as an
 // array-literal element AND again in the same expression must be cloned, not moved (#247 native


### PR DESCRIPTION
## What

Array higher-order methods now call the callback with the **source array as the trailing argument**, matching JavaScript:

- `map` / `filter` / `forEach` / `some` / `every` / `find` / `findIndex` / `findLast` / `findLastIndex` / `flatMap` → `(element, index, array)`
- `reduce` → `(accumulator, element, index, array)`

Before, tish passed only `(element, index)` (and `(acc, element, index)` for `reduce`), so a callback's `array` param was `null`:

```js
[3, 1, 4].map((x, i, arr) => arr.length)   // tish: [null,null,null]-ish → NaN/error   node: [3,3,3]
```

## Fix — two sites cover all six backends

- **`tishlang_builtins::array`** — the shared impl used by **vm / cranelift / wasi**, and by **native** via the `tishlang_runtime::array_*` re-exports. Thread the receiver array into each `cb.call`.
- **The tree-walking interpreter's inline HOF dispatch** — same, and the loops now **snapshot the backing store and drop the array borrow before any callback** (like the #382 builtins path). A callback that mutates the array via the `array` arg (or a capture) can no longer `RefCell`-panic — it iterates the pre-call snapshot, matching JS. This also closes a **pre-existing latent panic** on capture-and-mutate.

The native **fused-HOF pipeline** is unaffected: it only fires for single-param, element-only callbacks (which never observe the `array` arg) and bails to the shared `array_*` path otherwise.

## Perf

The native codegen fused path and the **#187** VM-JIT fused path both call the compiled numeric fn directly (never `cb.call`), so they are **unchanged** — native `array_hof` stays ~12ms. The generic (non-fused) **VM** path pays one extra array `VmRef` clone per element (~20% on `array_hof` VM over the boxed path); **#187 fusion eliminates this for numeric callbacks**, and the perf-gauntlet-gated **native** path is unaffected.

## Tests

- New cross-backend fixture `tests/core/parity_array_hof_callback_arg.tish` (+ `.js` twin + `.tish.expected`) — gates all of `interp/vm/native/cranelift/wasi/js` + node. Bundle (`tests/main.{tish,js}`) regenerated.
- Interp unit tests in `tish_eval`, including the mutation-during-iteration no-panic case and 1-/2-arg regressions.
- Full `test_mvp_programs` suite (all six backends) green; no existing fixture regressed.

Relates to #247.
