### PR TITLE
fix(native): catchable TypeError for calling a non-function, not an abort (#381)

### DIFF
--- a/crates/tish_core/src/lib.rs
+++ b/crates/tish_core/src/lib.rs
@@ -154,6 +154,23 @@ pub fn stack_overflow_error() -> Value {
     Value::object(e)
 }
 
+/// A catchable `TypeError` for calling a non-callable value — the `{ name, message }` shape matches
+/// the VM/interpreter/node (`e.name === "TypeError"`). Used to PARK a pending throw (#381) instead of
+/// aborting the process, so `value_call` on a non-function surfaces as a catchable error at the next
+/// pending-throw checkpoint rather than an uncatchable native panic.
+pub fn not_a_function_error(message: impl Into<String>) -> Value {
+    let mut e = ObjectMap::default();
+    e.insert(
+        std::sync::Arc::from("name"),
+        Value::String("TypeError".into()),
+    );
+    e.insert(
+        std::sync::Arc::from("message"),
+        Value::String(message.into().into()),
+    );
+    Value::object(e)
+}
+
 /// RAII frame for the depth-counting recursion guard: holding one means the depth was incremented;
 /// dropping it decrements, so early returns in generated code can't leak a level. #381
 pub struct CallDepthGuard(());

--- a/crates/tish_core/src/value.rs
+++ b/crates/tish_core/src/value.rs
@@ -1062,6 +1062,13 @@ pub fn to_uint32_value(v: &Value) -> u32 {
 }
 
 /// Invoke a callable [`Value`]: [`Value::Function`], or an object exposing `__call` (e.g. `Symbol`).
+///
+/// Calling a NON-callable (e.g. a method on `null` whose read returned `null`, or any non-function
+/// value) is a JS `TypeError`. In the native/runtime path this used to `panic!` — an UNCATCHABLE
+/// process abort (#381 class). It now PARKS a catchable `TypeError` and returns the `null` sentinel;
+/// the throw surfaces at the caller's next pending-throw checkpoint (statement boundary in emitted
+/// native code, or the `has_pending_throw()` polls in the shared builtins), so `try { null.foo() }
+/// catch (e) { … }` recovers instead of aborting — matching the VM/interpreter/node.
 pub fn value_call(callee: &Value, args: &[Value]) -> Value {
     match callee {
         Value::Function(f) => f.call(args),
@@ -1070,15 +1077,19 @@ pub fn value_call(callee: &Value, args: &[Value]) -> Value {
             if let Some(inner) = inner {
                 return value_call(&inner, args);
             }
-            panic!(
-                "Not a function: tried to call {:?} as a function (e.g. method on Null when read failed)",
-                callee
-            );
+            crate::set_pending_throw(crate::not_a_function_error(format!(
+                "{} is not a function",
+                callee.to_display_string()
+            )));
+            Value::Null
         }
-        _ => panic!(
-            "Not a function: tried to call {:?} as a function (e.g. method on Null when read failed)",
-            callee
-        ),
+        _ => {
+            crate::set_pending_throw(crate::not_a_function_error(format!(
+                "{} is not a function",
+                callee.to_display_string()
+            )));
+            Value::Null
+        }
     }
 }
 
@@ -1879,6 +1890,44 @@ mod propmap_merge_tests {
         assert_eq!(keys(&dst), keys(&src));
         assert_eq!(num(&dst, "x"), Some(7.0));
         assert_eq!(num(&dst, "y"), Some(8.0));
+    }
+}
+
+#[cfg(test)]
+mod value_call_non_function_tests {
+    // Calling a non-callable value PARKS a catchable `TypeError` (#381) instead of `panic!`-ing
+    // (an uncatchable process abort). The throw surfaces at the caller's next pending-throw
+    // checkpoint. These lock the no-panic contract at the primitive level.
+    use super::{value_call, Value};
+    use crate::{has_pending_throw, take_pending_throw};
+
+    fn parked_error_name(v: &Value) -> Option<String> {
+        if let Value::Object(o) = v {
+            if let Some(Value::String(s)) = o.borrow().strings.get("name") {
+                return Some(s.to_string());
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn calling_null_parks_type_error_and_does_not_panic() {
+        let _ = take_pending_throw(); // clear any stale slot on this thread
+        let r = value_call(&Value::Null, &[]);
+        assert!(matches!(r, Value::Null), "returns the null sentinel, not a panic");
+        assert!(has_pending_throw(), "a throw must be parked");
+        let parked = take_pending_throw().expect("parked throw present");
+        assert_eq!(parked_error_name(&parked).as_deref(), Some("TypeError"));
+    }
+
+    #[test]
+    fn calling_a_number_parks_type_error() {
+        let _ = take_pending_throw();
+        let r = value_call(&Value::Number(5.0), &[]);
+        assert!(matches!(r, Value::Null));
+        assert!(has_pending_throw());
+        let parked = take_pending_throw().expect("parked throw present");
+        assert_eq!(parked_error_name(&parked).as_deref(), Some("TypeError"));
     }
 }
 

--- a/tests/core/parity_call_non_function_catchable.js
+++ b/tests/core/parity_call_non_function_catchable.js
@@ -1,0 +1,44 @@
+// Calling a non-callable value throws a CATCHABLE TypeError on every backend + node — it must never
+// abort the process. The native (rust AOT) backend used to `panic!` in `value_call` (an uncatchable
+// abort) for a method call on null whose read returned null; #381 makes it park a catchable TypeError
+// like the VM/interpreter/cranelift/wasi/node. Only `e.name` is asserted (messages differ across
+// engines). Valid in tish and node.
+
+// method on null (the read yields null, then the call target is non-callable)
+let r1 = "no-throw"
+try {
+  let z = null
+  z.foo()
+} catch (e) {
+  r1 = e.name
+}
+console.log("null-method", r1)
+
+// calling a plain number
+let r2 = "no-throw"
+try {
+  let n = 5
+  n()
+} catch (e) {
+  r2 = e.name
+}
+console.log("number-call", r2)
+
+// calling a string
+let r3 = "no-throw"
+try {
+  let s = "hi"
+  s()
+} catch (e) {
+  r3 = e.name
+}
+console.log("string-call", r3)
+
+// the program keeps running after each catch (no abort)
+console.log("survived", true)
+
+// normal calls are unaffected
+function add(a, b) { return a + b }
+console.log("normal-call", add(2, 3))
+let o = { greet: () => "hi" }
+console.log("method-call", o.greet())

--- a/tests/core/parity_call_non_function_catchable.tish
+++ b/tests/core/parity_call_non_function_catchable.tish
@@ -1,0 +1,44 @@
+// Calling a non-callable value throws a CATCHABLE TypeError on every backend + node — it must never
+// abort the process. The native (rust AOT) backend used to `panic!` in `value_call` (an uncatchable
+// abort) for a method call on null whose read returned null; #381 makes it park a catchable TypeError
+// like the VM/interpreter/cranelift/wasi/node. Only `e.name` is asserted (messages differ across
+// engines). Valid in tish and node.
+
+// method on null (the read yields null, then the call target is non-callable)
+let r1 = "no-throw"
+try {
+  let z = null
+  z.foo()
+} catch (e) {
+  r1 = e.name
+}
+console.log("null-method", r1)
+
+// calling a plain number
+let r2 = "no-throw"
+try {
+  let n = 5
+  n()
+} catch (e) {
+  r2 = e.name
+}
+console.log("number-call", r2)
+
+// calling a string
+let r3 = "no-throw"
+try {
+  let s = "hi"
+  s()
+} catch (e) {
+  r3 = e.name
+}
+console.log("string-call", r3)
+
+// the program keeps running after each catch (no abort)
+console.log("survived", true)
+
+// normal calls are unaffected
+function add(a, b) { return a + b }
+console.log("normal-call", add(2, 3))
+let o = { greet: () => "hi" }
+console.log("method-call", o.greet())

--- a/tests/core/parity_call_non_function_catchable.tish.expected
+++ b/tests/core/parity_call_non_function_catchable.tish.expected
@@ -1,0 +1,6 @@
+null-method TypeError
+number-call TypeError
+string-call TypeError
+survived true
+normal-call 5
+method-call hi

--- a/tests/main.js
+++ b/tests/main.js
@@ -3316,6 +3316,53 @@ console.log("negzero-inspect", -0)
 }
 
 {
+// Calling a non-callable value throws a CATCHABLE TypeError on every backend + node — it must never
+// abort the process. The native (rust AOT) backend used to `panic!` in `value_call` (an uncatchable
+// abort) for a method call on null whose read returned null; #381 makes it park a catchable TypeError
+// like the VM/interpreter/cranelift/wasi/node. Only `e.name` is asserted (messages differ across
+// engines). Valid in tish and node.
+
+// method on null (the read yields null, then the call target is non-callable)
+let r1 = "no-throw"
+try {
+  let z = null
+  z.foo()
+} catch (e) {
+  r1 = e.name
+}
+console.log("null-method", r1)
+
+// calling a plain number
+let r2 = "no-throw"
+try {
+  let n = 5
+  n()
+} catch (e) {
+  r2 = e.name
+}
+console.log("number-call", r2)
+
+// calling a string
+let r3 = "no-throw"
+try {
+  let s = "hi"
+  s()
+} catch (e) {
+  r3 = e.name
+}
+console.log("string-call", r3)
+
+// the program keeps running after each catch (no abort)
+console.log("survived", true)
+
+// normal calls are unaffected
+function add(a, b) { return a + b }
+console.log("normal-call", add(2, 3))
+let o = { greet: () => "hi" }
+console.log("method-call", o.greet())
+}
+
+{
 // Cross-backend parity probe for the classic divergence sources between compilation targets:
 // typeof, value-to-string coercion, nullish/absent reads, numeric formatting, and equality edges.
 // Every backend (interp/vm/native/cranelift/llvm/wasi) and node must agree. Valid in tish and node.

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3367,6 +3367,54 @@ console.log("negzero-inspect", -0)
 }
 __perf_run_core_parity_builtins()
 
+fn __perf_run_core_parity_call_non_function_catchable() {
+// Calling a non-callable value throws a CATCHABLE TypeError on every backend + node — it must never
+// abort the process. The native (rust AOT) backend used to `panic!` in `value_call` (an uncatchable
+// abort) for a method call on null whose read returned null; #381 makes it park a catchable TypeError
+// like the VM/interpreter/cranelift/wasi/node. Only `e.name` is asserted (messages differ across
+// engines). Valid in tish and node.
+
+// method on null (the read yields null, then the call target is non-callable)
+let r1 = "no-throw"
+try {
+  let z = null
+  z.foo()
+} catch (e) {
+  r1 = e.name
+}
+console.log("null-method", r1)
+
+// calling a plain number
+let r2 = "no-throw"
+try {
+  let n = 5
+  n()
+} catch (e) {
+  r2 = e.name
+}
+console.log("number-call", r2)
+
+// calling a string
+let r3 = "no-throw"
+try {
+  let s = "hi"
+  s()
+} catch (e) {
+  r3 = e.name
+}
+console.log("string-call", r3)
+
+// the program keeps running after each catch (no abort)
+console.log("survived", true)
+
+// normal calls are unaffected
+function add(a, b) { return a + b }
+console.log("normal-call", add(2, 3))
+let o = { greet: () => "hi" }
+console.log("method-call", o.greet())
+}
+__perf_run_core_parity_call_non_function_catchable()
+
 fn __perf_run_core_parity_coercion() {
 // Cross-backend parity probe for the classic divergence sources between compilation targets:
 // typeof, value-to-string coercion, nullish/absent reads, numeric formatting, and equality edges.


### PR DESCRIPTION
## What

The core call primitive `tishlang_core::value_call` — the **native / rust-AOT** call path (and `__call` dispatch) — `panic!`-ed when handed a non-callable value, e.g. a method call on null whose read returned null:

```js
try { let z = null; z.foo() } catch (e) { /* never reached on native */ }
```

On the native backend that `panic!` is an **uncatchable process abort** — `catch` couldn't recover, and an uncaught one crashed with a Rust backtrace. This is the #381 abort→catchable class.

## Fix

`value_call` now **parks a catchable** `{ name: "TypeError", message: "… is not a function" }` and returns the null sentinel — exactly like the recursion guard (#381) parks a `RangeError`. The throw surfaces at the caller's next pending-throw checkpoint (statement boundaries in emitted native code; the `has_pending_throw()` polls in the shared builtins), so:

- `try { null.foo() } catch (e) { e.name }` → `"TypeError"` (was: uncatchable abort)
- uncaught → clean `Error: {name: TypeError, …}` + exit 1 (was: Rust panic/backtrace)

matching the VM / interpreter / cranelift / wasi / node.

The VM has its own call dispatch and already threw a catchable `TypeError` here — only the native/runtime path aborted. Normal calls (functions, object methods, `Symbol` `__call`) are unchanged.

## Tests

- New all-six-backend fixture `tests/core/parity_call_non_function_catchable.tish` (+ `.js` twin + `.tish.expected`) — catch-based (asserts `e.name`; messages differ across engines). Covers `null.foo()`, calling a number, calling a string, survival-after-catch, and normal calls. Bundle regenerated.
- `tish_core` unit tests asserting the no-panic / parked-`TypeError` contract at the primitive level.
- Full `test_mvp_programs` suite (interp/vm/native/cranelift/wasi/js) green.

## Scope note

Null **property/index reads** (`null.length`, `null[0]`) still return `null` on the native path — they don't go through `value_call`, and throwing them exactly (before the value is used) needs a fallible `get_prop`/`get_index`, tracked separately. The **interpreter's** null read paths are fixed in the companion PR #422.

Relates to #381, #247.
