### PR TITLE
fix(native): guard strict-< fast-path pending-throw checkpoint in native-typed frames (fannkuch BUILD-FAIL)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -13984,7 +13984,16 @@ impl Codegen {
                         self.emit_native_fn_body(&statements[i])?;
                     } else {
                         self.emit_statement(&statements[i])?;
-                        if Self::stmt_may_throw(&statements[i]) && !Self::is_terminator_stmt(&statements[i]) {
+                        // Same guard as the primary emit site above: a native-typed frame
+                        // (`-> f64`/`-> Vec<..>`/`-> ()`) can't type the `Err`/`Value::Null` check, so
+                        // suppress it there — the parked throw still surfaces at the first Value/Result
+                        // frame up the chain. Without this guard the strict-`<` fast-path emitted an
+                        // untypeable checkpoint after any may-throw stmt (e.g. an index read post-#425),
+                        // breaking pure-numeric fixtures like fannkuch.
+                        if Self::stmt_may_throw(&statements[i])
+                            && !Self::is_terminator_stmt(&statements[i])
+                            && (self.try_closure_depth > 0 || !self.in_native_typed_frame())
+                        {
                             self.emit_pending_throw_check();
                         }
                     }

--- a/tests/core/native_typed_frame_index_read.tish
+++ b/tests/core/native_typed_frame_index_read.tish
@@ -1,0 +1,44 @@
+// Regression lock (#426 follow-up): a native-typed frame (`-> f64`) whose body hits the
+// `promote_strict_lt` fast-path — `if (a === b) { break }` — followed by an array INDEX READ in the
+// promoted region. Post-#425, a non-optional index read counts as may-throw, so codegen emits a
+// pending-throw checkpoint after it; in a native-typed frame that checkpoint (`return Err(..)` /
+// `return Value::Null`) does not type-check. The primary emit site guards against this; the strict-`<`
+// fast-path (Site 2) did NOT, so this shape failed to BUILD on the rust native backend (fannkuch).
+// This fixture is compiled on every backend by the integration harness (incl. native), so it catches
+// a recurrence in fast PR CI, not only the nightly gauntlet.
+
+function kernel(n) {
+  let arr = []
+  let i = 0
+  while (i < n) { arr.push(i * 2); i = i + 1 }
+  let sum = 0
+  let r = 0
+  while (true) {
+    if (r === n) { break }   // strict-eq-of-idents + break -> promote_strict_lt fast-path
+    let v = arr[r]           // index read in the promoted region -> Site 2 checkpoint
+    sum = sum + v
+    r = r + 1
+  }
+  return sum
+}
+
+// A second shape: strict-eq break that is NOT the immediate exit, with a nested index read.
+function scan(m) {
+  let a = []
+  let i = 0
+  while (i < m) { a.push(m - i); i = i + 1 }
+  let acc = 0
+  let k = 0
+  while (true) {
+    if (k === m) { break }
+    let t = a[k]
+    if (t === k) { acc = acc + 1 }
+    acc = acc + a[k]
+    k = k + 1
+  }
+  return acc
+}
+
+console.log("kernel", kernel(5))
+console.log("kernel0", kernel(0))
+console.log("scan", scan(4))

--- a/tests/core/native_typed_frame_index_read.tish.expected
+++ b/tests/core/native_typed_frame_index_read.tish.expected
@@ -1,0 +1,3 @@
+kernel 20
+kernel0 0
+scan 11


### PR DESCRIPTION
## Problem — `main` gauntlet soundness gate is red

The **Perf gauntlet (soundness)** workflow fails on `main`: fixture **`fannkuch` = BUILD-FAIL**, tripping the strict gate (`1 fixture(s) with a build/run/checksum failure`). CI history pins the regression to `03c8b715` ("catchable TypeError for null property/index reads (#425)(#426)"): the immediately preceding commit `f5dfc6de` was the last green gauntlet run.

## Root cause

`03c8b715` widened `Codegen::stmt_may_throw` so non-optional `Expr::Member` / `Expr::Index` reads now count as may-throw (they can park a catchable TypeError on a nullish receiver). That flag drives emission of a post-statement pending-throw checkpoint (`emit_pending_throw_check()`), which writes `return Err(..)` / `return Value::Null`.

`emit_statements_with_folds` has **two** checkpoint emit sites:
- the **primary** site is guarded with `&& (self.try_closure_depth > 0 || !self.in_native_typed_frame())` — it suppresses the checkpoint inside a native-typed frame (`-> f64` / `-> Vec<..>` / `-> ()`), where `return Err`/`Value::Null` don't type-check;
- the **`promote_strict_lt` strict-`<` fast-path** site was **missing that guard**.

`fannkuch` compiles to a native-typed `-> f64` frame, is full of integer index reads, and its loop shape hits the fast-path — so post-`03c8b715` it emitted `return Value::Null;` into an `f64` function → generated Rust fails to compile (`E0308: expected f64, found Result`). Pre-`03c8b715` the latent asymmetry never fired because `stmt_may_throw` only matched `Call`/`New`.

## Fix

Give the fast-path emit site the identical guard the primary site already has. No semantic change: in a native-typed frame the parked throw still propagates via the thread-local slot and surfaces at the first `Value`/`Result` frame up the chain — exactly the primary site's already-tested behavior.

## Regression lock

Adds `tests/core/native_typed_frame_index_read` (compiled on **every** backend by the integration harness, incl. native), reproducing the exact shape — a native-typed fn with an `if (a === b) { break }` loop followed by an array index read. Verified: **without** the guard it fails to build (`E0308`); **with** it, `interp == vm == native == wasi`.

## Verification

- `scripts/run_perf_gauntlet.sh --strict` (local): **SOUNDNESS clean** (typed==boxed==node), `fannkuch` back to **PASS**.
- `test_mvp_programs_{interpreter,vm,native,wasi}`: green (incl. the new fixture and the existing `parity_null_read_catchable` for #425). The `cranelift` variant hit the known crates.io download flake, unrelated to this change.