### PR TITLE
fix(builtins): three cross-backend divergences (reduce no-init, string OOB, JSON control chars)

### DIFF
--- a/crates/tish_builtins/src/array.rs
+++ b/crates/tish_builtins/src/array.rs
@@ -417,16 +417,25 @@ pub fn filter(arr: &Value, callback: &Value) -> Value {
     }
 }
 
-pub fn reduce(arr: &Value, callback: &Value, initial: &Value) -> Value {
+/// `initial` is `None` when no initial value was passed (`arr.reduce(fn)`) and `Some` for an explicit
+/// one (`arr.reduce(fn, x)`, INCLUDING `arr.reduce(fn, null)`). This distinction matters: reducing an
+/// empty array with NO initial value is a `TypeError` in JS, while an explicit initial (even `null`)
+/// is returned as-is. A `Value::Null` sentinel can't tell the two apart — hence `Option`.
+pub fn reduce(arr: &Value, callback: &Value, initial: Option<&Value>) -> Value {
     // Packed fast path: fold the `Vec<f64>` snapshot directly. Same no-initial rule as the boxed
     // path (absent init → first element as the seed, scan from index 1).
     if let Some((data, cb)) = packed_snapshot(arr, callback) {
         // `reduce` passes `(accumulator, element, index, array)` — the array is the 4th arg.
         let arr_value = arr.clone();
-        let (start_idx, mut acc) = if matches!(initial, Value::Null) && !data.is_empty() {
-            (1usize, Value::Number(data[0]))
-        } else {
-            (0usize, initial.clone())
+        let (start_idx, mut acc) = match initial {
+            Some(v) => (0usize, v.clone()),
+            None if !data.is_empty() => (1usize, Value::Number(data[0])),
+            None => {
+                tishlang_core::set_pending_throw(tishlang_core::type_error(
+                    "Reduce of empty array with no initial value",
+                ));
+                return Value::Null;
+            }
         };
         // `skip(start_idx)` preserves the true element index for the callback's 3rd arg.
         for (i, &x) in data.iter().enumerate().skip(start_idx) {
@@ -440,11 +449,15 @@ pub fn reduce(arr: &Value, callback: &Value, initial: &Value) -> Value {
         let arr_borrow = arr.borrow().clone(); // #382: snapshot; drop the guard before any callback
         let arr_value = Value::Array(arr.clone()); // 4th callback arg (JS `array`)
         let len = arr_borrow.len();
-        let (start_idx, mut acc) = if matches!(initial, Value::Null) && !arr_borrow.is_empty() {
-            // No initial value: use first element as acc, start from index 1
-            (1, arr_borrow[0].clone())
-        } else {
-            (0, initial.clone())
+        let (start_idx, mut acc) = match initial {
+            Some(v) => (0, v.clone()),
+            None if !arr_borrow.is_empty() => (1, arr_borrow[0].clone()),
+            None => {
+                tishlang_core::set_pending_throw(tishlang_core::type_error(
+                    "Reduce of empty array with no initial value",
+                ));
+                return Value::Null;
+            }
         };
         for i in start_idx..len {
             if tishlang_core::has_pending_throw() { return acc; } // #303
@@ -974,14 +987,14 @@ mod packed_hof_tests {
         let n = na(&[3.0, 1.0, 4.0, 1.0, 5.0]);
         let add = cb_num(|acc, x| acc + x);
         // With init.
-        assert_eq!(reduce(&n, &add, &Value::Number(0.0)).as_number(), Some(14.0));
-        // No init → first element seeds, scan from index 1 (same total here).
-        assert_eq!(reduce(&n, &add, &Value::Null).as_number(), Some(14.0));
+        assert_eq!(reduce(&n, &add, Some(&Value::Number(0.0))).as_number(), Some(14.0));
+        // No init (None) → first element seeds, scan from index 1 (same total here).
+        assert_eq!(reduce(&n, &add, None).as_number(), Some(14.0));
         // Index arg: callback (acc, _elem, index) — sum the indices 0..5 = 10.
         let sum_idx = Value::native(|a: &[Value]| {
             Value::Number(a[0].as_number().unwrap() + a[2].as_number().unwrap())
         });
-        assert_eq!(reduce(&n, &sum_idx, &Value::Number(0.0)).as_number(), Some(10.0));
+        assert_eq!(reduce(&n, &sum_idx, Some(&Value::Number(0.0))).as_number(), Some(10.0));
     }
 
     #[test]

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -7076,9 +7076,15 @@ impl Codegen {
                                 }
                             }
                             let callback = arg_exprs.first().cloned().unwrap_or_else(|| "Value::Null".to_string());
+                            // `array_reduce` takes `Option<&Value>` init: `None` = no initial value, so an
+                            // empty array with no init throws (per JS) instead of returning `null`.
+                            let init_arg = match arg_exprs.get(1) {
+                                Some(e) => format!("Some(&{})", e),
+                                None => "None".to_string(),
+                            };
                             return Ok(format!(
-                                "tishlang_runtime::array_reduce(&{}, &{}, &{})",
-                                obj_expr, callback, initial
+                                "tishlang_runtime::array_reduce(&{}, &{}, {})",
+                                obj_expr, callback, init_arg
                             ));
                         }
                         "forEach" => {

--- a/crates/tish_core/src/json.rs
+++ b/crates/tish_core/src/json.rs
@@ -224,7 +224,11 @@ fn json_stringify_into_guarded(buf: &mut String, value: &Value, ancestors: &mut 
 /// to `buf`. Optimised for the common case where the input is ASCII and
 /// contains no characters that need escaping — we fast-pass the bytes
 /// straight through, only falling into the per-char path on a hit.
-fn escape_json_string_into(buf: &mut String, s: &str) {
+/// Append `s` to `buf` as a JSON string body (WITHOUT the surrounding quotes), escaping `"`, `\`,
+/// and every control char < 0x20 (`\n \r \t \b \f`, else `\u00xx`). The single source of truth for
+/// JSON string escaping, shared by the vm/native path here and the interpreter's `JSON.stringify`
+/// (which otherwise hand-rolled an escaper that missed `\b`/`\f`/`\u00xx` and emitted invalid JSON).
+pub fn escape_json_string_into(buf: &mut String, s: &str) {
     let bytes = s.as_bytes();
     let mut start = 0usize;
     for (i, &b) in bytes.iter().enumerate() {

--- a/crates/tish_core/src/lib.rs
+++ b/crates/tish_core/src/lib.rs
@@ -12,7 +12,9 @@ mod value;
 mod vmref;
 
 pub use console_style::{format_value_styled, format_values_for_console, use_console_colors};
-pub use json::{json_parse, json_stringify, json_stringify_into, write_json_number};
+pub use json::{
+    escape_json_string_into, json_parse, json_stringify, json_stringify_into, write_json_number,
+};
 pub use shape::{ShapeId, DICT_SHAPE, EMPTY_SHAPE};
 pub use uri::{percent_decode, percent_encode};
 pub use arcstr::ArcStr;
@@ -159,6 +161,22 @@ pub fn stack_overflow_error() -> Value {
 /// aborting the process, so `value_call` on a non-function surfaces as a catchable error at the next
 /// pending-throw checkpoint rather than an uncatchable native panic.
 pub fn not_a_function_error(message: impl Into<String>) -> Value {
+    let mut e = ObjectMap::default();
+    e.insert(
+        std::sync::Arc::from("name"),
+        Value::String("TypeError".into()),
+    );
+    e.insert(
+        std::sync::Arc::from("message"),
+        Value::String(message.into().into()),
+    );
+    Value::object(e)
+}
+
+/// A catchable `TypeError` with an arbitrary message (`{ name: "TypeError", message }`), matching the
+/// VM/interpreter/node shape. Used to PARK a pending throw from a shared builtin that returns a plain
+/// `Value` and so cannot signal an error with `Result` (e.g. `[].reduce(fn)` with no initial value).
+pub fn type_error(message: impl Into<String>) -> Value {
     let mut e = ObjectMap::default();
     e.insert(
         std::sync::Arc::from("name"),

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -4226,14 +4226,16 @@ impl Evaluator {
                 tishlang_core::write_json_number(&mut s, *n);
                 s
             }
-            Value::String(s) => format!(
-                "\"{}\"",
-                s.replace('\\', "\\\\")
-                    .replace('"', "\\\"")
-                    .replace('\n', "\\n")
-                    .replace('\r', "\\r")
-                    .replace('\t', "\\t")
-            ),
+            Value::String(s) => {
+                // Use the shared core escaper so control chars (`\b`, `\f`, `\u00xx`) are escaped
+                // exactly like the vm/native path — the old hand-rolled `.replace()` chain missed
+                // them and produced invalid JSON (raw control bytes). #437
+                let mut out = String::with_capacity(s.len() + 2);
+                out.push('"');
+                tishlang_core::escape_json_string_into(&mut out, s);
+                out.push('"');
+                out
+            }
             Value::Array(arr) => {
                 let ptr = Rc::as_ptr(arr) as *const ();
                 if ancestors.contains(&ptr) {

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -1389,7 +1389,7 @@ mod hof_fusion {
     /// (which would pass a `Value::Bool`, not a number). No-initial-value semantics match the generic
     /// path: absent init (`Value::Null`) with a non-empty array seeds `acc = data[0]` and scans from
     /// index 1; an empty array with no init throws (bail to the generic path, which raises it).
-    pub(super) fn reduce(arr: &Value, cb: &Value, init: &Value) -> Option<Value> {
+    pub(super) fn reduce(arr: &Value, cb: &Value, initial: Option<&Value>) -> Option<Value> {
         let nf = fused_numeric_fn(cb)?;
         if nf.arity() > 3 || nf.result_is_bool() {
             return None;
@@ -1398,11 +1398,11 @@ mod hof_fusion {
         let arity = nf.arity();
         // Determine seed. Reduce with no initial value AND an empty array is a TypeError in JS — let
         // the generic path produce that exact throw rather than replicate it here.
-        let (start, mut acc) = match init {
-            Value::Null if !data.is_empty() => (1usize, data[0]),
-            Value::Null => return None, // empty + no init → generic path throws
-            Value::Number(n) => (0usize, *n),
-            _ => return None, // non-numeric explicit init → generic path (acc wouldn't stay f64)
+        let (start, mut acc) = match initial {
+            None if !data.is_empty() => (1usize, data[0]),
+            None => return None,             // empty + no init → generic path throws
+            Some(Value::Number(n)) => (0usize, *n),
+            Some(_) => return None, // non-numeric/explicit-null init → generic path (acc wouldn't stay f64)
         };
         let mut args = [0.0f64; 3];
         for (i, &x) in data.iter().enumerate().skip(start) {
@@ -3829,12 +3829,12 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                         }),
                         "reduce" => make_native_fn(move |args| {
                             let cb = args.first().cloned().unwrap_or(Value::Null);
-                            let init = args.get(1).cloned().unwrap_or(Value::Null);
+                            let init = args.get(1).cloned(); // None = no initial value (empty array → throw)
                             #[cfg(not(target_arch = "wasm32"))]
-                            if let Some(v) = hof_fusion::reduce(&bv, &cb, &init) {
+                            if let Some(v) = hof_fusion::reduce(&bv, &cb, init.as_ref()) {
                                 return v;
                             }
-                            arr_builtins::reduce(&bv, &cb, &init)
+                            arr_builtins::reduce(&bv, &cb, init.as_ref())
                         }),
                         "forEach" => make_native_fn(move |args| {
                             let cb = args.first().cloned().unwrap_or(Value::Null);
@@ -4001,13 +4001,13 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                 }),
                 "reduce" => make_native_fn(move |args: &[Value]| {
                     let cb = args.first().cloned().unwrap_or(Value::Null);
-                    let init = args.get(1).cloned().unwrap_or(Value::Null);
+                    let init = args.get(1).cloned(); // None = no initial value (empty array → throw)
                     let arr = Value::Array(a_clone.clone());
                     #[cfg(not(target_arch = "wasm32"))]
-                    if let Some(v) = hof_fusion::reduce(&arr, &cb, &init) {
+                    if let Some(v) = hof_fusion::reduce(&arr, &cb, init.as_ref()) {
                         return v;
                     }
-                    arr_builtins::reduce(&arr, &cb, &init)
+                    arr_builtins::reduce(&arr, &cb, init.as_ref())
                 }),
                 "forEach" => make_native_fn(move |args: &[Value]| {
                     let cb = args.first().cloned().unwrap_or(Value::Null);
@@ -4375,10 +4375,9 @@ fn get_index(obj: &Value, idx: &Value) -> Result<Value, String> {
                 Value::Number(n) => {
                     let n = *n;
                     if n < 0.0 || n.fract() != 0.0 {
-                        return Err(format!(
-                            "String index must be non-negative integer, got {}",
-                            n
-                        ));
+                        // A negative / non-integer string index reads `null` (JS `undefined`), NOT a
+                        // throw — interp and native already return null; the vm must agree. (#437)
+                        return Ok(Value::Null);
                     }
                     n as usize
                 }
@@ -4393,7 +4392,8 @@ fn get_index(obj: &Value, idx: &Value) -> Result<Value, String> {
             // O(n) `chars().count()` pre-check (#203).
             match str_builtins::nth_char(s, i) {
                 Some(c) => Ok(Value::String(tishlang_core::ArcStr::from(c.to_string()))),
-                None => Err("Index out of bounds".to_string()),
+                // Past the end → `null` (JS `undefined`), matching interp/native, not a throw. (#437)
+                None => Ok(Value::Null),
             }
         }
         // A missing own property returns `null`, not a thrown error — matching dot reads

--- a/tests/core/parity_builtins.js
+++ b/tests/core/parity_builtins.js
@@ -29,6 +29,18 @@ console.log("sign-neg", Math.sign(-5))
 console.log("pad-empty", "x".padStart(3, ""))
 console.log("pad-space", "x".padStart(3))
 console.log("padend-empty", "x".padEnd(3, ""))
+// [].reduce with no initial value throws TypeError; an explicit init (incl. null) is returned as-is.
+let redThrew = "no"
+try { [].reduce((a, b) => a + b) } catch (e) { redThrew = e.name }
+console.log("reduce-empty-throw", redThrew)
+console.log("reduce-empty-init", [].reduce((a, b) => a + b, 42))
+console.log("reduce-empty-null", [].reduce((a, b) => a + b, null))
+// Out-of-range / negative string index reads falsy (null in tish, undefined in node) — no throw.
+console.log("str-oob", "abc"[10] || "none")
+console.log("str-neg", "abc"[-1] || "none")
+// JSON.stringify escapes control chars (valid JSON), not raw bytes.
+console.log("json-nul", JSON.stringify(String.fromCharCode(0)))
+console.log("json-bs", JSON.stringify(String.fromCharCode(8)))
 console.log("includes-nan", [1, 0 / 0].includes(0 / 0))
 console.log("includes-no", [1, 2].includes(3))
 console.log("parseint-hex", parseInt("0x1F", 16))

--- a/tests/core/parity_builtins.tish
+++ b/tests/core/parity_builtins.tish
@@ -29,6 +29,18 @@ console.log("sign-neg", Math.sign(-5))
 console.log("pad-empty", "x".padStart(3, ""))
 console.log("pad-space", "x".padStart(3))
 console.log("padend-empty", "x".padEnd(3, ""))
+// [].reduce with no initial value throws TypeError; an explicit init (incl. null) is returned as-is.
+let redThrew = "no"
+try { [].reduce((a, b) => a + b) } catch (e) { redThrew = e.name }
+console.log("reduce-empty-throw", redThrew)
+console.log("reduce-empty-init", [].reduce((a, b) => a + b, 42))
+console.log("reduce-empty-null", [].reduce((a, b) => a + b, null))
+// Out-of-range / negative string index reads falsy (null in tish, undefined in node) — no throw.
+console.log("str-oob", "abc"[10] || "none")
+console.log("str-neg", "abc"[-1] || "none")
+// JSON.stringify escapes control chars (valid JSON), not raw bytes.
+console.log("json-nul", JSON.stringify(String.fromCharCode(0)))
+console.log("json-bs", JSON.stringify(String.fromCharCode(8)))
 console.log("includes-nan", [1, 0 / 0].includes(0 / 0))
 console.log("includes-no", [1, 2].includes(3))
 console.log("parseint-hex", parseInt("0x1F", 16))

--- a/tests/core/parity_builtins.tish.expected
+++ b/tests/core/parity_builtins.tish.expected
@@ -22,6 +22,13 @@ sign-neg -1
 pad-empty x
 pad-space   x
 padend-empty x
+reduce-empty-throw TypeError
+reduce-empty-init 42
+reduce-empty-null null
+str-oob none
+str-neg none
+json-nul "\u0000"
+json-bs "\b"
 includes-nan true
 includes-no false
 parseint-hex 31

--- a/tests/main.js
+++ b/tests/main.js
@@ -3384,6 +3384,18 @@ console.log("sign-neg", Math.sign(-5))
 console.log("pad-empty", "x".padStart(3, ""))
 console.log("pad-space", "x".padStart(3))
 console.log("padend-empty", "x".padEnd(3, ""))
+// [].reduce with no initial value throws TypeError; an explicit init (incl. null) is returned as-is.
+let redThrew = "no"
+try { [].reduce((a, b) => a + b) } catch (e) { redThrew = e.name }
+console.log("reduce-empty-throw", redThrew)
+console.log("reduce-empty-init", [].reduce((a, b) => a + b, 42))
+console.log("reduce-empty-null", [].reduce((a, b) => a + b, null))
+// Out-of-range / negative string index reads falsy (null in tish, undefined in node) — no throw.
+console.log("str-oob", "abc"[10] || "none")
+console.log("str-neg", "abc"[-1] || "none")
+// JSON.stringify escapes control chars (valid JSON), not raw bytes.
+console.log("json-nul", JSON.stringify(String.fromCharCode(0)))
+console.log("json-bs", JSON.stringify(String.fromCharCode(8)))
 console.log("includes-nan", [1, 0 / 0].includes(0 / 0))
 console.log("includes-no", [1, 2].includes(3))
 console.log("parseint-hex", parseInt("0x1F", 16))

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3437,6 +3437,18 @@ console.log("sign-neg", Math.sign(-5))
 console.log("pad-empty", "x".padStart(3, ""))
 console.log("pad-space", "x".padStart(3))
 console.log("padend-empty", "x".padEnd(3, ""))
+// [].reduce with no initial value throws TypeError; an explicit init (incl. null) is returned as-is.
+let redThrew = "no"
+try { [].reduce((a, b) => a + b) } catch (e) { redThrew = e.name }
+console.log("reduce-empty-throw", redThrew)
+console.log("reduce-empty-init", [].reduce((a, b) => a + b, 42))
+console.log("reduce-empty-null", [].reduce((a, b) => a + b, null))
+// Out-of-range / negative string index reads falsy (null in tish, undefined in node) — no throw.
+console.log("str-oob", "abc"[10] || "none")
+console.log("str-neg", "abc"[-1] || "none")
+// JSON.stringify escapes control chars (valid JSON), not raw bytes.
+console.log("json-nul", JSON.stringify(String.fromCharCode(0)))
+console.log("json-bs", JSON.stringify(String.fromCharCode(8)))
 console.log("includes-nan", [1, 0 / 0].includes(0 / 0))
 console.log("includes-no", [1, 2].includes(3))
 console.log("parseint-hex", parseInt("0x1F", 16))


### PR DESCRIPTION
## Summary

Three cross-backend builtin divergences from the [#437](https://github.com/tishlang/tish/issues/437) audit — each makes a lagging backend agree with the others (validated interp/vm/native/node, locked with `parity_builtins` cases).

### 1. `[].reduce(fn)` no-init → throw (closes #441)
Empty array with no initial value silently returned `null` on **vm & native** instead of throwing `TypeError`. Root cause: the shared builtin used a `Value::Null` sentinel for "no initial", colliding with an explicit `null` init. Fixed by threading `Option<&Value>` (`None` = absent) through the shared `reduce`, the vm fusion path, and native codegen — so `[].reduce(fn)` throws while `[].reduce(fn, null)` correctly returns `null`. (interp was already correct.)

### 2. String out-of-range / negative index → `null` (not a throw)
`"abc"[10]` / `"abc"[-1]` threw an *uncatchable* `Index out of bounds` on the **vm**; interp/native/node read null/undefined. The vm now returns `null`. (vm-only fix.)

### 3. `JSON.stringify` control-char escaping (invalid JSON)
Control chars (`\b`, `\f`, `\u00xx`) were emitted as raw bytes — **invalid JSON** — by the **interpreter**, which hand-rolled a `.replace()` escaper that missed them. Routed through the shared `escape_json_string_into` (now public), the same escaper the vm/native path uses. (interp-only fix.)

Adds `tishlang_core::type_error(msg)` for parking a catchable throw from a shared builtin.

## Validation
- interp/vm/native/node agree on all three (parity_builtins cases added).
- `tishlang_builtins` + `tishlang_core` unit tests green (incl. updated `reduce_packed`).
- Heavy suites (integration, gauntlet soundness, regression examples+downstream, cross-backend parity) run in CI.

Refs #437.
