### PR TITLE
feat(string): add String.prototype.trimStart / trimEnd

### DIFF
--- a/crates/tish_builtins/src/string.rs
+++ b/crates/tish_builtins/src/string.rs
@@ -317,6 +317,22 @@ pub fn trim(s: &Value) -> Value {
     }
 }
 
+pub fn trim_start(s: &Value) -> Value {
+    if let Value::String(s) = s {
+        Value::String(s.trim_start().into())
+    } else {
+        Value::Null
+    }
+}
+
+pub fn trim_end(s: &Value) -> Value {
+    if let Value::String(s) = s {
+        Value::String(s.trim_end().into())
+    } else {
+        Value::Null
+    }
+}
+
 pub fn to_upper_case(s: &Value) -> Value {
     if let Value::String(s) = s {
         Value::String(s.to_uppercase().into())

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -6936,6 +6936,12 @@ impl Codegen {
                         "trim" => {
                             return Ok(format!("tishlang_runtime::string_trim(&{})", obj_expr));
                         }
+                        "trimStart" => {
+                            return Ok(format!("tishlang_runtime::string_trim_start(&{})", obj_expr));
+                        }
+                        "trimEnd" => {
+                            return Ok(format!("tishlang_runtime::string_trim_end(&{})", obj_expr));
+                        }
                         "toUpperCase" => {
                             return Ok(format!("tishlang_runtime::string_to_upper_case(&{})", obj_expr));
                         }

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -2303,6 +2303,12 @@ impl Evaluator {
                             "trim" => {
                                 return Ok(Value::String(s.trim().into()));
                             }
+                            "trimStart" => {
+                                return Ok(Value::String(s.trim_start().into()));
+                            }
+                            "trimEnd" => {
+                                return Ok(Value::String(s.trim_end().into()));
+                            }
                             "toUpperCase" => {
                                 return Ok(Value::String(s.to_uppercase().into()));
                             }

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -139,7 +139,7 @@ pub use tishlang_builtins::string::{
     starts_with as string_starts_with_impl, substr as string_substr_impl,
     substring as string_substring_impl,
     to_lower_case as string_to_lower_case, to_upper_case as string_to_upper_case,
-    trim as string_trim,
+    trim as string_trim, trim_end as string_trim_end, trim_start as string_trim_start,
 };
 
 // Wrapper functions to maintain API compatibility

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -4142,6 +4142,12 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                 "trim" => make_native_fn(move |_args: &[Value]| {
                     str_builtins::trim(&Value::String(s_clone.clone()))
                 }),
+                "trimStart" => make_native_fn(move |_args: &[Value]| {
+                    str_builtins::trim_start(&Value::String(s_clone.clone()))
+                }),
+                "trimEnd" => make_native_fn(move |_args: &[Value]| {
+                    str_builtins::trim_end(&Value::String(s_clone.clone()))
+                }),
                 "toUpperCase" => make_native_fn(move |_args: &[Value]| {
                     str_builtins::to_upper_case(&Value::String(s_clone.clone()))
                 }),

--- a/tests/core/parity_builtins.js
+++ b/tests/core/parity_builtins.js
@@ -49,6 +49,8 @@ console.log("endsw-pos", "abc".endsWith("ab", 2))
 // Global isNaN/isFinite coerce their arg via ToNumber (like Number()).
 console.log("isnan-str", isNaN("3"), isNaN("x"), isNaN(""))
 console.log("isfinite-str", isFinite("3"), isFinite("x"), isFinite(""))
+console.log("trimstart", "[" + "  x  ".trimStart() + "]")
+console.log("trimend", "[" + "  x  ".trimEnd() + "]")
 console.log("includes-nan", [1, 0 / 0].includes(0 / 0))
 console.log("includes-no", [1, 2].includes(3))
 console.log("parseint-hex", parseInt("0x1F", 16))

--- a/tests/core/parity_builtins.tish
+++ b/tests/core/parity_builtins.tish
@@ -49,6 +49,8 @@ console.log("endsw-pos", "abc".endsWith("ab", 2))
 // Global isNaN/isFinite coerce their arg via ToNumber (like Number()).
 console.log("isnan-str", isNaN("3"), isNaN("x"), isNaN(""))
 console.log("isfinite-str", isFinite("3"), isFinite("x"), isFinite(""))
+console.log("trimstart", "[" + "  x  ".trimStart() + "]")
+console.log("trimend", "[" + "  x  ".trimEnd() + "]")
 console.log("includes-nan", [1, 0 / 0].includes(0 / 0))
 console.log("includes-no", [1, 2].includes(3))
 console.log("parseint-hex", parseInt("0x1F", 16))

--- a/tests/core/parity_builtins.tish.expected
+++ b/tests/core/parity_builtins.tish.expected
@@ -35,6 +35,8 @@ startsw-pos true
 endsw-pos true
 isnan-str false true false
 isfinite-str true false true
+trimstart [x  ]
+trimend [  x]
 includes-nan true
 includes-no false
 parseint-hex 31

--- a/tests/main.js
+++ b/tests/main.js
@@ -3404,6 +3404,8 @@ console.log("endsw-pos", "abc".endsWith("ab", 2))
 // Global isNaN/isFinite coerce their arg via ToNumber (like Number()).
 console.log("isnan-str", isNaN("3"), isNaN("x"), isNaN(""))
 console.log("isfinite-str", isFinite("3"), isFinite("x"), isFinite(""))
+console.log("trimstart", "[" + "  x  ".trimStart() + "]")
+console.log("trimend", "[" + "  x  ".trimEnd() + "]")
 console.log("includes-nan", [1, 0 / 0].includes(0 / 0))
 console.log("includes-no", [1, 2].includes(3))
 console.log("parseint-hex", parseInt("0x1F", 16))

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3457,6 +3457,8 @@ console.log("endsw-pos", "abc".endsWith("ab", 2))
 // Global isNaN/isFinite coerce their arg via ToNumber (like Number()).
 console.log("isnan-str", isNaN("3"), isNaN("x"), isNaN(""))
 console.log("isfinite-str", isFinite("3"), isFinite("x"), isFinite(""))
+console.log("trimstart", "[" + "  x  ".trimStart() + "]")
+console.log("trimend", "[" + "  x  ".trimEnd() + "]")
 console.log("includes-nan", [1, 0 / 0].includes(0 / 0))
 console.log("includes-no", [1, 2].includes(3))
 console.log("parseint-hex", parseInt("0x1F", 16))


### PR DESCRIPTION
From the #437 missing-builtins list. Trivial additive methods (Rust trim_start/trim_end, same Unicode whitespace as the shipped `trim`), wired across shared builtin + vm + interp + native. Validated interp/vm/native/node identical; parity case added. Refs #437.