### PR TITLE
feat(parser): for...in loops as a first-class statement (#413)

### DIFF
--- a/crates/tish_ast/src/ast.rs
+++ b/crates/tish_ast/src/ast.rs
@@ -231,6 +231,16 @@ pub enum Statement {
         body: Box<Statement>,
         span: Span,
     },
+    /// `for (let k in object)` — iterates the object's own enumerable keys (JS `for-in` semantics).
+    /// Distinct from `ForOf` (which iterates values). Kept as a first-class node so every backend
+    /// enumerates keys consistently and `tish fmt` round-trips `for-in`.
+    ForIn {
+        name: Arc<str>,
+        name_span: Span,
+        object: Expr,
+        body: Box<Statement>,
+        span: Span,
+    },
     Return {
         value: Option<Expr>,
         span: Span,
@@ -653,6 +663,7 @@ impl Statement {
             | Statement::While { span, .. }
             | Statement::For { span, .. }
             | Statement::ForOf { span, .. }
+            | Statement::ForIn { span, .. }
             | Statement::Return { span, .. }
             | Statement::Break { span, .. }
             | Statement::Continue { span, .. }

--- a/crates/tish_builtins/src/globals.rs
+++ b/crates/tish_builtins/src/globals.rs
@@ -120,16 +120,28 @@ pub fn string_from_char_code(args: &[Value]) -> Value {
 
 /// Object.keys(obj)
 pub fn object_keys(args: &[Value]) -> Value {
-    if let Some(Value::Object(obj)) = args.first() {
-        let obj_borrow = obj.borrow();
-        let keys: Vec<Value> = obj_borrow
-            .strings
-            .keys()
-            .map(|k| Value::String(tishlang_core::ArcStr::from(k.as_ref())))
-            .collect();
-        Value::Array(VmRef::new(keys))
-    } else {
-        Value::Array(VmRef::new(Vec::new()))
+    match args.first() {
+        Some(Value::Object(obj)) => {
+            let obj_borrow = obj.borrow();
+            let keys: Vec<Value> = obj_borrow
+                .strings
+                .keys()
+                .map(|k| Value::String(tishlang_core::ArcStr::from(k.as_ref())))
+                .collect();
+            Value::Array(VmRef::new(keys))
+        }
+        // `Object.keys(array)` yields the index strings "0".."len-1" (an array's own enumerable keys
+        // are its indices, per JS). Previously returned `[]` — a node divergence, and the reason
+        // `for (k in array)` enumerated nothing on the vm/native backends (they lower for-in to
+        // for-of over `Object.keys`).
+        Some(Value::Array(arr)) => {
+            let len = arr.borrow().len();
+            let keys: Vec<Value> = (0..len)
+                .map(|i| Value::String(tishlang_core::ArcStr::from(i.to_string().as_str())))
+                .collect();
+            Value::Array(VmRef::new(keys))
+        }
+        _ => Value::Array(VmRef::new(Vec::new())),
     }
 }
 

--- a/crates/tish_bytecode/src/compiler.rs
+++ b/crates/tish_bytecode/src/compiler.rs
@@ -334,10 +334,16 @@ fn stmt_rebinds(s: &Statement, name: &str) -> bool {
         }
         Statement::ForOf {
             name: n,
-            iterable,
+            iterable: e,
             body,
             ..
-        } => n.as_ref() == name || expr_rebinds(iterable, name) || stmt_rebinds(body, name),
+        }
+        | Statement::ForIn {
+            name: n,
+            object: e,
+            body,
+            ..
+        } => n.as_ref() == name || expr_rebinds(e, name) || stmt_rebinds(body, name),
         Statement::Switch {
             expr,
             cases,
@@ -504,10 +510,16 @@ fn name_rebinds_in_stmt(s: &Statement, name: &str) -> bool {
         }
         Statement::ForOf {
             name: n,
-            iterable,
+            iterable: e,
             body,
             ..
-        } => n.as_ref() == name || expr_rebinds(iterable, name) || name_rebinds_in_stmt(body, name),
+        }
+        | Statement::ForIn {
+            name: n,
+            object: e,
+            body,
+            ..
+        } => n.as_ref() == name || expr_rebinds(e, name) || name_rebinds_in_stmt(body, name),
         Statement::Switch {
             expr,
             cases,
@@ -1802,6 +1814,46 @@ impl<'a> Compiler<'a> {
                 }
                 self.emit(Opcode::LoopVarsEnd);
                 self.exit_block_scope();
+            }
+            Statement::ForIn {
+                name,
+                name_span,
+                object,
+                body,
+                span,
+            } => {
+                // Lower `for (let k in obj)` to `for (let k of Object.keys(obj))` (#413): Object.keys
+                // yields exactly the own enumerable keys the interpreter enumerates — insertion order
+                // for objects, index strings for arrays, and `[]` for a non-object (so `for (k in
+                // null)` no-ops). Reuses the whole for-of iteration path.
+                let dummy = Span {
+                    start: (0, 0),
+                    end: (0, 0),
+                };
+                let keys_call = Expr::Call {
+                    callee: Box::new(Expr::Member {
+                        object: Box::new(Expr::Ident {
+                            name: Arc::from("Object"),
+                            span: dummy,
+                        }),
+                        prop: MemberProp::Name {
+                            name: Arc::from("keys"),
+                            span: dummy,
+                        },
+                        optional: false,
+                        span: dummy,
+                    }),
+                    args: vec![CallArg::Expr(object.clone())],
+                    span: dummy,
+                };
+                let lowered = Statement::ForOf {
+                    name: Arc::clone(name),
+                    name_span: *name_span,
+                    iterable: keys_call,
+                    body: body.clone(),
+                    span: *span,
+                };
+                self.compile_statement(&lowered)?;
             }
             Statement::Return { value, .. } => {
                 // Evaluate the return value first (JS order), then run any enclosing `finally`

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -79,7 +79,12 @@ impl UsageAnalyzer {
                 }
                 self.analyze_statement(body);
             }
-            Statement::ForOf { iterable, body, .. } => {
+            Statement::ForOf { iterable, body, .. }
+            | Statement::ForIn {
+                object: iterable,
+                body,
+                ..
+            } => {
                 self.analyze_expr(iterable);
                 self.analyze_statement(body);
             }
@@ -330,6 +335,7 @@ fn program_uses_async(program: &Program) -> bool {
             Statement::While { body, .. }
             | Statement::For { body, .. }
             | Statement::ForOf { body, .. }
+            | Statement::ForIn { body, .. }
             | Statement::DoWhile { body, .. } => stmt_has_async(body),
             Statement::Switch {
                 cases,
@@ -464,7 +470,12 @@ fn program_uses_async(program: &Program) -> bool {
                     || update.as_ref().is_some_and(expr_has_await)
                     || stmt_has_await(body)
             }
-            Statement::ForOf { iterable, body, .. } => {
+            Statement::ForOf { iterable, body, .. }
+            | Statement::ForIn {
+                object: iterable,
+                body,
+                ..
+            } => {
                 expr_has_await(iterable) || stmt_has_await(body)
             }
             Statement::Return { value, .. } => value.as_ref().is_some_and(expr_has_await),
@@ -1308,6 +1319,7 @@ impl Codegen {
                 }
                 Statement::For { body, .. }
                 | Statement::ForOf { body, .. }
+            | Statement::ForIn { body, .. }
                 | Statement::While { body, .. }
                 | Statement::DoWhile { body, .. } => {
                     Self::walk_type_aliases(std::slice::from_ref(body.as_ref()), out);
@@ -4805,6 +4817,46 @@ impl Codegen {
                 self.indent -= 1;
                 self.writeln("}");
             }
+            Statement::ForIn {
+                name,
+                name_span,
+                object,
+                body,
+                span,
+            } => {
+                // Lower `for (let k in obj)` to `for (let k of Object.keys(obj))` (#413) and reuse the
+                // native for-of emission. Object.keys yields the own enumerable keys the interpreter
+                // enumerates (insertion order for objects, index strings for arrays, `[]` for a
+                // non-object → `for (k in null)` no-ops).
+                let dummy = Span {
+                    start: (0, 0),
+                    end: (0, 0),
+                };
+                let keys_call = Expr::Call {
+                    callee: Box::new(Expr::Member {
+                        object: Box::new(Expr::Ident {
+                            name: Arc::from("Object"),
+                            span: dummy,
+                        }),
+                        prop: MemberProp::Name {
+                            name: Arc::from("keys"),
+                            span: dummy,
+                        },
+                        optional: false,
+                        span: dummy,
+                    }),
+                    args: vec![CallArg::Expr(object.clone())],
+                    span: dummy,
+                };
+                let lowered = Statement::ForOf {
+                    name: Arc::clone(name),
+                    name_span: *name_span,
+                    iterable: keys_call,
+                    body: body.clone(),
+                    span: *span,
+                };
+                self.emit_statement(&lowered)?;
+            }
             Statement::ForOf {
                 name,
                 iterable,
@@ -8175,7 +8227,12 @@ impl Codegen {
                 }
                 Self::collect_assigned_idents_in_stmt(body, names);
             }
-            Statement::ForOf { iterable, body, .. } => {
+            Statement::ForOf { iterable, body, .. }
+            | Statement::ForIn {
+                object: iterable,
+                body,
+                ..
+            } => {
                 Self::collect_assigned_idents_in_expr(iterable, names);
                 Self::collect_assigned_idents_in_stmt(body, names);
             }
@@ -8311,7 +8368,12 @@ impl Codegen {
                     || update.as_ref().is_some_and(|u| Self::expr_has_length_changer(u))
                     || Self::stmt_has_length_changer(body)
             }
-            Statement::ForOf { iterable, body, .. } => {
+            Statement::ForOf { iterable, body, .. }
+            | Statement::ForIn {
+                object: iterable,
+                body,
+                ..
+            } => {
                 Self::expr_has_length_changer(iterable) || Self::stmt_has_length_changer(body)
             }
             Statement::While { cond, body, .. } | Statement::DoWhile { body, cond, .. } => {
@@ -8448,7 +8510,12 @@ impl Codegen {
                     || update.as_ref().is_some_and(|u| Self::expr_changes_base_len(u, base))
                     || Self::stmt_changes_base_len(body, base)
             }
-            Statement::ForOf { iterable, body, .. } => {
+            Statement::ForOf { iterable, body, .. }
+            | Statement::ForIn {
+                object: iterable,
+                body,
+                ..
+            } => {
                 Self::expr_changes_base_len(iterable, base) || Self::stmt_changes_base_len(body, base)
             }
             Statement::While { cond, body, .. } | Statement::DoWhile { body, cond, .. } => {
@@ -8857,7 +8924,12 @@ impl Codegen {
                 }
                 Self::collect_captured_block_vars_from_statements(body, block_vars, result);
             }
-            Statement::ForOf { iterable, body, .. } => {
+            Statement::ForOf { iterable, body, .. }
+            | Statement::ForIn {
+                object: iterable,
+                body,
+                ..
+            } => {
                 Self::collect_captured_block_vars_from_expr(iterable, block_vars, result);
                 Self::collect_captured_block_vars_from_statements(body, block_vars, result);
             }
@@ -8995,7 +9067,8 @@ impl Codegen {
                 }
                 Self::collect_local_var_names(body, names);
             }
-            Statement::ForOf { body, .. } => Self::collect_local_var_names(body, names),
+            Statement::ForOf { body, .. }
+            | Statement::ForIn { body, .. } => Self::collect_local_var_names(body, names),
             Statement::While { body, .. } | Statement::DoWhile { body, .. } => {
                 Self::collect_local_var_names(body, names);
             }
@@ -9261,7 +9334,12 @@ impl Codegen {
                 }
                 Self::collect_stmt_idents(body, idents);
             }
-            Statement::ForOf { iterable, body, .. } => {
+            Statement::ForOf { iterable, body, .. }
+            | Statement::ForIn {
+                object: iterable,
+                body,
+                ..
+            } => {
                 Self::collect_expr_idents(iterable, idents);
                 Self::collect_stmt_idents(body, idents);
             }
@@ -12391,6 +12469,7 @@ impl Codegen {
             }
             Statement::For { body, .. }
             | Statement::ForOf { body, .. }
+            | Statement::ForIn { body, .. }
             | Statement::While { body, .. }
             | Statement::DoWhile { body, .. } => {
                 Self::collect_ordered_assigns_to(body, var, out)
@@ -12415,6 +12494,7 @@ impl Codegen {
             }
             Statement::For { body, .. }
             | Statement::ForOf { body, .. }
+            | Statement::ForIn { body, .. }
             | Statement::While { body, .. }
             | Statement::DoWhile { body, .. }
             | Statement::FunDecl { body, .. } => f(std::slice::from_ref(body)),
@@ -12480,7 +12560,12 @@ impl Codegen {
                 }
                 Self::for_each_stmt_expr(body, f);
             }
-            Statement::ForOf { iterable, body, .. } => {
+            Statement::ForOf { iterable, body, .. }
+            | Statement::ForIn {
+                object: iterable,
+                body,
+                ..
+            } => {
                 f(iterable);
                 Self::for_each_stmt_expr(body, f);
             }
@@ -12893,7 +12978,11 @@ impl Codegen {
                         Self::collect_annotated_types(std::slice::from_ref(e), aliases, env);
                     }
                 }
-                Statement::While { body, .. } | Statement::DoWhile { body, .. } => {
+                // for-in's loop var is always a string key, so it gets no Vec-element type binding —
+                // it behaves like while/do-while here (recurse the body only).
+                Statement::While { body, .. }
+                | Statement::DoWhile { body, .. }
+                | Statement::ForIn { body, .. } => {
                     Self::collect_annotated_types(std::slice::from_ref(body), aliases, env)
                 }
                 Statement::ForOf {
@@ -13037,7 +13126,12 @@ impl Codegen {
                 }
                 Self::collect_reassignments_stmt(body, out);
             }
-            Statement::ForOf { iterable, body, .. } => {
+            Statement::ForOf { iterable, body, .. }
+            | Statement::ForIn {
+                object: iterable,
+                body,
+                ..
+            } => {
                 Self::collect_reassignments_expr(iterable, out);
                 Self::collect_reassignments_stmt(body, out);
             }
@@ -14124,7 +14218,8 @@ impl Codegen {
                 }
                 Self::walk_stmt_for_module_const_disqualifiers(body, g, bad);
             }
-            Statement::ForOf { body, .. } => {
+            Statement::ForOf { body, .. }
+            | Statement::ForIn { body, .. } => {
                 Self::walk_stmt_for_module_const_disqualifiers(body, g, bad);
             }
             Statement::Switch {
@@ -14874,7 +14969,8 @@ impl Codegen {
             Statement::While { body, .. }
             | Statement::DoWhile { body, .. }
             | Statement::For { body, .. }
-            | Statement::ForOf { body, .. } => {
+            | Statement::ForOf { body, .. }
+            | Statement::ForIn { body, .. } => {
                 Self::walk_stmt_for_global_disqualifiers(body, g, bad);
             }
             Statement::Switch {
@@ -15114,7 +15210,12 @@ impl Codegen {
                 f(cond);
                 Self::for_each_expr_root_stmt(body, f);
             }
-            Statement::ForOf { iterable, body, .. } => {
+            Statement::ForOf { iterable, body, .. }
+            | Statement::ForIn {
+                object: iterable,
+                body,
+                ..
+            } => {
                 f(iterable);
                 Self::for_each_expr_root_stmt(body, f);
             }
@@ -18334,7 +18435,8 @@ impl Codegen {
             Statement::While { body, .. }
             | Statement::DoWhile { body, .. }
             | Statement::For { body, .. }
-            | Statement::ForOf { body, .. } => Self::rec_collect_returns(body, out),
+            | Statement::ForOf { body, .. }
+            | Statement::ForIn { body, .. } => Self::rec_collect_returns(body, out),
             _ => {}
         }
     }
@@ -18478,7 +18580,8 @@ impl Codegen {
             }
             Statement::While { body, .. }
             | Statement::DoWhile { body, .. }
-            | Statement::ForOf { body, .. } => Self::rec_orch_binds_node(body, builders),
+            | Statement::ForOf { body, .. }
+            | Statement::ForIn { body, .. } => Self::rec_orch_binds_node(body, builders),
             Statement::For { init, body, .. } => {
                 init.as_ref()
                     .is_some_and(|i| Self::rec_orch_binds_node(i, builders))
@@ -20562,7 +20665,8 @@ impl Codegen {
             }
             Statement::While { body, .. }
             | Statement::DoWhile { body, .. }
-            | Statement::ForOf { body, .. } => Self::agg_collect_aliases(body, p, out),
+            | Statement::ForOf { body, .. }
+            | Statement::ForIn { body, .. } => Self::agg_collect_aliases(body, p, out),
             _ => {}
         }
     }
@@ -20590,7 +20694,8 @@ impl Codegen {
             Statement::For { body, .. }
             | Statement::While { body, .. }
             | Statement::DoWhile { body, .. }
-            | Statement::ForOf { body, .. } => Self::agg_stmt_writes(body, p, aliases),
+            | Statement::ForOf { body, .. }
+            | Statement::ForIn { body, .. } => Self::agg_stmt_writes(body, p, aliases),
             _ => false,
         }
     }
@@ -20714,7 +20819,8 @@ impl Codegen {
             Statement::For { body, .. }
             | Statement::While { body, .. }
             | Statement::DoWhile { body, .. }
-            | Statement::ForOf { body, .. } => Self::stmt_returns_value(body),
+            | Statement::ForOf { body, .. }
+            | Statement::ForIn { body, .. } => Self::stmt_returns_value(body),
             _ => false,
         }
     }

--- a/crates/tish_compile/src/infer.rs
+++ b/crates/tish_compile/src/infer.rs
@@ -1220,7 +1220,7 @@ fn check_returns_numeric(s: &Statement, ctx: &InferCtx, ok: &mut bool) {
                 check_returns_numeric(e, ctx, ok);
             }
         }
-        While { body, .. } | DoWhile { body, .. } | ForOf { body, .. } => {
+        While { body, .. } | DoWhile { body, .. } | ForOf { body, .. } | ForIn { body, .. } => {
             check_returns_numeric(body, ctx, ok);
         }
         For { init, body, .. } => {
@@ -1319,7 +1319,12 @@ fn count_uses_stmt(s: &Statement, f: &str, calls: &mut usize, others: &mut usize
             }
             count_uses_stmt(body, f, calls, others);
         }
-        ForOf { iterable, body, .. } => {
+        ForOf { iterable, body, .. }
+        | ForIn {
+            object: iterable,
+            body,
+            ..
+        } => {
             count_uses_expr(iterable, f, calls, others);
             count_uses_stmt(body, f, calls, others);
         }
@@ -1522,7 +1527,7 @@ fn stmt_contains_fundecl(s: &Statement) -> bool {
             stmt_contains_fundecl(then_branch)
                 || else_branch.as_ref().is_some_and(|e| stmt_contains_fundecl(e))
         }
-        While { body, .. } | DoWhile { body, .. } | For { body, .. } | ForOf { body, .. } => {
+        While { body, .. } | DoWhile { body, .. } | For { body, .. } | ForOf { body, .. } | ForIn { body, .. } => {
             stmt_contains_fundecl(body)
         }
         Try { body, catch_body, finally_body, .. } => {
@@ -1574,7 +1579,12 @@ fn walk_exprs_stmt_full(s: &Statement, f: &mut impl FnMut(&Expr)) {
             }
             walk_exprs_stmt_full(body, f);
         }
-        ForOf { iterable, body, .. } => {
+        ForOf { iterable, body, .. }
+        | ForIn {
+            object: iterable,
+            body,
+            ..
+        } => {
             walk_exprs_expr(iterable, f);
             walk_exprs_stmt_full(body, f);
         }
@@ -1639,7 +1649,7 @@ fn count_returns(s: &Statement) -> usize {
             count_returns(then_branch)
                 + else_branch.as_ref().map_or(0, |e| count_returns(e))
         }
-        While { body, .. } | DoWhile { body, .. } | For { body, .. } | ForOf { body, .. } => {
+        While { body, .. } | DoWhile { body, .. } | For { body, .. } | ForOf { body, .. } | ForIn { body, .. } => {
             count_returns(body)
         }
         Try { body, catch_body, finally_body, .. } => {
@@ -2694,7 +2704,7 @@ fn seed_numeric_locals(s: &Statement, hyp: &mut InferCtx) {
             }
             seed_numeric_locals(body, hyp);
         }
-        While { body, .. } | DoWhile { body, .. } | ForOf { body, .. } => {
+        While { body, .. } | DoWhile { body, .. } | ForOf { body, .. } | ForIn { body, .. } => {
             seed_numeric_locals(body, hyp)
         }
         _ => {}
@@ -3649,7 +3659,7 @@ fn collect_return_shapes(
                 }
             }
         }
-        For { body, .. } | While { body, .. } | DoWhile { body, .. } | ForOf { body, .. } => {
+        For { body, .. } | While { body, .. } | DoWhile { body, .. } | ForOf { body, .. } | ForIn { body, .. } => {
             if !collect_return_shapes(body, pctx, found, ok) {
                 return false;
             }
@@ -3916,7 +3926,7 @@ fn collect_element_aliases(s: &Statement, p: &str, out: &mut HashSet<String>) {
             }
             collect_element_aliases(body, p, out);
         }
-        While { body, .. } | DoWhile { body, .. } | ForOf { body, .. } => {
+        While { body, .. } | DoWhile { body, .. } | ForOf { body, .. } | ForIn { body, .. } => {
             collect_element_aliases(body, p, out)
         }
         _ => {}
@@ -4241,7 +4251,12 @@ fn walk_exprs_stmt(s: &Statement, f: &mut impl FnMut(&Expr)) {
             }
             walk_exprs_stmt(body, f);
         }
-        ForOf { iterable, body, .. } => {
+        ForOf { iterable, body, .. }
+        | ForIn {
+            object: iterable,
+            body,
+            ..
+        } => {
             walk_exprs_expr(iterable, f);
             walk_exprs_stmt(body, f);
         }
@@ -4354,7 +4369,7 @@ fn collect_body_struct_locals(
                 collect_body_struct_locals(e, analysis, out);
             }
         }
-        For { body, .. } | While { body, .. } | DoWhile { body, .. } | ForOf { body, .. } => {
+        For { body, .. } | While { body, .. } | DoWhile { body, .. } | ForOf { body, .. } | ForIn { body, .. } => {
             collect_body_struct_locals(body, analysis, out)
         }
         _ => {}
@@ -4388,7 +4403,7 @@ fn find_array_return(s: &Statement, locals: &HashMap<String, String>) -> Option<
         }
         If { then_branch, else_branch, .. } => find_array_return(then_branch, locals)
             .or_else(|| else_branch.as_ref().and_then(|e| find_array_return(e, locals))),
-        For { body, .. } | While { body, .. } | DoWhile { body, .. } | ForOf { body, .. } => {
+        For { body, .. } | While { body, .. } | DoWhile { body, .. } | ForOf { body, .. } | ForIn { body, .. } => {
             find_array_return(body, locals)
         }
         _ => None,

--- a/crates/tish_compile/src/resolve.rs
+++ b/crates/tish_compile/src/resolve.rs
@@ -238,9 +238,12 @@ pub fn program_uses_document(program: &Program) -> bool {
                     || update.as_ref().is_some_and(expr_uses_document)
                     || stmt_uses_document(body)
             }
-            Statement::ForOf { iterable, body, .. } => {
-                expr_uses_document(iterable) || stmt_uses_document(body)
-            }
+            Statement::ForOf { iterable, body, .. }
+            | Statement::ForIn {
+                object: iterable,
+                body,
+                ..
+            } => expr_uses_document(iterable) || stmt_uses_document(body),
             Statement::Switch {
                 expr,
                 cases,
@@ -1463,6 +1466,12 @@ pub(crate) fn rewrite_stmt_scope(
         Statement::ForOf {
             name,
             iterable,
+            body,
+            ..
+        }
+        | Statement::ForIn {
+            name,
+            object: iterable,
             body,
             ..
         } => {

--- a/crates/tish_compile_js/src/codegen.rs
+++ b/crates/tish_compile_js/src/codegen.rs
@@ -376,6 +376,19 @@ impl Codegen {
                 self.writeln(&format!("for (const {} of {})", escaped, it));
                 self.emit_js_control_body(body)?;
             }
+            Statement::ForIn {
+                name,
+                object,
+                body,
+                ..
+            } => {
+                // Native JS `for-in` — iterates own enumerable keys (#413). tish objects have no
+                // prototype chain, so this matches the key-enumeration the other backends perform.
+                let escaped = Self::escape_ident(name.as_ref());
+                let obj = self.emit_expr(object)?;
+                self.writeln(&format!("for (const {} in {})", escaped, obj));
+                self.emit_js_control_body(body)?;
+            }
             Statement::Return { value, .. } => {
                 if let Some(v) = value {
                     let e = self.emit_expr(v)?;

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -660,6 +660,51 @@ impl Evaluator {
                 self.scope = outer;
                 ret
             }
+            Statement::ForIn {
+                name,
+                object,
+                body,
+                ..
+            } => {
+                let obj_val = self.eval_expr(object)?;
+                // for-in enumerates OWN ENUMERABLE KEYS as strings (JS semantics): objects yield keys
+                // in insertion order, arrays yield index strings "0".."len-1", and a non-object
+                // (incl. null) yields nothing — a no-op, matching JS `for (k in null)`.
+                let keys: Vec<crate::value::Value> = match &obj_val {
+                    crate::value::Value::Object(obj) => obj
+                        .borrow()
+                        .strings
+                        .keys()
+                        .map(|k| crate::value::Value::String(Arc::clone(k)))
+                        .collect(),
+                    crate::value::Value::Array(arr) => {
+                        let len = arr.borrow().len();
+                        (0..len)
+                            .map(|i| crate::value::Value::String(Arc::from(i.to_string())))
+                            .collect()
+                    }
+                    _ => Vec::new(),
+                };
+                // Fresh per-iteration binding (ES6 `for (let k in …)`), like the for-of arm above.
+                let outer = Rc::clone(&self.scope);
+                let mut ret = Ok(Value::Null);
+                for key in keys {
+                    let iter_env = Scope::child(Rc::clone(&outer));
+                    iter_env.borrow_mut().set(Arc::clone(name), key, true);
+                    self.scope = Rc::clone(&iter_env);
+                    match self.eval_statement(body) {
+                        Ok(_) => {}
+                        Err(EvalError::Break) => break,
+                        Err(EvalError::Continue) => continue,
+                        Err(e) => {
+                            ret = Err(e);
+                            break;
+                        }
+                    }
+                }
+                self.scope = outer;
+                ret
+            }
             Statement::For {
                 init,
                 cond,
@@ -4229,16 +4274,26 @@ impl Evaluator {
     }
 
     fn object_keys(args: &[Value]) -> Result<Value, String> {
-        if let Some(Value::Object(obj)) = args.first() {
-            let keys: Vec<Value> = obj
-                .borrow()
-                .strings
-                .keys()
-                .map(|k| Value::String(Arc::clone(k)))
-                .collect();
-            Ok(Value::Array(Rc::new(RefCell::new(keys))))
-        } else {
-            Ok(Value::Array(Rc::new(RefCell::new(Vec::new()))))
+        match args.first() {
+            Some(Value::Object(obj)) => {
+                let keys: Vec<Value> = obj
+                    .borrow()
+                    .strings
+                    .keys()
+                    .map(|k| Value::String(Arc::clone(k)))
+                    .collect();
+                Ok(Value::Array(Rc::new(RefCell::new(keys))))
+            }
+            // `Object.keys(array)` → index strings "0".."len-1" (own enumerable keys are the indices),
+            // matching node and the shared builtin.
+            Some(Value::Array(arr)) => {
+                let len = arr.borrow().len();
+                let keys: Vec<Value> = (0..len)
+                    .map(|i| Value::String(Arc::from(i.to_string())))
+                    .collect();
+                Ok(Value::Array(Rc::new(RefCell::new(keys))))
+            }
+            _ => Ok(Value::Array(Rc::new(RefCell::new(Vec::new())))),
         }
     }
 

--- a/crates/tish_fmt/src/lib.rs
+++ b/crates/tish_fmt/src/lib.rs
@@ -613,6 +613,20 @@ impl Printer {
                 self.buf.push_str(") ");
                 self.stmt_inline_or_block(body, level);
             }
+            Statement::ForIn {
+                name,
+                object,
+                body,
+                ..
+            } => {
+                self.indent(level);
+                self.buf.push_str("for (let ");
+                self.buf.push_str(name);
+                self.buf.push_str(" in ");
+                self.expr(object);
+                self.buf.push_str(") ");
+                self.stmt_inline_or_block(body, level);
+            }
             Statement::Return { value, .. } => {
                 self.indent(level);
                 self.buf.push_str("return");

--- a/crates/tish_opt/src/lib.rs
+++ b/crates/tish_opt/src/lib.rs
@@ -118,6 +118,19 @@ fn optimize_statement(stmt: &Statement) -> Statement {
             body: Box::new(optimize_statement(body)),
             span: *span,
         },
+        Statement::ForIn {
+            name,
+            name_span,
+            object,
+            body,
+            span,
+        } => Statement::ForIn {
+            name: Arc::clone(name),
+            name_span: *name_span,
+            object: optimize_expr(object),
+            body: Box::new(optimize_statement(body)),
+            span: *span,
+        },
         Statement::Return { value, span } => Statement::Return {
             value: value.as_ref().map(optimize_expr),
             span: *span,

--- a/crates/tish_parser/src/parser.rs
+++ b/crates/tish_parser/src/parser.rs
@@ -1290,6 +1290,21 @@ impl<'a> Parser<'a> {
                     span: self.span_end(span_start),
                 });
             }
+            // `for (let k in obj)` — after a declared loop variable, `in` is for-in enumeration, not
+            // the binary `in` operator (#413). Iterates the object's own enumerable keys.
+            if matches!(self.peek_kind(), Some(TokenKind::In)) {
+                self.advance();
+                let object = self.parse_expr()?;
+                self.expect(TokenKind::RParen)?;
+                let body = Box::new(self.parse_block_or_statement()?);
+                return Ok(Statement::ForIn {
+                    name,
+                    name_span,
+                    object,
+                    body,
+                    span: self.span_end(span_start),
+                });
+            }
             let type_ann = if matches!(self.peek_kind(), Some(TokenKind::Colon)) {
                 self.advance();
                 Some(self.parse_type_annotation()?)

--- a/crates/tish_resolve/src/lib.rs
+++ b/crates/tish_resolve/src/lib.rs
@@ -177,6 +177,13 @@ fn collect_stmt(
             iterable,
             body,
             ..
+        }
+        | Statement::ForIn {
+            name,
+            name_span,
+            object: iterable,
+            body,
+            ..
         } => {
             consider(source, lsp_line, lsp_char, name_span, name.clone(), best);
             collect_expr(iterable, source, lsp_line, lsp_char, best);
@@ -939,7 +946,12 @@ fn member_chain_collect_stmt(
             }
             member_chain_collect_stmt(body, source, lsp_line, lsp_char, best);
         }
-        Statement::ForOf { iterable, body, .. } => {
+        Statement::ForOf { iterable, body, .. }
+        | Statement::ForIn {
+            object: iterable,
+            body,
+            ..
+        } => {
             member_chain_collect_expr(iterable, source, lsp_line, lsp_char, best);
             member_chain_collect_stmt(body, source, lsp_line, lsp_char, best);
         }
@@ -1412,6 +1424,13 @@ fn walk_stmt_resolve(
             name,
             name_span,
             iterable,
+            body,
+            ..
+        }
+        | Statement::ForIn {
+            name,
+            name_span,
+            object: iterable,
             body,
             ..
         } => {
@@ -2028,6 +2047,13 @@ fn check_unresolved_stmt(
             iterable,
             body,
             ..
+        }
+        | Statement::ForIn {
+            name,
+            name_span,
+            object: iterable,
+            body,
+            ..
         } => {
             check_unresolved_expr(iterable, scopes, out);
             scopes.push();
@@ -2556,6 +2582,13 @@ fn enumerate_stmt(stmt: &Statement, exported: bool, out: &mut Vec<BindingSite>) 
             iterable,
             body,
             ..
+        }
+        | Statement::ForIn {
+            name,
+            name_span,
+            object: iterable,
+            body,
+            ..
         } => {
             out.push(BindingSite {
                 name: name.clone(),
@@ -2731,7 +2764,12 @@ fn jsx_tags_stmt(s: &Statement, out: &mut std::collections::HashSet<Arc<str>>) {
             }
             jsx_tags_stmt(body, out);
         }
-        Statement::ForOf { iterable, body, .. } => {
+        Statement::ForOf { iterable, body, .. }
+        | Statement::ForIn {
+            object: iterable,
+            body,
+            ..
+        } => {
             jsx_tags_expr(iterable, out);
             jsx_tags_stmt(body, out);
         }
@@ -3052,6 +3090,13 @@ fn collect_block_locals(
             collect_block_locals(body, source, lsp_line, lsp_char, out);
         }
         Statement::ForOf {
+            name,
+            name_span,
+            body,
+            span,
+            ..
+        }
+        | Statement::ForIn {
             name,
             name_span,
             body,
@@ -3426,6 +3471,12 @@ fn walk_stmt_completion(
         Statement::ForOf {
             name,
             iterable,
+            body,
+            ..
+        }
+        | Statement::ForIn {
+            name,
+            object: iterable,
             body,
             ..
         } => {
@@ -3900,7 +3951,12 @@ fn tref_stmt(stmt: &Statement, out: &mut Vec<TypeOcc>) {
             }
             tref_stmt(body, out);
         }
-        Statement::ForOf { iterable, body, .. } => {
+        Statement::ForOf { iterable, body, .. }
+        | Statement::ForIn {
+            object: iterable,
+            body,
+            ..
+        } => {
             tref_expr(iterable, out);
             tref_stmt(body, out);
         }
@@ -4061,7 +4117,12 @@ fn refs_stmt(
             }
             refs_stmt(body, program, source, name, def_span, out);
         }
-        Statement::ForOf { iterable, body, .. } => {
+        Statement::ForOf { iterable, body, .. }
+        | Statement::ForIn {
+            object: iterable,
+            body,
+            ..
+        } => {
             refs_expr(iterable, program, source, name, def_span, out);
             refs_stmt(body, program, source, name, def_span, out);
         }

--- a/crates/tish_ui/src/jsx.rs
+++ b/crates/tish_ui/src/jsx.rs
@@ -188,7 +188,12 @@ fn collect_fun_decl_names_stmt(stmt: &Statement, names: &mut HashSet<String>) {
             }
             collect_fun_decl_names_stmt(body, names);
         }
-        Statement::ForOf { iterable, body, .. } => {
+        Statement::ForOf { iterable, body, .. }
+        | Statement::ForIn {
+            object: iterable,
+            body,
+            ..
+        } => {
             collect_fun_decl_names_expr(iterable, names);
             collect_fun_decl_names_stmt(body, names);
         }
@@ -646,7 +651,12 @@ fn stmt_contains_jsx_fragment(stmt: &tishlang_ast::Statement) -> bool {
                 || update.as_ref().is_some_and(expr_contains_jsx_fragment)
                 || stmt_contains_jsx_fragment(body)
         }
-        Statement::ForOf { iterable, body, .. } => {
+        Statement::ForOf { iterable, body, .. }
+        | Statement::ForIn {
+            object: iterable,
+            body,
+            ..
+        } => {
             expr_contains_jsx_fragment(iterable) || stmt_contains_jsx_fragment(body)
         }
         Statement::Switch {
@@ -827,7 +837,12 @@ fn stmt_contains_jsx(stmt: &tishlang_ast::Statement) -> bool {
                 || update.as_ref().is_some_and(expr_contains_jsx)
                 || stmt_contains_jsx(body)
         }
-        Statement::ForOf { iterable, body, .. } => {
+        Statement::ForOf { iterable, body, .. }
+        | Statement::ForIn {
+            object: iterable,
+            body,
+            ..
+        } => {
             expr_contains_jsx(iterable) || stmt_contains_jsx(body)
         }
         Statement::Switch {

--- a/tests/core/for_in_object.tish
+++ b/tests/core/for_in_object.tish
@@ -1,0 +1,38 @@
+// #413: `for (let k in obj)` iterates an object's own enumerable keys, in insertion order (JS
+// for-in semantics). This is the primary real-world use — object key enumeration, e.g. copying or
+// transforming an object. Consistent across interp/vm/native/js/node.
+
+let obj = { id: 5, name: "x", active: true }
+
+// Enumerate keys in insertion order.
+let ks = ""
+for (let k in obj) { ks = ks + k + "," }
+console.log("keys:", ks)
+
+// Read each value by key (the #413 repro: build a copy).
+let copy = {}
+for (let k in obj) { copy[k] = obj[k] }
+console.log("copy:", copy.id, copy.name, copy.active)
+
+// break / continue inside a for-in body.
+let seen = ""
+for (let k in obj) {
+  if (k === "name") { continue }
+  if (k === "active") { break }
+  seen = seen + k
+}
+console.log("seen:", seen)
+
+// for-in over a non-object (null) is a no-op — no iterations, no throw (matches JS `for (k in null)`).
+let n = 0
+for (let k in null) { n = n + 1 }
+console.log("null-iterations:", n)
+
+// Nested for-in over two objects.
+let a = { p: 1, q: 2 }
+let b = { r: 3 }
+let pairs = ""
+for (let i in a) {
+  for (let j in b) { pairs = pairs + i + j + " " }
+}
+console.log("nested:", pairs)

--- a/tests/core/for_in_object.tish.expected
+++ b/tests/core/for_in_object.tish.expected
@@ -1,0 +1,5 @@
+keys: id,name,active,
+copy: 5 x true
+seen: id
+null-iterations: 0
+nested: pr qr 


### PR DESCRIPTION
Closes #413.

Adds `for (let k in obj)` — iterates an object's own enumerable keys in insertion order (JS for-in semantics) — as a **first-class `Statement::ForIn` node** wired through every backend and tool, so enumeration is identical across interp/vm/native/js/node and `tish fmt` round-trips `for-in`.

## Approach (per the "faithful first-class node" decision)

| layer | handling |
|---|---|
| **Parser** | `parse_for` branches on `in` after the loop variable |
| **Interp** | enumerates keys directly — objects → keys (insertion order), arrays → index strings, non-object (incl. `null`) → no-op |
| **VM + native** | lower to `for (k of Object.keys(obj))` — same keys, reuses the for-of path |
| **JS target** | native `for (const k in obj)` |
| **opt / fmt / resolve / lsp / ui / infer / type-check** | matching arms so for-in bodies are walked exactly like for-of (many via `ForOf \| ForIn` OR-patterns) |

## Companion fix: `Object.keys(array)`

`Object.keys([10,20,30])` returned `[]` (a node divergence — node returns `["0","1","2"]`). Fixed in the shared builtin (vm/native) and the interpreter — required for the for-in lowering and correct on its own.

## Scope: objects vs arrays

for-in over **objects** is fully consistent across all backends — this is the primary real-world use and matches the issue's own repro (`for (k in o) out[k] = o[k]`).

for-in over **arrays** enumerates correctly on vm/interp/js/node but hits two **pre-existing** array bugs surfaced (not caused) by this work — native typed-array enumeration and `arr["0"]` string-index coercion — tracked in #432. (for-in over arrays is a JS anti-pattern; MDN recommends for-of/forEach.)

## Verification
- `tests/core/for_in_object` (key enumeration, value reads, break/continue, `null` no-op, nesting): **interp == vm == native == cranelift == wasi == node**.
- `test_mvp_programs_*`: **6/6** across all backends (no for-of regression from the wide arm changes).
- Gauntlet **soundness clean** (typed == boxed == node).