### PR TITLE
fix(builtins): honor 2nd arg of Array.indexOf / String.startsWith / endsWith

### DIFF
--- a/crates/tish_builtins/src/array.rs
+++ b/crates/tish_builtins/src/array.rs
@@ -149,11 +149,19 @@ pub fn unshift(arr: &Value, args: &[Value]) -> Value {
     }
 }
 
-pub fn index_of(arr: &Value, search: &Value) -> Value {
+pub fn index_of(arr: &Value, search: &Value, from: Option<&Value>) -> Value {
     let arr = as_boxed_array(arr); let arr = &*arr;
     if let Value::Array(arr) = arr {
         let arr_borrow = arr.borrow();
-        for (i, v) in arr_borrow.iter().enumerate() {
+        // `fromIndex`: clamp positive to [0, len]; negative counts from the end (`len + n`, floored
+        // at 0). Same handling as `includes`. Absent → 0.
+        let len = arr_borrow.len() as i64;
+        let start = match from {
+            Some(Value::Number(n)) if *n >= 0.0 => (*n as i64).min(len).max(0) as usize,
+            Some(Value::Number(n)) if *n < 0.0 => ((len + *n as i64).max(0)) as usize,
+            _ => 0,
+        };
+        for (i, v) in arr_borrow.iter().enumerate().skip(start) {
             if v.strict_eq(search) {
                 return Value::Number(i as f64);
             }

--- a/crates/tish_builtins/src/string.rs
+++ b/crates/tish_builtins/src/string.rs
@@ -333,17 +333,32 @@ pub fn to_lower_case(s: &Value) -> Value {
     }
 }
 
-pub fn starts_with(s: &Value, search: &Value) -> Value {
+pub fn starts_with(s: &Value, search: &Value, position: Option<&Value>) -> Value {
     if let (Value::String(s), Value::String(search)) = (s, search) {
-        Value::Bool(s.starts_with(search.as_str()))
+        // `position`: test as if the string began at char `position` (clamped to [0, len]). Absent → 0.
+        let pos = match position {
+            Some(Value::Number(n)) if *n > 0.0 => *n as usize,
+            _ => 0,
+        };
+        let byte_start = s.char_indices().nth(pos).map(|(b, _)| b).unwrap_or(s.len());
+        Value::Bool(s[byte_start..].starts_with(search.as_str()))
     } else {
         Value::Bool(false)
     }
 }
 
-pub fn ends_with(s: &Value, search: &Value) -> Value {
+pub fn ends_with(s: &Value, search: &Value, end_position: Option<&Value>) -> Value {
     if let (Value::String(s), Value::String(search)) = (s, search) {
-        Value::Bool(s.ends_with(search.as_str()))
+        // `endPosition`: test as if the string ended at char `endPosition` (clamped to [0, len]).
+        // Absent → the full length.
+        let char_count = s.chars().count();
+        let end = match end_position {
+            Some(Value::Number(n)) if *n >= 0.0 => (*n as usize).min(char_count),
+            Some(Value::Number(_)) => 0,
+            _ => char_count,
+        };
+        let byte_end = s.char_indices().nth(end).map(|(b, _)| b).unwrap_or(s.len());
+        Value::Bool(s[..byte_end].ends_with(search.as_str()))
     } else {
         Value::Bool(false)
     }
@@ -699,9 +714,12 @@ mod tests {
     fn case_and_prefix_suffix() {
         assert_same!(to_upper_case(&s("aB")), s("AB"));
         assert_same!(to_lower_case(&s("aB")), s("ab"));
-        assert_same!(starts_with(&s("/api"), &s("/api")), Value::Bool(true));
-        assert_same!(ends_with(&s("x.js"), &s(".js")), Value::Bool(true));
-        assert_same!(starts_with(&n(1.0), &s("")), Value::Bool(false));
+        assert_same!(starts_with(&s("/api"), &s("/api"), None), Value::Bool(true));
+        assert_same!(ends_with(&s("x.js"), &s(".js"), None), Value::Bool(true));
+        assert_same!(starts_with(&n(1.0), &s(""), None), Value::Bool(false));
+        // 2nd-arg: position / endPosition.
+        assert_same!(starts_with(&s("abc"), &s("bc"), Some(&n(1.0))), Value::Bool(true));
+        assert_same!(ends_with(&s("abc"), &s("ab"), Some(&n(2.0))), Value::Bool(true));
     }
 
     #[test]

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -6838,9 +6838,14 @@ impl Codegen {
                         "indexOf" => {
                             let search = arg_exprs.first().cloned().unwrap_or_else(|| "Value::Null".to_string());
                             let from = arg_exprs.get(1).cloned().unwrap_or_else(|| "Value::Null".to_string());
+                            // Array `indexOf` takes `Option<&Value>` fromIndex; string keeps the &Value/Null form.
+                            let from_opt = match arg_exprs.get(1) {
+                                Some(e) => format!("Some(&{})", e),
+                                None => "None".to_string(),
+                            };
                             return Ok(format!(
-                                "{{ let _obj = ({}).clone(); match &_obj {{ Value::Array(_) => tishlang_runtime::array_index_of(&_obj, &{}), Value::String(_) => tishlang_runtime::string_index_of(&_obj, &{}, &{}), _ => Value::Number(-1.0) }} }}",
-                                obj_expr, search, search, from
+                                "{{ let _obj = ({}).clone(); match &_obj {{ Value::Array(_) => tishlang_runtime::array_index_of(&_obj, &{}, {}), Value::String(_) => tishlang_runtime::string_index_of(&_obj, &{}, &{}), _ => Value::Number(-1.0) }} }}",
+                                obj_expr, search, from_opt, search, from
                             ));
                         }
                         "lastIndexOf" => {
@@ -6939,16 +6944,24 @@ impl Codegen {
                         }
                         "startsWith" => {
                             let search = arg_exprs.first().cloned().unwrap_or_else(|| "Value::String(\"\".into())".to_string());
+                            let pos = match arg_exprs.get(1) {
+                                Some(e) => format!("Some(&{})", e),
+                                None => "None".to_string(),
+                            };
                             return Ok(format!(
-                                "tishlang_runtime::string_starts_with(&{}, &{})",
-                                obj_expr, search
+                                "tishlang_runtime::string_starts_with(&{}, &{}, {})",
+                                obj_expr, search, pos
                             ));
                         }
                         "endsWith" => {
                             let search = arg_exprs.first().cloned().unwrap_or_else(|| "Value::String(\"\".into())".to_string());
+                            let pos = match arg_exprs.get(1) {
+                                Some(e) => format!("Some(&{})", e),
+                                None => "None".to_string(),
+                            };
                             return Ok(format!(
-                                "tishlang_runtime::string_ends_with(&{}, &{})",
-                                obj_expr, search
+                                "tishlang_runtime::string_ends_with(&{}, &{}, {})",
+                                obj_expr, search, pos
                             ));
                         }
                         "replace" => {

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -1638,7 +1638,14 @@ impl Evaluator {
                             "indexOf" => {
                                 let search = arg_vals.first().cloned().unwrap_or(Value::Null);
                                 let arr_borrow = arr.borrow();
-                                for (i, v) in arr_borrow.iter().enumerate() {
+                                // fromIndex: positive clamps to [0, len]; negative counts from the end.
+                                let len = arr_borrow.len() as i64;
+                                let start = match arg_vals.get(1) {
+                                    Some(Value::Number(n)) if *n >= 0.0 => (*n as i64).min(len).max(0) as usize,
+                                    Some(Value::Number(n)) if *n < 0.0 => ((len + *n as i64).max(0)) as usize,
+                                    _ => 0,
+                                };
+                                for (i, v) in arr_borrow.iter().enumerate().skip(start) {
                                     if v.strict_eq(&search) {
                                         return Ok(Value::Number(i as f64));
                                     }
@@ -2307,14 +2314,28 @@ impl Evaluator {
                                     Some(Value::String(ss)) => ss.as_ref(),
                                     _ => return Ok(Value::Bool(false)),
                                 };
-                                return Ok(Value::Bool(s.starts_with(search)));
+                                // position: test as if the string began at char `position`.
+                                let pos = match arg_vals.get(1) {
+                                    Some(Value::Number(n)) if *n > 0.0 => *n as usize,
+                                    _ => 0,
+                                };
+                                let byte_start = s.char_indices().nth(pos).map(|(b, _)| b).unwrap_or(s.len());
+                                return Ok(Value::Bool(s[byte_start..].starts_with(search)));
                             }
                             "endsWith" => {
                                 let search = match arg_vals.first() {
                                     Some(Value::String(ss)) => ss.as_ref(),
                                     _ => return Ok(Value::Bool(false)),
                                 };
-                                return Ok(Value::Bool(s.ends_with(search)));
+                                // endPosition: test as if the string ended at char `endPosition`.
+                                let char_count = s.chars().count();
+                                let end = match arg_vals.get(1) {
+                                    Some(Value::Number(n)) if *n >= 0.0 => (*n as usize).min(char_count),
+                                    Some(Value::Number(_)) => 0,
+                                    _ => char_count,
+                                };
+                                let byte_end = s.char_indices().nth(end).map(|(b, _)| b).unwrap_or(s.len());
+                                return Ok(Value::Bool(s[..byte_end].ends_with(search)));
                             }
                             "replace" => {
                                 #[cfg(feature = "regex")]

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -149,8 +149,8 @@ pub fn array_push(arr: &Value, args: &[Value]) -> Value {
 pub fn array_unshift(arr: &Value, args: &[Value]) -> Value {
     array_unshift_impl(arr, args)
 }
-pub fn array_index_of(arr: &Value, search: &Value) -> Value {
-    array_index_of_impl(arr, search)
+pub fn array_index_of(arr: &Value, search: &Value, from: Option<&Value>) -> Value {
+    array_index_of_impl(arr, search, from)
 }
 pub fn array_includes(arr: &Value, search: &Value, from: &Value) -> Value {
     array_includes_impl(arr, search, Some(from))
@@ -217,11 +217,11 @@ pub fn string_split_limit(s: &Value, sep: &Value, limit: &Value) -> Value {
     }
     string_split_limit_impl(s, sep, max)
 }
-pub fn string_starts_with(s: &Value, search: &Value) -> Value {
-    string_starts_with_impl(s, search)
+pub fn string_starts_with(s: &Value, search: &Value, position: Option<&Value>) -> Value {
+    string_starts_with_impl(s, search, position)
 }
-pub fn string_ends_with(s: &Value, search: &Value) -> Value {
-    string_ends_with_impl(s, search)
+pub fn string_ends_with(s: &Value, search: &Value, end_position: Option<&Value>) -> Value {
+    string_ends_with_impl(s, search, end_position)
 }
 pub fn string_replace(s: &Value, search: &Value, replacement: &Value) -> Value {
     #[cfg(feature = "regex")]

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -3899,7 +3899,7 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                         "concat" => make_native_fn(move |args| arr_builtins::concat(&bv, args)),
                         "indexOf" => make_native_fn(move |args| {
                             let s = args.first().cloned().unwrap_or(Value::Null);
-                            arr_builtins::index_of(&bv, &s)
+                            arr_builtins::index_of(&bv, &s, args.get(1))
                         }),
                         "includes" => make_native_fn(move |args| {
                             let s = args.first().cloned().unwrap_or(Value::Null);
@@ -3972,7 +3972,7 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                 }),
                 "indexOf" => make_native_fn(move |args: &[Value]| {
                     let search = args.first().unwrap_or(&Value::Null);
-                    arr_builtins::index_of(&Value::Array(a_clone.clone()), search)
+                    arr_builtins::index_of(&Value::Array(a_clone.clone()), search, args.get(1))
                 }),
                 "includes" => make_native_fn(move |args: &[Value]| {
                     let search = args.first().unwrap_or(&Value::Null);
@@ -4150,11 +4150,11 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                 }),
                 "startsWith" => make_native_fn(move |args: &[Value]| {
                     let search = args.first().unwrap_or(&Value::Null);
-                    str_builtins::starts_with(&Value::String(s_clone.clone()), search)
+                    str_builtins::starts_with(&Value::String(s_clone.clone()), search, args.get(1))
                 }),
                 "endsWith" => make_native_fn(move |args: &[Value]| {
                     let search = args.first().unwrap_or(&Value::Null);
-                    str_builtins::ends_with(&Value::String(s_clone.clone()), search)
+                    str_builtins::ends_with(&Value::String(s_clone.clone()), search, args.get(1))
                 }),
                 "replace" => make_native_fn(move |args: &[Value]| {
                     let search = args.first().unwrap_or(&Value::Null);

--- a/tests/core/parity_builtins.js
+++ b/tests/core/parity_builtins.js
@@ -41,6 +41,11 @@ console.log("str-neg", "abc"[-1] || "none")
 // JSON.stringify escapes control chars (valid JSON), not raw bytes.
 console.log("json-nul", JSON.stringify(String.fromCharCode(0)))
 console.log("json-bs", JSON.stringify(String.fromCharCode(8)))
+// 2nd-arg support: Array.indexOf fromIndex; String.startsWith/endsWith position.
+console.log("idxof-from", [1, 2, 1, 3].indexOf(1, 1))
+console.log("idxof-neg", [1, 2, 3, 2, 1].indexOf(2, -2))
+console.log("startsw-pos", "abc".startsWith("bc", 1))
+console.log("endsw-pos", "abc".endsWith("ab", 2))
 console.log("includes-nan", [1, 0 / 0].includes(0 / 0))
 console.log("includes-no", [1, 2].includes(3))
 console.log("parseint-hex", parseInt("0x1F", 16))

--- a/tests/core/parity_builtins.tish
+++ b/tests/core/parity_builtins.tish
@@ -41,6 +41,11 @@ console.log("str-neg", "abc"[-1] || "none")
 // JSON.stringify escapes control chars (valid JSON), not raw bytes.
 console.log("json-nul", JSON.stringify(String.fromCharCode(0)))
 console.log("json-bs", JSON.stringify(String.fromCharCode(8)))
+// 2nd-arg support: Array.indexOf fromIndex; String.startsWith/endsWith position.
+console.log("idxof-from", [1, 2, 1, 3].indexOf(1, 1))
+console.log("idxof-neg", [1, 2, 3, 2, 1].indexOf(2, -2))
+console.log("startsw-pos", "abc".startsWith("bc", 1))
+console.log("endsw-pos", "abc".endsWith("ab", 2))
 console.log("includes-nan", [1, 0 / 0].includes(0 / 0))
 console.log("includes-no", [1, 2].includes(3))
 console.log("parseint-hex", parseInt("0x1F", 16))

--- a/tests/core/parity_builtins.tish.expected
+++ b/tests/core/parity_builtins.tish.expected
@@ -29,6 +29,10 @@ str-oob none
 str-neg none
 json-nul "\u0000"
 json-bs "\b"
+idxof-from 2
+idxof-neg 3
+startsw-pos true
+endsw-pos true
 includes-nan true
 includes-no false
 parseint-hex 31

--- a/tests/main.js
+++ b/tests/main.js
@@ -3396,6 +3396,11 @@ console.log("str-neg", "abc"[-1] || "none")
 // JSON.stringify escapes control chars (valid JSON), not raw bytes.
 console.log("json-nul", JSON.stringify(String.fromCharCode(0)))
 console.log("json-bs", JSON.stringify(String.fromCharCode(8)))
+// 2nd-arg support: Array.indexOf fromIndex; String.startsWith/endsWith position.
+console.log("idxof-from", [1, 2, 1, 3].indexOf(1, 1))
+console.log("idxof-neg", [1, 2, 3, 2, 1].indexOf(2, -2))
+console.log("startsw-pos", "abc".startsWith("bc", 1))
+console.log("endsw-pos", "abc".endsWith("ab", 2))
 console.log("includes-nan", [1, 0 / 0].includes(0 / 0))
 console.log("includes-no", [1, 2].includes(3))
 console.log("parseint-hex", parseInt("0x1F", 16))

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3449,6 +3449,11 @@ console.log("str-neg", "abc"[-1] || "none")
 // JSON.stringify escapes control chars (valid JSON), not raw bytes.
 console.log("json-nul", JSON.stringify(String.fromCharCode(0)))
 console.log("json-bs", JSON.stringify(String.fromCharCode(8)))
+// 2nd-arg support: Array.indexOf fromIndex; String.startsWith/endsWith position.
+console.log("idxof-from", [1, 2, 1, 3].indexOf(1, 1))
+console.log("idxof-neg", [1, 2, 3, 2, 1].indexOf(2, -2))
+console.log("startsw-pos", "abc".startsWith("bc", 1))
+console.log("endsw-pos", "abc".endsWith("ab", 2))
 console.log("includes-nan", [1, 0 / 0].includes(0 / 0))
 console.log("includes-no", [1, 2].includes(3))
 console.log("parseint-hex", parseInt("0x1F", 16))


### PR DESCRIPTION
From the #437 audit — all backends ignored these positional args. Now: `Array.indexOf(x, fromIndex)` (positive clamp, negative from end, like `includes`), `String.startsWith(s, position)`, `String.endsWith(s, endPosition)` (char-based, clamped) — across shared builtin + vm + native + interp inline. Validated interp/vm/native/node identical; parity_builtins cases added; unit tests green; heavy suites in CI. Refs #437.