### PR TITLE
feat(parser): async in expression positions — async arrows (#428)

### DIFF
--- a/crates/js_to_tish/src/transform/expr.rs
+++ b/crates/js_to_tish/src/transform/expr.rs
@@ -176,7 +176,12 @@ pub fn convert_expr(expr: &OxcExpr<'_>, ctx: &Ctx<'_>) -> Result<Expr, ConvertEr
                     span: span_util::oxc_span_to_tish(ctx.1, &*arrow.body),
                 }))
             };
-            Ok(Expr::ArrowFunction { params, body, span })
+            Ok(Expr::ArrowFunction {
+                async_: arrow.r#async,
+                params,
+                body,
+                span,
+            })
         }
         OxcExpr::AwaitExpression(a) => Ok(Expr::Await {
             operand: Box::new(convert_expr(&a.argument, ctx)?),
@@ -229,7 +234,12 @@ pub fn convert_expr(expr: &OxcExpr<'_>, ctx: &Ctx<'_>) -> Result<Expr, ConvertEr
                     }))
                 }
             };
-            Ok(Expr::ArrowFunction { params, body, span })
+            Ok(Expr::ArrowFunction {
+                async_: f.r#async,
+                params,
+                body,
+                span,
+            })
         }
         _ => Err(ConvertError::new(ConvertErrorKind::Unsupported {
             what: format!("expression: {:?}", std::mem::discriminant(expr)),

--- a/crates/tish_ast/src/ast.rs
+++ b/crates/tish_ast/src/ast.rs
@@ -443,6 +443,9 @@ pub enum Expr {
     },
     /// Arrow function: (params) => body
     ArrowFunction {
+        /// `true` for `async () => …` (#428) — the body runs in async context (`await` allowed) and
+        /// the JS target emits an `async` prefix. Non-async arrows have `async_: false`.
+        async_: bool,
         params: Vec<FunParam>,
         body: ArrowBody,
         span: Span,

--- a/crates/tish_compile_js/src/codegen.rs
+++ b/crates/tish_compile_js/src/codegen.rs
@@ -902,7 +902,9 @@ impl Codegen {
                 let val = self.emit_expr(value)?;
                 format!("({}[{}] = {})", obj, idx, val)
             }
-            Expr::ArrowFunction { params, body, .. } => {
+            Expr::ArrowFunction {
+                async_, params, body, ..
+            } => {
                 let ps = self.emit_params(params, None)?;
                 let body_str = match body {
                     ArrowBody::Expr(e) => self.emit_expr(e)?,
@@ -918,10 +920,11 @@ impl Codegen {
                         block
                     }
                 };
+                let prefix = if *async_ { "async " } else { "" }; // #428
                 if matches!(body, ArrowBody::Expr(_)) {
-                    format!("({}) => ({})", ps, body_str)
+                    format!("{}({}) => ({})", prefix, ps, body_str)
                 } else {
-                    format!("({}) => {}", ps, body_str)
+                    format!("{}({}) => {}", prefix, ps, body_str)
                 }
             }
             Expr::TemplateLiteral { quasis, exprs, .. } => {

--- a/crates/tish_opt/src/lib.rs
+++ b/crates/tish_opt/src/lib.rs
@@ -513,12 +513,18 @@ fn optimize_expr(expr: &Expr) -> Expr {
             value: Box::new(optimize_expr(value)),
             span: *span,
         },
-        Expr::ArrowFunction { params, body, span } => {
+        Expr::ArrowFunction {
+            async_,
+            params,
+            body,
+            span,
+        } => {
             let opt_body = match body {
                 ArrowBody::Expr(e) => ArrowBody::Expr(Box::new(optimize_expr(e))),
                 ArrowBody::Block(s) => ArrowBody::Block(Box::new(optimize_statement(s))),
             };
             Expr::ArrowFunction {
+                async_: *async_,
                 params: params.clone(),
                 body: opt_body,
                 span: *span,

--- a/crates/tish_parser/src/lib.rs
+++ b/crates/tish_parser/src/lib.rs
@@ -77,6 +77,30 @@ mod tests {
         assert!(parse("let y = a !== null && a.b").is_ok());
     }
 
+    /// #428: `async` in expression position parses as an async arrow (paren and single-param forms);
+    /// non-async arrows keep `async_: false`.
+    #[test]
+    fn async_arrow_expressions_parse() {
+        use tishlang_ast::Expr;
+        let arrow_async = |src: &str| -> bool {
+            let p = parse(src).expect("parse");
+            let Some(Statement::VarDecl { init: Some(e), .. }) = p.statements.first() else {
+                panic!("expected `let x = <arrow>`");
+            };
+            match e {
+                Expr::ArrowFunction { async_, .. } => *async_,
+                other => panic!("expected ArrowFunction, got {other:?}"),
+            }
+        };
+        assert!(arrow_async("let f = async () => 1"), "async paren arrow");
+        assert!(arrow_async("let g = async x => x + 1"), "async single-param arrow");
+        assert!(arrow_async("let h = async (a, b) => a + b"), "async multi-param arrow");
+        assert!(!arrow_async("let f = () => 1"), "plain arrow is not async");
+        assert!(!arrow_async("let g = x => x"), "plain single-param arrow is not async");
+        // `async` not followed by an arrow in expr position is an error, not a silent identifier.
+        assert!(parse("let x = async 5").is_err());
+    }
+
     #[test]
     fn test_async_fn_parse() {
         let program = parse("async fn foo() { }").expect("parse async fn");

--- a/crates/tish_parser/src/parser.rs
+++ b/crates/tish_parser/src/parser.rs
@@ -2464,6 +2464,50 @@ impl<'a> Parser<'a> {
                 value: Literal::Null,
                 span,
             }),
+            // `async` in expression position (#428): an async arrow — `async () => …` or
+            // `async x => …`. The body runs in async context (`await` allowed). Async function
+            // expressions / method shorthand need function-expression support, which tish lacks.
+            TokenKind::Async => {
+                if matches!(self.peek_kind(), Some(TokenKind::LParen)) {
+                    self.advance(); // consume `(`
+                    if let Some(arrow) = self.try_parse_arrow_function(&span, true)? {
+                        return Ok(arrow);
+                    }
+                    return Err("Expected an arrow function after `async (`".to_string());
+                }
+                if matches!(
+                    self.peek_kind(),
+                    Some(TokenKind::Ident | TokenKind::Fn | TokenKind::Type)
+                ) {
+                    let name_tok = self.advance().ok_or("Expected parameter name")?;
+                    let name = name_tok.literal.clone().ok_or("Expected parameter name")?;
+                    let name_span = Span {
+                        start: name_tok.span.start,
+                        end: name_tok.span.end,
+                    };
+                    self.expect(TokenKind::Arrow)?;
+                    let body = self.parse_arrow_body()?;
+                    let end = self.previous_span_end();
+                    return Ok(Expr::ArrowFunction {
+                        async_: true,
+                        params: vec![FunParam::Simple(TypedParam {
+                            name,
+                            name_span,
+                            type_ann: None,
+                            default: None,
+                        })],
+                        body,
+                        span: Span {
+                            start: span.start,
+                            end,
+                        },
+                    });
+                }
+                Err(
+                    "`async` in expression position must be followed by an arrow function (`async () => …`)"
+                        .to_string(),
+                )
+            }
             // `fn` / `type` as a value reference or single-param arrow head (issue #55).
             // `fn`/`type` function-expressions don't exist and statement-leading decls are
             // handled in parse_statement, so treating them as identifiers here is additive.
@@ -2475,6 +2519,7 @@ impl<'a> Parser<'a> {
                     let body = self.parse_arrow_body()?;
                     let end = self.previous_span_end();
                     return Ok(Expr::ArrowFunction {
+                        async_: false,
                         params: vec![FunParam::Simple(TypedParam {
                             name: name.clone(),
                             name_span: span,
@@ -2492,7 +2537,7 @@ impl<'a> Parser<'a> {
             }
             TokenKind::LParen => {
                 // Check if this is an arrow function: (params) => ...
-                if let Some(arrow_fn) = self.try_parse_arrow_function(&span)? {
+                if let Some(arrow_fn) = self.try_parse_arrow_function(&span, false)? {
                     return Ok(arrow_fn);
                 }
                 // Otherwise it's a grouping expression
@@ -2652,7 +2697,11 @@ impl<'a> Parser<'a> {
 
     /// Try to parse an arrow function starting with '(' already consumed.
     /// Returns Some(Expr) if successful, None if it's not an arrow function.
-    fn try_parse_arrow_function(&mut self, start_span: &Span) -> Result<Option<Expr>, String> {
+    fn try_parse_arrow_function(
+        &mut self,
+        start_span: &Span,
+        async_: bool,
+    ) -> Result<Option<Expr>, String> {
         // Save position for backtracking
         let saved_pos = self.pos;
 
@@ -2706,6 +2755,7 @@ impl<'a> Parser<'a> {
         let end = self.previous_span_end();
 
         Ok(Some(Expr::ArrowFunction {
+            async_,
             params,
             body,
             span: Span {


### PR DESCRIPTION
Addresses the async-arrow half of #428.

## Problem
`const f = async () => …` / `async x => …` failed to parse — `async` was only accepted before a top-level `fn`.

## Fix
Add `async_: bool` to `Expr::ArrowFunction` and parse `async` in expression position as an async arrow (paren + single-param forms).

| layer | handling |
|---|---|
| **Parser** | `async` in `parse_primary` → async arrow (or error if not followed by `=>`) |
| **JS target** | emits `async (…) => …` |
| **js_to_tish** | carries the oxc `async` flag through (arrow + function expressions) |
| **opt** | passes `async_` through |

## Verified across backends
`let add = async (a,b) => a+b; … await add(3,4)` → **7** on the **JS target (node), vm, and native**. Async arrows now behave exactly like `async fn`.

## Known / out of scope
- The **interpreter**'s strict `await` (`await <non-promise>`) is a **pre-existing** limitation affecting *all* `async` on `--backend interp` — a plain `async fn` + `await` fails identically. Not introduced here.
- **Async function expressions / method shorthand** (`async function(){}`, `{ async m(){} }`) need function-expression support, which tish lacks entirely (`let f = function(){}` doesn't parse). Left open on #428.

## Tests
New `async_arrow_expressions_parse` parser test; parser/opt/js_to_tish suites green; `test_mvp_programs` **6/6**; async integration tests green.