### PR TITLE
fix(native): catchable TypeError for null property/index reads (#425)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -13884,8 +13884,17 @@ impl Codegen {
         let mut found = false;
         Self::for_each_stmt_expr(stmt, &mut |e| {
             Self::walk_subexprs(e, &mut |x| {
-                if matches!(x, Expr::Call { .. } | Expr::New { .. }) {
-                    found = true;
+                // A call/new may throw; a NON-optional property/index read may throw a TypeError when
+                // the receiver is nullish (#425 — `get_prop`/`get_index` PARK it). Flagging these makes
+                // the emitted post-statement pending-throw checkpoint fire so the throw surfaces at the
+                // right scope (e.g. is caught by an enclosing `try` whose body is a pure read). Optional
+                // chaining (`a?.b`) yields null on a nullish receiver and never throws, so it's excluded.
+                match x {
+                    Expr::Call { .. } | Expr::New { .. } => found = true,
+                    Expr::Member { optional: false, .. } | Expr::Index { optional: false, .. } => {
+                        found = true
+                    }
+                    _ => {}
                 }
             });
         });

--- a/crates/tish_core/src/lib.rs
+++ b/crates/tish_core/src/lib.rs
@@ -171,6 +171,23 @@ pub fn not_a_function_error(message: impl Into<String>) -> Value {
     Value::object(e)
 }
 
+/// A catchable `TypeError` for reading a property/index of the nullish value — the `{ name, message }`
+/// shape matches the VM/interpreter/node (`e.name === "TypeError"`). Used to PARK a pending throw in
+/// the native/runtime `get_prop`/`get_index` null arm (#425), so `null.length` / `null[0]` surface a
+/// catchable error at the next pending-throw checkpoint instead of silently reading back `null`.
+pub fn cannot_read_property_error(prop: &str) -> Value {
+    let mut e = ObjectMap::default();
+    e.insert(
+        std::sync::Arc::from("name"),
+        Value::String("TypeError".into()),
+    );
+    e.insert(
+        std::sync::Arc::from("message"),
+        Value::String(format!("Cannot read property '{}' of null", prop).into()),
+    );
+    Value::object(e)
+}
+
 /// RAII frame for the depth-counting recursion guard: holding one means the depth was incremented;
 /// dropping it decrements, so early returns in generated code can't leak a level. #381
 pub struct CallDepthGuard(());

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -1289,6 +1289,15 @@ pub fn get_prop(obj: &Value, key: impl AsRef<str>) -> Value {
             }
             _ => Value::Null,
         },
+        // Reading a property of the nullish value is a JS TypeError. PARK a catchable throw (#425)
+        // and return the null sentinel; it surfaces at the next pending-throw checkpoint. This is the
+        // ONLY receiver that throws — a number/bool/function with no such property reads back `null`
+        // (JS `undefined`), matching the VM/interpreter/node. Free for valid reads: `Object` is matched
+        // first, so this cold arm never runs on the hot path.
+        Value::Null => {
+            tishlang_core::set_pending_throw(tishlang_core::cannot_read_property_error(key));
+            Value::Null
+        }
         _ => Value::Null,
     }
 }
@@ -1329,6 +1338,16 @@ pub fn get_index(obj: &Value, index: &Value) -> Value {
             Value::String(k) => get_prop(obj, k.as_str()),
             _ => Value::Null,
         },
+        // Indexing the nullish value throws a catchable TypeError (#425), like `get_prop` above —
+        // parked and surfaced at the next checkpoint. Every other receiver reads back `null`.
+        Value::Null => {
+            let key = match index {
+                Value::String(s) => s.to_string(),
+                other => other.to_js_string(),
+            };
+            tishlang_core::set_pending_throw(tishlang_core::cannot_read_property_error(&key));
+            Value::Null
+        }
         _ => Value::Null,
     }
 }
@@ -1904,5 +1923,63 @@ pub fn string_search_regex(s: &Value, regexp: &Value) -> Value {
             Err(_) => Value::Number(-1.0),
         },
         _ => Value::Number(-1.0),
+    }
+}
+
+#[cfg(test)]
+mod null_read_parking_tests_425 {
+    // Reading a property/index of the nullish value PARKS a catchable TypeError (#425) instead of
+    // silently reading back `null` — the native/runtime read paths. The throw surfaces at the caller's
+    // next pending-throw checkpoint. Every other receiver (number/bool/valid object/array) reads back
+    // a value with NO parked throw.
+    use super::{get_index, get_prop};
+    use tishlang_core::{has_pending_throw, take_pending_throw, Value, VmRef};
+
+    fn parked_name() -> Option<String> {
+        take_pending_throw().and_then(|v| {
+            if let Value::Object(o) = v {
+                if let Some(Value::String(s)) = o.borrow().strings.get("name") {
+                    return Some(s.to_string());
+                }
+            }
+            None
+        })
+    }
+
+    #[test]
+    fn get_prop_on_null_parks_type_error() {
+        let _ = take_pending_throw();
+        let r = get_prop(&Value::Null, "length");
+        assert!(matches!(r, Value::Null));
+        assert!(has_pending_throw());
+        assert_eq!(parked_name().as_deref(), Some("TypeError"));
+    }
+
+    #[test]
+    fn get_index_on_null_parks_type_error() {
+        let _ = take_pending_throw();
+        let r = get_index(&Value::Null, &Value::Number(0.0));
+        assert!(matches!(r, Value::Null));
+        assert!(has_pending_throw());
+        assert_eq!(parked_name().as_deref(), Some("TypeError"));
+    }
+
+    #[test]
+    fn valid_reads_do_not_park() {
+        let _ = take_pending_throw();
+        // object property, array index, and array length must NOT park a throw.
+        let obj = Value::object({
+            let mut m = tishlang_core::ObjectMap::default();
+            m.insert(std::sync::Arc::from("a"), Value::Number(42.0));
+            m
+        });
+        assert!(matches!(get_prop(&obj, "a"), Value::Number(n) if n == 42.0));
+        assert!(!has_pending_throw(), "valid property read must not park");
+        let arr = Value::Array(VmRef::new(vec![Value::Number(7.0)]));
+        assert!(matches!(get_index(&arr, &Value::Number(0.0)), Value::Number(n) if n == 7.0));
+        assert!(!has_pending_throw(), "valid index read must not park");
+        // a MISSING object property reads back null WITHOUT parking (JS `undefined`, not a throw).
+        assert!(matches!(get_prop(&obj, "missing"), Value::Null));
+        assert!(!has_pending_throw(), "missing property must not park");
     }
 }

--- a/tests/core/parity_null_read_catchable.js
+++ b/tests/core/parity_null_read_catchable.js
@@ -1,0 +1,47 @@
+// Reading a property or index of the nullish value throws a CATCHABLE TypeError on every backend +
+// node (interp/vm/cranelift/wasi already threw; native now parks a catchable throw — #425). Only
+// `e.name` is asserted (messages differ across engines). Catch-based so the parked-throw surfacing is
+// observed at the enclosing `try`. Valid in tish and node.
+
+// property read on null (try body contains a call)
+let a = "no-throw"
+try {
+  let z = null
+  console.log("unreachable " + z.length)
+} catch (e) { a = e.name }
+console.log("member-call", a)
+
+// property read on null — PURE read in the try body (no call): the throw must still be caught
+let b = "no-throw"
+try {
+  let z = null
+  let x = z.length
+  let y = x + 1
+} catch (e) { b = e.name }
+console.log("member-pure", b)
+
+// index read on null
+let c = "no-throw"
+try {
+  let z = null
+  let x = z[0]
+} catch (e) { c = e.name }
+console.log("index", c)
+
+// program keeps running after each catch
+console.log("survived", true)
+
+// valid reads are unaffected
+let o = { a: 42, b: 7 }
+console.log("valid-prop", o.a + o.b)
+let arr = [10, 20, 30]
+console.log("valid-index", arr[1])
+console.log("valid-len", arr.length)
+
+// an out-of-bounds array index does NOT throw (only a nullish RECEIVER throws)
+let e2 = "no-throw"
+try {
+  let arr2 = [1, 2, 3]
+  let x = arr2[9]
+} catch (e) { e2 = "threw" }
+console.log("oob-index-no-throw", e2)

--- a/tests/core/parity_null_read_catchable.tish
+++ b/tests/core/parity_null_read_catchable.tish
@@ -1,0 +1,47 @@
+// Reading a property or index of the nullish value throws a CATCHABLE TypeError on every backend +
+// node (interp/vm/cranelift/wasi already threw; native now parks a catchable throw — #425). Only
+// `e.name` is asserted (messages differ across engines). Catch-based so the parked-throw surfacing is
+// observed at the enclosing `try`. Valid in tish and node.
+
+// property read on null (try body contains a call)
+let a = "no-throw"
+try {
+  let z = null
+  console.log("unreachable " + z.length)
+} catch (e) { a = e.name }
+console.log("member-call", a)
+
+// property read on null — PURE read in the try body (no call): the throw must still be caught
+let b = "no-throw"
+try {
+  let z = null
+  let x = z.length
+  let y = x + 1
+} catch (e) { b = e.name }
+console.log("member-pure", b)
+
+// index read on null
+let c = "no-throw"
+try {
+  let z = null
+  let x = z[0]
+} catch (e) { c = e.name }
+console.log("index", c)
+
+// program keeps running after each catch
+console.log("survived", true)
+
+// valid reads are unaffected
+let o = { a: 42, b: 7 }
+console.log("valid-prop", o.a + o.b)
+let arr = [10, 20, 30]
+console.log("valid-index", arr[1])
+console.log("valid-len", arr.length)
+
+// an out-of-bounds array index does NOT throw (only a nullish RECEIVER throws)
+let e2 = "no-throw"
+try {
+  let arr2 = [1, 2, 3]
+  let x = arr2[9]
+} catch (e) { e2 = "threw" }
+console.log("oob-index-no-throw", e2)

--- a/tests/core/parity_null_read_catchable.tish.expected
+++ b/tests/core/parity_null_read_catchable.tish.expected
@@ -1,0 +1,8 @@
+member-call TypeError
+member-pure TypeError
+index TypeError
+survived true
+valid-prop 49
+valid-index 20
+valid-len 3
+oob-index-no-throw no-throw

--- a/tests/main.js
+++ b/tests/main.js
@@ -3559,6 +3559,56 @@ console.log("sieve", sieveCount(10000))
 }
 
 {
+// Reading a property or index of the nullish value throws a CATCHABLE TypeError on every backend +
+// node (interp/vm/cranelift/wasi already threw; native now parks a catchable throw — #425). Only
+// `e.name` is asserted (messages differ across engines). Catch-based so the parked-throw surfacing is
+// observed at the enclosing `try`. Valid in tish and node.
+
+// property read on null (try body contains a call)
+let a = "no-throw"
+try {
+  let z = null
+  console.log("unreachable " + z.length)
+} catch (e) { a = e.name }
+console.log("member-call", a)
+
+// property read on null — PURE read in the try body (no call): the throw must still be caught
+let b = "no-throw"
+try {
+  let z = null
+  let x = z.length
+  let y = x + 1
+} catch (e) { b = e.name }
+console.log("member-pure", b)
+
+// index read on null
+let c = "no-throw"
+try {
+  let z = null
+  let x = z[0]
+} catch (e) { c = e.name }
+console.log("index", c)
+
+// program keeps running after each catch
+console.log("survived", true)
+
+// valid reads are unaffected
+let o = { a: 42, b: 7 }
+console.log("valid-prop", o.a + o.b)
+let arr = [10, 20, 30]
+console.log("valid-index", arr[1])
+console.log("valid-len", arr.length)
+
+// an out-of-bounds array index does NOT throw (only a nullish RECEIVER throws)
+let e2 = "no-throw"
+try {
+  let arr2 = [1, 2, 3]
+  let x = arr2[9]
+} catch (e) { e2 = "threw" }
+console.log("oob-index-no-throw", e2)
+}
+
+{
 // Cross-backend parity: member access / method calls on numeric literals. `(255).toString(16)` must
 // compile to valid JS — emitting `255.toString(16)` is a JS syntax error (the lexer reads `255.` as
 // a float). The parens must be preserved for integer literals (and folded integer constants). Every

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3618,6 +3618,57 @@ console.log("sieve", sieveCount(10000))
 }
 __perf_run_core_parity_mixed_numeric_compare()
 
+fn __perf_run_core_parity_null_read_catchable() {
+// Reading a property or index of the nullish value throws a CATCHABLE TypeError on every backend +
+// node (interp/vm/cranelift/wasi already threw; native now parks a catchable throw — #425). Only
+// `e.name` is asserted (messages differ across engines). Catch-based so the parked-throw surfacing is
+// observed at the enclosing `try`. Valid in tish and node.
+
+// property read on null (try body contains a call)
+let a = "no-throw"
+try {
+  let z = null
+  console.log("unreachable " + z.length)
+} catch (e) { a = e.name }
+console.log("member-call", a)
+
+// property read on null — PURE read in the try body (no call): the throw must still be caught
+let b = "no-throw"
+try {
+  let z = null
+  let x = z.length
+  let y = x + 1
+} catch (e) { b = e.name }
+console.log("member-pure", b)
+
+// index read on null
+let c = "no-throw"
+try {
+  let z = null
+  let x = z[0]
+} catch (e) { c = e.name }
+console.log("index", c)
+
+// program keeps running after each catch
+console.log("survived", true)
+
+// valid reads are unaffected
+let o = { a: 42, b: 7 }
+console.log("valid-prop", o.a + o.b)
+let arr = [10, 20, 30]
+console.log("valid-index", arr[1])
+console.log("valid-len", arr.length)
+
+// an out-of-bounds array index does NOT throw (only a nullish RECEIVER throws)
+let e2 = "no-throw"
+try {
+  let arr2 = [1, 2, 3]
+  let x = arr2[9]
+} catch (e) { e2 = "threw" }
+console.log("oob-index-no-throw", e2)
+}
+__perf_run_core_parity_null_read_catchable()
+
 fn __perf_run_core_parity_number_methods() {
 // Cross-backend parity: member access / method calls on numeric literals. `(255).toString(16)` must
 // compile to valid JS — emitting `255.toString(16)` is a JS syntax error (the lexer reads `255.` as


### PR DESCRIPTION
Closes #425.

## What

On the **native (rust AOT)** backend, `null.length` / `null[0]` silently read back `null` — `tishlang_runtime::get_prop`/`get_index` fell through to `_ => Value::Null` for a null receiver. The VM / interpreter / cranelift / wasi / node all throw a `TypeError` here; native was the last outlier in the null-access cluster (companion to #422, which fixed the interpreter reads, and #424, which fixed the native `null.foo()` panic).

```js
let z = null
console.log(z.length)   // native: null  →  now: catchable TypeError (like everyone else)
```

## Fix

`get_prop`/`get_index` now **park a catchable** `{ name: "TypeError", message: "Cannot read property '…' of null" }` in the null arm and return the null sentinel — exactly like `value_call` (#424) and the recursion guard (#381). This is the **only** receiver that throws — a number/bool/function with a missing property still reads back `null` (JS `undefined`). Free on the hot path: `Object` is matched first, so the cold null arm never runs for a valid read.

**Surfacing.** `stmt_may_throw` now also flags **non-optional** property/index reads, so the emitted post-statement pending-throw checkpoint fires and the parked throw surfaces at the right scope — e.g. it's caught by an enclosing `try` whose body is a **pure read** (no call), which would otherwise let the throw escape. Optional chaining (`a?.b`) yields null and never throws, so it's excluded.

## Perf

The checkpoint is a single thread-local bool test + predicted-not-taken branch, and it's already suppressed in pure-numeric typed frames. Measured regression is **within noise**:

- dynamic property-read microbench (native): 38ms → 39ms
- `object_sum` gauntlet: unchanged at 2ms (typed struct access doesn't go through `get_prop`)

## Tests

- New all-six-backend fixture `tests/core/parity_null_read_catchable.tish` (+ `.js` twin + `.tish.expected`), catch-based — covers member read, index read, the **pure-read-in-try** case, survival-after-catch, valid reads, and OOB-index-no-throw. Bundle regenerated.
- `tish_runtime` unit tests: parks a `TypeError` on null; does **not** park on valid or missing-property reads.
- Full `test_mvp_programs` suite (interp/vm/native/cranelift/wasi/js) green; native gauntlet soundness clean (`typed==boxed==node`).

## Known minor imperfection

Because the throw is parked and surfaced at the next checkpoint (not mid-expression), a single-statement *use-then-throw* like `console.log(null.length)` may run the enclosing call before the checkpoint. In practice the common shapes (caught, or separate statements, or uncaught-at-top-level) all match node; a fully mid-expression throw would require a fallible `get_prop` ABI, which isn't worth the hot-path cost. Called out for transparency.

Relates to #381, #247.
