### PR TITLE
feat(parser): reject loose equality ==/!= at parse, uniformly (#244)

### DIFF
--- a/crates/tish/tests/shortcircuit.rs
+++ b/crates/tish/tests/shortcircuit.rs
@@ -9,7 +9,7 @@ use tishlang_vm;
 
 #[test]
 fn test_and_shortcircuit_emits_jump() {
-    let source = "let x = null; let y = x != null && x.foo;";
+    let source = "let x = null; let y = x !== null && x.foo;";
     let program = parse(source).expect("parse");
     let chunk = compile_unoptimized(&program).expect("compile");
     let code = &chunk.code;
@@ -22,7 +22,7 @@ fn test_and_shortcircuit_emits_jump() {
 
 #[test]
 fn test_and_shortcircuit_runs_unoptimized() {
-    let source = "let x = null; let y = x != null && x.foo;";
+    let source = "let x = null; let y = x !== null && x.foo;";
     let program = parse(source).expect("parse");
     let chunk = compile_unoptimized(&program).expect("compile");
     let result = tishlang_vm::run(&chunk);
@@ -35,7 +35,7 @@ fn test_and_shortcircuit_runs_unoptimized() {
 
 #[test]
 fn test_and_shortcircuit_runs_optimized() {
-    let source = "let x = null; let y = x != null && x.foo;";
+    let source = "let x = null; let y = x !== null && x.foo;";
     let program = parse(source).expect("parse");
     let program = tishlang_opt::optimize(&program);
     let chunk = tishlang_bytecode::compile(&program).expect("compile");

--- a/crates/tish_parser/src/lib.rs
+++ b/crates/tish_parser/src/lib.rs
@@ -60,6 +60,23 @@ mod tests {
         assert!(parse("fn f() { if (a) { if (b) { return 1 } } }").is_ok());
     }
 
+    /// #244: loose equality `==` / `!=` is rejected uniformly at parse (across every backend), with an
+    /// actionable message pointing at the strict form. `===` / `!==` still parse.
+    #[test]
+    fn loose_equality_is_rejected_at_parse() {
+        let eq = parse("let b = 1 == 1").unwrap_err();
+        assert!(eq.contains("'=='") && eq.contains("'==='"), "got: {eq}");
+        let ne = parse("let b = 1 != 2").unwrap_err();
+        assert!(ne.contains("'!='") && ne.contains("'!=='"), "got: {ne}");
+        // Rejected wherever an expression is parsed, not just at top level.
+        assert!(parse("fn f(x) { if (x == 0) { return 1 } return 0 }").is_err());
+        assert!(parse("let y = a != null && a.b").is_err());
+        // Strict forms are unaffected.
+        assert!(parse("let b = 1 === 1").is_ok());
+        assert!(parse("let b = 1 !== 2").is_ok());
+        assert!(parse("let y = a !== null && a.b").is_ok());
+    }
+
     #[test]
     fn test_async_fn_parse() {
         let program = parse("async fn foo() { }").expect("parse async fn");

--- a/crates/tish_parser/src/parser.rs
+++ b/crates/tish_parser/src/parser.rs
@@ -1977,9 +1977,54 @@ impl<'a> Parser<'a> {
     binary_single_op!(parse_bit_and, parse_shift, BitAnd, BinOp::BitAnd);
 
     binary_multi_op!(parse_shift, parse_equality, Shl => BinOp::Shl, Shr => BinOp::Shr, UShr => BinOp::UShr);
-    binary_multi_op!(parse_equality, parse_comparison,
-        StrictEq => BinOp::StrictEq, StrictNe => BinOp::StrictNe,
-        Eq => BinOp::Eq, Ne => BinOp::Ne);
+
+    // Loose equality `==` / `!=` is rejected at parse, uniformly across every backend (#244). Its
+    // coercion is a footgun, and leaving it accepted was a portability trap: interp/vm silently
+    // treated `==` as strict, the `--target js` backend emitted true JS loose `==` (so `1 == "1"`
+    // disagreed), and the native-rust backend refused to compile it. Only `===` / `!==` are accepted;
+    // `Eq` / `Ne` produce an actionable error pointing at the strict form. `StrictEq` / `StrictNe`
+    // parse exactly as the generic `binary_multi_op!` would.
+    fn parse_equality(&mut self) -> Result<Expr, String> {
+        let mut left = self.parse_comparison()?;
+        loop {
+            let op = match self.peek_kind() {
+                Some(TokenKind::StrictEq) => BinOp::StrictEq,
+                Some(TokenKind::StrictNe) => BinOp::StrictNe,
+                Some(TokenKind::Eq) => {
+                    let at = self
+                        .peek()
+                        .map(|t| format!("{:?}", t.span))
+                        .unwrap_or_else(|| "EOF".to_string());
+                    return Err(format!(
+                        "Loose equality '==' is not supported — use strict '===' (at {})",
+                        at
+                    ));
+                }
+                Some(TokenKind::Ne) => {
+                    let at = self
+                        .peek()
+                        .map(|t| format!("{:?}", t.span))
+                        .unwrap_or_else(|| "EOF".to_string());
+                    return Err(format!(
+                        "Loose inequality '!=' is not supported — use strict '!==' (at {})",
+                        at
+                    ));
+                }
+                _ => break,
+            };
+            self.advance();
+            let right = self.parse_comparison()?;
+            let start = expr_span(&left).start;
+            let end = expr_span(&right).end;
+            left = Expr::Binary {
+                left: Box::new(left),
+                op,
+                right: Box::new(right),
+                span: Span { start, end },
+            };
+        }
+        Ok(left)
+    }
     binary_multi_op!(parse_comparison, parse_term,
         Lt => BinOp::Lt, Le => BinOp::Le, Gt => BinOp::Gt, Ge => BinOp::Ge, In => BinOp::In);
     binary_multi_op!(parse_term, parse_factor, Plus => BinOp::Add, Minus => BinOp::Sub);

--- a/crates/tish_resolve/src/lib.rs
+++ b/crates/tish_resolve/src/lib.rs
@@ -4657,7 +4657,7 @@ mod tests {
 
     #[test]
     fn mutual_recursion_not_unresolved_or_unused() {
-        let src = "fn even(n) { if (n == 0) { return true } return odd(n - 1) }\nfn odd(n) { if (n == 0) { return false } return even(n - 1) }\neven(10)\n";
+        let src = "fn even(n) { if (n === 0) { return true } return odd(n - 1) }\nfn odd(n) { if (n === 0) { return false } return even(n - 1) }\neven(10)\n";
         let program = parse(src).expect("parse");
         assert!(
             collect_unresolved_identifiers(&program).is_empty(),

--- a/crates/tish_vm/src/jit.rs
+++ b/crates/tish_vm/src/jit.rs
@@ -3634,7 +3634,7 @@ mod tests {
     #[test]
     fn osr_region_handles_branches() {
         let chunk = top_chunk(
-            "let s = 0.0\nlet i = 0.0\nwhile (i < 20.0) { if (i % 2.0 == 0.0) { s = s + i }; i = i + 1.0 }\n",
+            "let s = 0.0\nlet i = 0.0\nwhile (i < 20.0) { if (i % 2.0 === 0.0) { s = s + i }; i = i + 1.0 }\n",
         );
         let (header, end) = first_region(&chunk);
         let lf =

--- a/examples/tty/keys.tish
+++ b/examples/tty/keys.tish
@@ -12,13 +12,13 @@ if (!isTTY()) {
   let running = true
   while (running) {
     let ev = read(200)          // poll with a 200ms timeout (non-blocking-ish)
-    if (ev == null) { continue } // nothing this tick
-    if (ev.type == "key") {
+    if (ev === null) { continue } // nothing this tick
+    if (ev.type === "key") {
       console.log("key:", ev.key, "ctrl:", ev.ctrl, "alt:", ev.alt, "shift:", ev.shift)
-      if (ev.key == "q") { running = false }
-      if (ev.ctrl && ev.key == "c") { running = false }
+      if (ev.key === "q") { running = false }
+      if (ev.ctrl && ev.key === "c") { running = false }
     }
-    if (ev.type == "resize") {
+    if (ev.type === "resize") {
       console.log("resize:", ev.cols, "x", ev.rows)
     }
   }

--- a/tests/core/jit_regression.tish
+++ b/tests/core/jit_regression.tish
@@ -31,8 +31,8 @@ console.log(a.filter(x => x % 2 === 1).join(","));  // 1,3,5
 console.log(a.reduce((s, x) => s + x, 0));         // 15
 console.log(a.reduce((s, x) => s + x * x, 0));     // 55
 
-// --- loose ==/!= behave as strict, consistent across all backends (was an interp error) ---
-console.log((1 == 1) + "," + (2 == 2) + "," + (1 == 2) + "," + ("a" == "a") + "," + (1 != 2));  // true,true,false,true,true
+// --- strict ===/!== consistent across all backends (loose ==/!= is rejected at parse, #244) ---
+console.log((1 === 1) + "," + (2 === 2) + "," + (1 === 2) + "," + ("a" === "a") + "," + (1 !== 2));  // true,true,false,true,true
 
 // --- object key order: insertion order (PropMap), matches JS/Node ---
 // (regression: was hash order; JSON used to sort keys alphabetically)

--- a/tests/shortcircuit.tish
+++ b/tests/shortcircuit.tish
@@ -1,3 +1,3 @@
 let x = null
-let y = x != null && x.foo
+let y = x !== null && x.foo
 console.log("y=" + String(y))


### PR DESCRIPTION
Closes #244.

## Problem

Loose `==`/`!=` was a portability trap — it behaved **three different ways** depending on backend:

| backend | `1 == "1"` |
|---|---|
| `tish run` (interp) / vm | `false` (silently treated `==` as strict `===`) |
| `--target js` | `true` (emitted **real JS loose `==`**) |
| native **rust** | **build error** ("Loose equality not supported") |

So code that passed `tish run` could behave differently — or fail to compile — on another target.

## Fix

Reject `==`/`!=` at the single parse choke point (`parse_equality`), uniformly across every backend, with an actionable message:

```
Loose equality '==' is not supported — use strict '===' (at Span { start: (2, 7), end: (2, 9) })
```

Only `===`/`!==` are accepted. This removes the operator (per the issue title) rather than reconciling three incompatible semantics, and matches tish's strict / no-`undefined` design.

## Note — this reverses prior work (flagging for the merge decision)

There was a deliberate earlier change making `==` behave as strict (the interp/vm `Eq => strict_eq` mappings + the `jit_regression` `==` probe with the comment *"loose ==/!= behave as strict … was an interp error"*). That unified interp==vm but left the **JS-target** (`==` loose) and **native-rust** (won't compile) divergences unfixed. #244's direction is to reject instead. The now-unreachable `Eq`/`Ne` arms in the interp/vm/native codegens are kept as exhaustive-match backstops (not removed).

## Sweep

Converted the genuine loose `==`/`!=` in the repo's own tish + embedded-tish-in-Rust programs to `===`/`!==`:
- `examples/tty/keys.tish`, `tests/shortcircuit.tish`, `tests/core/jit_regression.tish`
- embedded test programs in `tish_resolve`, `tish_vm` (jit), `tish/tests/shortcircuit.rs`

No perf/module/http fixture used loose `==` (bundle unchanged). The `tests/test262/*.js` JS-conformance files that test `==` are reference files not run through tish's parser.

## Verification
- New parser unit test `loose_equality_is_rejected_at_parse` (rejection + strict-form hint; `===`/`!==` still parse) — green.
- `test_mvp_programs_{interpreter,vm,native,cranelift,wasi}`: **6/6 green** (incl. converted `jit_regression`).
- `===`/`!==` compile + run on the native backend.