### PR TITLE
feat(array): ES2023 toReversed/toSorted/with/toSpliced

### DIFF
--- a/crates/tish_builtins/src/array.rs
+++ b/crates/tish_builtins/src/array.rs
@@ -226,6 +226,57 @@ pub fn reverse(arr: &Value) -> Value {
     }
 }
 
+/// `Array.prototype.toReversed()` — a reversed COPY (ES2023); the receiver is untouched.
+pub fn to_reversed(arr: &Value) -> Value {
+    let mut v = snapshot_values(arr);
+    v.reverse();
+    Value::Array(VmRef::new(v))
+}
+
+/// `Array.prototype.toSorted(cmp?)` — a sorted COPY (ES2023); the receiver is untouched. Sorting runs
+/// on the copy via the same comparator/default machinery as `sort`.
+pub fn to_sorted(arr: &Value, comparator: Option<&Value>) -> Value {
+    let copy = Value::Array(VmRef::new(snapshot_values(arr)));
+    match comparator {
+        Some(cmp @ Value::Function(_)) => sort_with_comparator(&copy, cmp),
+        _ => sort_default(&copy),
+    }
+}
+
+/// `Array.prototype.with(index, value)` — a COPY with `index` replaced (ES2023). A negative index
+/// counts from the end; an out-of-range index parks a catchable `RangeError` (matches node's message).
+pub fn with(arr: &Value, index: &Value, value: &Value) -> Value {
+    let mut v = snapshot_values(arr);
+    let len = v.len() as i64;
+    let rel = match index {
+        Value::Number(n) if n.is_finite() => *n as i64,
+        _ => 0,
+    };
+    let actual = if rel >= 0 { rel } else { len + rel };
+    if actual < 0 || actual >= len {
+        tishlang_core::set_pending_throw(tishlang_core::range_error(format!(
+            "Invalid index : {}",
+            rel
+        )));
+        return Value::Null;
+    }
+    v[actual as usize] = value.clone();
+    Value::Array(VmRef::new(v))
+}
+
+/// `Array.prototype.toSpliced(start, deleteCount?, ...items)` — a COPY with the splice applied (ES2023);
+/// unlike `splice` (which returns the removed elements) this returns the resulting array.
+pub fn to_spliced(
+    arr: &Value,
+    start: &Value,
+    delete_count: Option<&Value>,
+    items: &[Value],
+) -> Value {
+    let copy = Value::Array(VmRef::new(snapshot_values(arr)));
+    splice(&copy, start, delete_count, items);
+    copy
+}
+
 /// Fisher-Yates shuffle. Returns a new shuffled array (does not mutate).
 pub fn shuffle(arr: &Value) -> Value {
     let arr = as_boxed_array(arr); let arr = &*arr;

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -6928,6 +6928,9 @@ impl Codegen {
                         "reverse" => {
                             return Ok(format!("tishlang_runtime::array_reverse(&{})", obj_expr));
                         }
+                        "toReversed" => {
+                            return Ok(format!("tishlang_runtime::array_to_reversed(&{})", obj_expr));
+                        }
                         "fill" => {
                             let value = arg_exprs.first().cloned().unwrap_or_else(|| "Value::Null".to_string());
                             let start = arg_exprs.get(1).cloned().unwrap_or_else(|| "Value::Null".to_string());
@@ -7285,6 +7288,38 @@ impl Codegen {
                             return Ok(format!(
                                 "tishlang_runtime::array_splice(&{}, &{}, {}, {})",
                                 obj_expr, start, delete_count, items
+                            ));
+                        }
+                        "toSpliced" => {
+                            let start = arg_exprs.first().cloned().unwrap_or_else(|| "Value::Number(0.0)".to_string());
+                            let delete_count = arg_exprs.get(1).map(|d| format!("Some(&{})", d)).unwrap_or_else(|| "None".to_string());
+                            let items = if arg_exprs.len() > 2 {
+                                let items_vec = arg_exprs[2..].iter()
+                                    .map(|a| format!("{}.clone()", a))
+                                    .collect::<Vec<_>>()
+                                    .join(", ");
+                                format!("&[{}]", items_vec)
+                            } else {
+                                "&[]".to_string()
+                            };
+                            return Ok(format!(
+                                "tishlang_runtime::array_to_spliced(&{}, &{}, {}, {})",
+                                obj_expr, start, delete_count, items
+                            ));
+                        }
+                        "toSorted" => {
+                            let comparator = arg_exprs.first().map(|c| format!("Some(&{})", c)).unwrap_or_else(|| "None".to_string());
+                            return Ok(format!(
+                                "tishlang_runtime::array_to_sorted(&{}, {})",
+                                obj_expr, comparator
+                            ));
+                        }
+                        "with" => {
+                            let index = arg_exprs.first().cloned().unwrap_or_else(|| "Value::Null".to_string());
+                            let value = arg_exprs.get(1).cloned().unwrap_or_else(|| "Value::Null".to_string());
+                            return Ok(format!(
+                                "tishlang_runtime::array_with(&{}, &{}, &{})",
+                                obj_expr, index, value
                             ));
                         }
                         "flat" => {
@@ -8502,6 +8537,7 @@ impl Codegen {
                 | "normalize" | "localeCompare" | "map" | "filter" | "reduce" | "reduceRight"
                 | "forEach" | "find" | "findIndex" | "findLast" | "findLastIndex" | "some" | "every"
                 | "join" | "flat" | "flatMap" | "keys" | "values" | "entries"
+                | "toReversed" | "toSorted" | "with" | "toSpliced"
         )
     }
 

--- a/crates/tish_core/src/lib.rs
+++ b/crates/tish_core/src/lib.rs
@@ -189,6 +189,22 @@ pub fn type_error(message: impl Into<String>) -> Value {
     Value::object(e)
 }
 
+/// A catchable `RangeError` with an arbitrary message (`{ name: "RangeError", message }`), matching the
+/// VM/interpreter/node shape. Used to PARK a pending throw from a shared builtin that returns a plain
+/// `Value` (e.g. `[1,2].with(5, x)` with an out-of-range index).
+pub fn range_error(message: impl Into<String>) -> Value {
+    let mut e = ObjectMap::default();
+    e.insert(
+        std::sync::Arc::from("name"),
+        Value::String("RangeError".into()),
+    );
+    e.insert(
+        std::sync::Arc::from("message"),
+        Value::String(message.into().into()),
+    );
+    Value::object(e)
+}
+
 /// A catchable `TypeError` for reading a property/index of the nullish value — the `{ name, message }`
 /// shape matches the VM/interpreter/node (`e.name === "TypeError"`). Used to PARK a pending throw in
 /// the native/runtime `get_prop`/`get_index` null arm (#425), so `null.length` / `null[0]` surface a

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -1815,6 +1815,91 @@ impl Evaluator {
                                 arr.borrow_mut().reverse();
                                 return Ok(obj.clone());
                             }
+                            "toReversed" => {
+                                // ES2023: a reversed COPY; the receiver is untouched.
+                                let mut v = arr.borrow().clone();
+                                v.reverse();
+                                return Ok(Value::Array(Rc::new(RefCell::new(v))));
+                            }
+                            "toSorted" => {
+                                // ES2023: a sorted COPY. Uses the general comparator/default path (the
+                                // numeric fast-paths in `sort` are speed-only and give identical order).
+                                let comparator = arg_vals.into_iter().next();
+                                let arr_values: Vec<Value> = arr.borrow().clone();
+                                let len = arr_values.len();
+                                let mut indices: Vec<usize> = (0..len).collect();
+                                if let Some(cmp_fn) = comparator {
+                                    let mut pending: Option<EvalError> = None;
+                                    indices.sort_by(|&i, &j| {
+                                        if pending.is_some() {
+                                            return std::cmp::Ordering::Equal;
+                                        }
+                                        match self.call_func(&cmp_fn, &[arr_values[i].clone(), arr_values[j].clone()]) {
+                                            Ok(Value::Number(n)) if n < 0.0 => std::cmp::Ordering::Less,
+                                            Ok(Value::Number(n)) if n > 0.0 => std::cmp::Ordering::Greater,
+                                            Ok(_) => std::cmp::Ordering::Equal,
+                                            Err(e) => { pending = Some(e); std::cmp::Ordering::Equal }
+                                        }
+                                    });
+                                    if let Some(e) = pending {
+                                        return Err(e);
+                                    }
+                                } else {
+                                    indices.sort_by(|&i, &j| {
+                                        arr_values[i].to_string().cmp(&arr_values[j].to_string())
+                                    });
+                                }
+                                let sorted: Vec<Value> =
+                                    indices.into_iter().map(|i| arr_values[i].clone()).collect();
+                                return Ok(Value::Array(Rc::new(RefCell::new(sorted))));
+                            }
+                            "with" => {
+                                // ES2023: a COPY with one index replaced; negative index counts from the
+                                // end; out-of-range throws a catchable RangeError (matches vm/native/node).
+                                let index = arg_vals.first().cloned().unwrap_or(Value::Null);
+                                let value = arg_vals.get(1).cloned().unwrap_or(Value::Null);
+                                let mut v = arr.borrow().clone();
+                                let len = v.len() as i64;
+                                let rel = match index {
+                                    Value::Number(n) if n.is_finite() => n as i64,
+                                    _ => 0,
+                                };
+                                let actual = if rel >= 0 { rel } else { len + rel };
+                                if actual < 0 || actual >= len {
+                                    let err = crate::natives::range_error_construct(&[Value::String(
+                                        format!("Invalid index : {}", rel).into(),
+                                    )])
+                                    .unwrap_or(Value::Null);
+                                    return Err(EvalError::Throw(err));
+                                }
+                                v[actual as usize] = value;
+                                return Ok(Value::Array(Rc::new(RefCell::new(v))));
+                            }
+                            "toSpliced" => {
+                                // ES2023: a COPY with the splice applied; returns the resulting array
+                                // (splice returns the removed elements). Same normalization as `splice`.
+                                let mut result = arr.borrow().clone();
+                                let len = result.len() as i64;
+                                let start = match arg_vals.first() {
+                                    Some(Value::Number(n)) => {
+                                        let n = *n as i64;
+                                        if n < 0 { (len + n).max(0) as usize } else { n.min(len) as usize }
+                                    }
+                                    _ => 0,
+                                };
+                                let delete_count = match arg_vals.get(1) {
+                                    Some(Value::Number(n)) => (*n as i64).max(0) as usize,
+                                    _ => (len as usize).saturating_sub(start),
+                                };
+                                let actual_delete = delete_count.min(result.len().saturating_sub(start));
+                                result.drain(start..start + actual_delete);
+                                if arg_vals.len() > 2 {
+                                    for (i, item) in arg_vals[2..].iter().cloned().enumerate() {
+                                        result.insert(start + i, item);
+                                    }
+                                }
+                                return Ok(Value::Array(Rc::new(RefCell::new(result))));
+                            }
                             "fill" => {
                                 // Array.prototype.fill(value, start?, end?) — in place (issue #76).
                                 let value = arg_vals.first().cloned().unwrap_or(Value::Null);

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -126,6 +126,8 @@ pub use tishlang_builtins::array::{
     sort_by_keys as array_sort_by_keys, sort_default as array_sort_default,
     sort_numeric_asc as array_sort_numeric_asc, sort_numeric_desc as array_sort_numeric_desc,
     sort_with_comparator as array_sort_with_comparator, splice as array_splice_impl,
+    to_reversed as array_to_reversed, to_sorted as array_to_sorted,
+    to_spliced as array_to_spliced, with as array_with,
     unshift as array_unshift_impl,
 };
 

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -3939,6 +3939,21 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                             arr_builtins::flat_map(&bv, &cb)
                         }),
                         "reverse" => make_native_fn(move |_| arr_builtins::reverse(&bv)),
+                        "toReversed" => make_native_fn(move |_| arr_builtins::to_reversed(&bv)),
+                        "toSorted" => {
+                            make_native_fn(move |args| arr_builtins::to_sorted(&bv, args.first()))
+                        }
+                        "with" => make_native_fn(move |args| {
+                            let i = args.first().cloned().unwrap_or(Value::Null);
+                            let v = args.get(1).cloned().unwrap_or(Value::Null);
+                            arr_builtins::with(&bv, &i, &v)
+                        }),
+                        "toSpliced" => make_native_fn(move |args| {
+                            let start = args.first().cloned().unwrap_or(Value::Null);
+                            let dc = args.get(1).cloned();
+                            let items: Vec<Value> = args.iter().skip(2).cloned().collect();
+                            arr_builtins::to_spliced(&bv, &start, dc.as_ref(), &items)
+                        }),
                         "fill" => make_native_fn(move |args| {
                             let v = args.first().cloned().unwrap_or(Value::Null);
                             let s = args.get(1).cloned().unwrap_or(Value::Null);
@@ -4152,6 +4167,28 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                     let delete_count = args.get(1).map(|v| v as &Value);
                     let items: Vec<Value> = args.get(2..).unwrap_or(&[]).to_vec();
                     arr_builtins::splice(
+                        &Value::Array(a_clone.clone()),
+                        start,
+                        delete_count,
+                        &items,
+                    )
+                }),
+                "toReversed" => make_native_fn(move |_: &[Value]| {
+                    arr_builtins::to_reversed(&Value::Array(a_clone.clone()))
+                }),
+                "toSorted" => make_native_fn(move |args: &[Value]| {
+                    arr_builtins::to_sorted(&Value::Array(a_clone.clone()), args.first())
+                }),
+                "with" => make_native_fn(move |args: &[Value]| {
+                    let i = args.first().cloned().unwrap_or(Value::Null);
+                    let v = args.get(1).cloned().unwrap_or(Value::Null);
+                    arr_builtins::with(&Value::Array(a_clone.clone()), &i, &v)
+                }),
+                "toSpliced" => make_native_fn(move |args: &[Value]| {
+                    let start = args.first().unwrap_or(&Value::Null);
+                    let delete_count = args.get(1).map(|v| v as &Value);
+                    let items: Vec<Value> = args.get(2..).unwrap_or(&[]).to_vec();
+                    arr_builtins::to_spliced(
                         &Value::Array(a_clone.clone()),
                         start,
                         delete_count,

--- a/tests/core/parity_builtins.js
+++ b/tests/core/parity_builtins.js
@@ -104,3 +104,13 @@ console.log("scarr", JSON.stringify(structuredClone([1,[2,3]])));
 let _scc = { k: 1 }; _scc.self = _scc;
 let _scd = structuredClone(_scc);
 console.log("sccycle", _scd.self === _scd);
+// ES2023 change-array-by-copy — toReversed/toSorted/with/toSpliced (#437)
+let _bc = [3, 1, 2];
+console.log("bcSorted", JSON.stringify(_bc.toSorted()), JSON.stringify(_bc));
+console.log("bcSortedCmp", JSON.stringify([3,1,2,10].toSorted((x,y)=>x-y)));
+console.log("bcReversed", JSON.stringify(_bc.toReversed()), JSON.stringify(_bc));
+console.log("bcWith", JSON.stringify(_bc.with(1, 99)), JSON.stringify([1,2,3].with(-1, 9)));
+console.log("bcSpliced", JSON.stringify([1,2,3,4].toSpliced(1, 2, "a", "b")), JSON.stringify([1,2,3,4].toSpliced(1)));
+let _bcerr = "none";
+try { [1,2,3].with(5, 0); } catch (e) { _bcerr = e.name; }
+console.log("bcWithErr", _bcerr);

--- a/tests/core/parity_builtins.tish
+++ b/tests/core/parity_builtins.tish
@@ -104,3 +104,13 @@ console.log("scarr", JSON.stringify(structuredClone([1,[2,3]])));
 let _scc = { k: 1 }; _scc.self = _scc;
 let _scd = structuredClone(_scc);
 console.log("sccycle", _scd.self === _scd);
+// ES2023 change-array-by-copy — toReversed/toSorted/with/toSpliced (#437)
+let _bc = [3, 1, 2];
+console.log("bcSorted", JSON.stringify(_bc.toSorted()), JSON.stringify(_bc));
+console.log("bcSortedCmp", JSON.stringify([3,1,2,10].toSorted((x,y)=>x-y)));
+console.log("bcReversed", JSON.stringify(_bc.toReversed()), JSON.stringify(_bc));
+console.log("bcWith", JSON.stringify(_bc.with(1, 99)), JSON.stringify([1,2,3].with(-1, 9)));
+console.log("bcSpliced", JSON.stringify([1,2,3,4].toSpliced(1, 2, "a", "b")), JSON.stringify([1,2,3,4].toSpliced(1)));
+let _bcerr = "none";
+try { [1,2,3].with(5, 0); } catch (e) { _bcerr = e.name; }
+console.log("bcWithErr", _bcerr);

--- a/tests/core/parity_builtins.tish.expected
+++ b/tests/core/parity_builtins.tish.expected
@@ -83,3 +83,9 @@ sc 1 9 x y false
 scprim 7 hi
 scarr [1,[2,3]]
 sccycle true
+bcSorted [1,2,3] [3,1,2]
+bcSortedCmp [1,2,3,10]
+bcReversed [2,1,3] [3,1,2]
+bcWith [3,99,2] [1,2,9]
+bcSpliced [1,"a","b",4] [1]
+bcWithErr RangeError

--- a/tests/main.js
+++ b/tests/main.js
@@ -3459,6 +3459,16 @@ console.log("scarr", JSON.stringify(structuredClone([1,[2,3]])));
 let _scc = { k: 1 }; _scc.self = _scc;
 let _scd = structuredClone(_scc);
 console.log("sccycle", _scd.self === _scd);
+// ES2023 change-array-by-copy — toReversed/toSorted/with/toSpliced (#437)
+let _bc = [3, 1, 2];
+console.log("bcSorted", JSON.stringify(_bc.toSorted()), JSON.stringify(_bc));
+console.log("bcSortedCmp", JSON.stringify([3,1,2,10].toSorted((x,y)=>x-y)));
+console.log("bcReversed", JSON.stringify(_bc.toReversed()), JSON.stringify(_bc));
+console.log("bcWith", JSON.stringify(_bc.with(1, 99)), JSON.stringify([1,2,3].with(-1, 9)));
+console.log("bcSpliced", JSON.stringify([1,2,3,4].toSpliced(1, 2, "a", "b")), JSON.stringify([1,2,3,4].toSpliced(1)));
+let _bcerr = "none";
+try { [1,2,3].with(5, 0); } catch (e) { _bcerr = e.name; }
+console.log("bcWithErr", _bcerr);
 }
 
 {

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3512,6 +3512,16 @@ console.log("scarr", JSON.stringify(structuredClone([1,[2,3]])));
 let _scc = { k: 1 }; _scc.self = _scc;
 let _scd = structuredClone(_scc);
 console.log("sccycle", _scd.self === _scd);
+// ES2023 change-array-by-copy — toReversed/toSorted/with/toSpliced (#437)
+let _bc = [3, 1, 2];
+console.log("bcSorted", JSON.stringify(_bc.toSorted()), JSON.stringify(_bc));
+console.log("bcSortedCmp", JSON.stringify([3,1,2,10].toSorted((x,y)=>x-y)));
+console.log("bcReversed", JSON.stringify(_bc.toReversed()), JSON.stringify(_bc));
+console.log("bcWith", JSON.stringify(_bc.with(1, 99)), JSON.stringify([1,2,3].with(-1, 9)));
+console.log("bcSpliced", JSON.stringify([1,2,3,4].toSpliced(1, 2, "a", "b")), JSON.stringify([1,2,3,4].toSpliced(1)));
+let _bcerr = "none";
+try { [1,2,3].with(5, 0); } catch (e) { _bcerr = e.name; }
+console.log("bcWithErr", _bcerr);
 }
 __perf_run_core_parity_builtins()
 


### PR DESCRIPTION
From the #437 missing-builtins list. The four ES2023 change-array-by-copy methods across interp/vm/native — each returns a new array, receiver untouched; `with` out-of-range parks a catchable RangeError. Validated interp==vm==native==node incl. non-mutation + RangeError; parity added. Refs #437.