### PR TITLE
feat(string): String.prototype.normalize (NFC/NFD/NFKC/NFKD)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3240,6 +3240,7 @@ dependencies = [
  "indexmap",
  "rand 0.10.1",
  "tishlang_core",
+ "unicode-normalization",
 ]
 
 [[package]]

--- a/crates/tish_builtins/Cargo.toml
+++ b/crates/tish_builtins/Cargo.toml
@@ -11,6 +11,7 @@ repository = { workspace = true }
 ahash = "0.8.11"
 indexmap = "2"
 rand = "0.10.1"
+unicode-normalization = "0.1.25"
 tishlang_core = { path = "../tish_core", version = ">=0.1" }
 
 [features]

--- a/crates/tish_builtins/src/string.rs
+++ b/crates/tish_builtins/src/string.rs
@@ -325,6 +325,43 @@ pub fn trim_start(s: &Value) -> Value {
     }
 }
 
+/// Pure `String.prototype.normalize` core (ECMA-262 §22.1.3.13). `form` is one of NFC/NFD/NFKC/NFKD;
+/// returns `None` for an unrecognized form so the caller can surface a `RangeError`. Shared by every
+/// backend so interp/vm/native stay byte-identical.
+pub fn normalize_form(s: &str, form: &str) -> Option<String> {
+    use unicode_normalization::UnicodeNormalization;
+    match form {
+        "NFC" => Some(s.nfc().collect()),
+        "NFD" => Some(s.nfd().collect()),
+        "NFKC" => Some(s.nfkc().collect()),
+        "NFKD" => Some(s.nfkd().collect()),
+        _ => None,
+    }
+}
+
+/// `String.prototype.normalize(form?)` — core-`Value` entry (vm/native). An omitted form defaults to
+/// NFC; an invalid form parks a catchable `RangeError`.
+pub fn normalize(s: &Value, form: &Value) -> Value {
+    let input = match s {
+        Value::String(s) => s.as_ref(),
+        _ => return Value::Null,
+    };
+    let f: String = match form {
+        Value::Null => "NFC".to_string(),
+        Value::String(f) => f.to_string(),
+        v => v.to_display_string(),
+    };
+    match normalize_form(input, &f) {
+        Some(out) => Value::String(out.into()),
+        None => {
+            tishlang_core::set_pending_throw(tishlang_core::range_error(
+                "The normalization form should be one of NFC, NFD, NFKC, NFKD.",
+            ));
+            Value::Null
+        }
+    }
+}
+
 pub fn trim_end(s: &Value) -> Value {
     if let Value::String(s) = s {
         Value::String(s.trim_end().into())

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -6998,6 +6998,13 @@ impl Codegen {
                         "trimEnd" => {
                             return Ok(format!("tishlang_runtime::string_trim_end(&{})", obj_expr));
                         }
+                        "normalize" => {
+                            let form = arg_exprs.first().cloned().unwrap_or_else(|| "Value::Null".to_string());
+                            return Ok(format!(
+                                "tishlang_runtime::string_normalize(&{}, &{})",
+                                obj_expr, form
+                            ));
+                        }
                         "codePointAt" => {
                             let idx = arg_exprs.first().cloned().unwrap_or_else(|| "Value::Null".to_string());
                             return Ok(format!(

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -2573,6 +2573,26 @@ impl Evaluator {
                             "trimEnd" => {
                                 return Ok(Value::String(s.trim_end().into()));
                             }
+                            "normalize" => {
+                                let form = match arg_vals.first() {
+                                    None | Some(Value::Null) => "NFC".to_string(),
+                                    Some(Value::String(f)) => f.to_string(),
+                                    Some(v) => v.to_string(),
+                                };
+                                match tishlang_builtins::string::normalize_form(s, &form) {
+                                    Some(out) => return Ok(Value::String(out.into())),
+                                    None => {
+                                        let err = crate::natives::range_error_construct(&[
+                                            Value::String(
+                                                "The normalization form should be one of NFC, NFD, NFKC, NFKD."
+                                                    .into(),
+                                            ),
+                                        ])
+                                        .unwrap_or(Value::Null);
+                                        return Err(EvalError::Throw(err));
+                                    }
+                                }
+                            }
                             "toUpperCase" => {
                                 return Ok(Value::String(s.to_uppercase().into()));
                             }

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -143,8 +143,9 @@ pub use tishlang_builtins::string::{
     slice as string_slice_impl, split as string_split_impl, split_limit as string_split_limit_impl,
     starts_with as string_starts_with_impl, substr as string_substr_impl,
     substring as string_substring_impl,
-    to_lower_case as string_to_lower_case, to_upper_case as string_to_upper_case,
-    trim as string_trim, trim_end as string_trim_end, trim_start as string_trim_start,
+    normalize as string_normalize, to_lower_case as string_to_lower_case,
+    to_upper_case as string_to_upper_case, trim as string_trim, trim_end as string_trim_end,
+    trim_start as string_trim_start,
 };
 
 // Wrapper functions to maintain API compatibility

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -4271,6 +4271,10 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                 "trimEnd" => make_native_fn(move |_args: &[Value]| {
                     str_builtins::trim_end(&Value::String(s_clone.clone()))
                 }),
+                "normalize" => make_native_fn(move |args: &[Value]| {
+                    let form = args.first().cloned().unwrap_or(Value::Null);
+                    str_builtins::normalize(&Value::String(s_clone.clone()), &form)
+                }),
                 "toUpperCase" => make_native_fn(move |_args: &[Value]| {
                     str_builtins::to_upper_case(&Value::String(s_clone.clone()))
                 }),

--- a/tests/core/parity_builtins.js
+++ b/tests/core/parity_builtins.js
@@ -124,3 +124,13 @@ let _pe = "none"; try { (1).toPrecision(0); } catch (e) { _pe = e.name; }
 console.log("precErr", _pe);
 console.log("hasOwn", Object.hasOwn({a:1}, "a"), Object.hasOwn({a:1}, "b"), Object.hasOwn({a:1}, "toString"));
 console.log("hasOwnArr", Object.hasOwn([9,8], 0), Object.hasOwn([9,8], 5), Object.hasOwn([9], "length"));
+// String.normalize NFC/NFD/NFKC/NFKD (#437)
+let _nc = "\u00e9";      // composed e-acute
+let _nd = "e\u0301";     // decomposed e + combining acute
+console.log("normEq", _nc === _nd, _nc.length, _nd.length);
+console.log("normNFC", _nc.normalize("NFC") === _nd.normalize("NFC"), _nd.normalize("NFC").length);
+console.log("normNFD", _nc.normalize("NFD") === _nd.normalize("NFD"), _nc.normalize("NFD").length);
+console.log("normDefault", "\u00e9".normalize() === "\u00e9".normalize("NFC"));
+console.log("normNFKC", "\ufb01".normalize("NFKC"), "\ufb01".normalize("NFKD"));
+let _nerr = "none"; try { "x".normalize("BOGUS"); } catch (e) { _nerr = e.name; }
+console.log("normErr", _nerr);

--- a/tests/core/parity_builtins.tish
+++ b/tests/core/parity_builtins.tish
@@ -124,3 +124,13 @@ let _pe = "none"; try { (1).toPrecision(0); } catch (e) { _pe = e.name; }
 console.log("precErr", _pe);
 console.log("hasOwn", Object.hasOwn({a:1}, "a"), Object.hasOwn({a:1}, "b"), Object.hasOwn({a:1}, "toString"));
 console.log("hasOwnArr", Object.hasOwn([9,8], 0), Object.hasOwn([9,8], 5), Object.hasOwn([9], "length"));
+// String.normalize NFC/NFD/NFKC/NFKD (#437)
+let _nc = "\u00e9";      // composed e-acute
+let _nd = "e\u0301";     // decomposed e + combining acute
+console.log("normEq", _nc === _nd, _nc.length, _nd.length);
+console.log("normNFC", _nc.normalize("NFC") === _nd.normalize("NFC"), _nd.normalize("NFC").length);
+console.log("normNFD", _nc.normalize("NFD") === _nd.normalize("NFD"), _nc.normalize("NFD").length);
+console.log("normDefault", "\u00e9".normalize() === "\u00e9".normalize("NFC"));
+console.log("normNFKC", "\ufb01".normalize("NFKC"), "\ufb01".normalize("NFKD"));
+let _nerr = "none"; try { "x".normalize("BOGUS"); } catch (e) { _nerr = e.name; }
+console.log("normErr", _nerr);

--- a/tests/core/parity_builtins.tish.expected
+++ b/tests/core/parity_builtins.tish.expected
@@ -97,3 +97,9 @@ precBig 123.00 1.00e+6
 precErr RangeError
 hasOwn true false false
 hasOwnArr true false true
+normEq false 1 2
+normNFC true 1
+normNFD true 2
+normDefault true
+normNFKC fi fi
+normErr RangeError

--- a/tests/main.js
+++ b/tests/main.js
@@ -3479,6 +3479,16 @@ let _pe = "none"; try { (1).toPrecision(0); } catch (e) { _pe = e.name; }
 console.log("precErr", _pe);
 console.log("hasOwn", Object.hasOwn({a:1}, "a"), Object.hasOwn({a:1}, "b"), Object.hasOwn({a:1}, "toString"));
 console.log("hasOwnArr", Object.hasOwn([9,8], 0), Object.hasOwn([9,8], 5), Object.hasOwn([9], "length"));
+// String.normalize NFC/NFD/NFKC/NFKD (#437)
+let _nc = "\u00e9";      // composed e-acute
+let _nd = "e\u0301";     // decomposed e + combining acute
+console.log("normEq", _nc === _nd, _nc.length, _nd.length);
+console.log("normNFC", _nc.normalize("NFC") === _nd.normalize("NFC"), _nd.normalize("NFC").length);
+console.log("normNFD", _nc.normalize("NFD") === _nd.normalize("NFD"), _nc.normalize("NFD").length);
+console.log("normDefault", "\u00e9".normalize() === "\u00e9".normalize("NFC"));
+console.log("normNFKC", "\ufb01".normalize("NFKC"), "\ufb01".normalize("NFKD"));
+let _nerr = "none"; try { "x".normalize("BOGUS"); } catch (e) { _nerr = e.name; }
+console.log("normErr", _nerr);
 }
 
 {

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3532,6 +3532,16 @@ let _pe = "none"; try { (1).toPrecision(0); } catch (e) { _pe = e.name; }
 console.log("precErr", _pe);
 console.log("hasOwn", Object.hasOwn({a:1}, "a"), Object.hasOwn({a:1}, "b"), Object.hasOwn({a:1}, "toString"));
 console.log("hasOwnArr", Object.hasOwn([9,8], 0), Object.hasOwn([9,8], 5), Object.hasOwn([9], "length"));
+// String.normalize NFC/NFD/NFKC/NFKD (#437)
+let _nc = "\u00e9";      // composed e-acute
+let _nd = "e\u0301";     // decomposed e + combining acute
+console.log("normEq", _nc === _nd, _nc.length, _nd.length);
+console.log("normNFC", _nc.normalize("NFC") === _nd.normalize("NFC"), _nd.normalize("NFC").length);
+console.log("normNFD", _nc.normalize("NFD") === _nd.normalize("NFD"), _nc.normalize("NFD").length);
+console.log("normDefault", "\u00e9".normalize() === "\u00e9".normalize("NFC"));
+console.log("normNFKC", "\ufb01".normalize("NFKC"), "\ufb01".normalize("NFKD"));
+let _nerr = "none"; try { "x".normalize("BOGUS"); } catch (e) { _nerr = e.name; }
+console.log("normErr", _nerr);
 }
 __perf_run_core_parity_builtins()
 


### PR DESCRIPTION
From the #437 missing-builtins list. Unicode normalization across interp/vm/native via the unicode-normalization crate (already transitively in the tree). Omitted form defaults to NFC; invalid form parks a catchable RangeError. Validated interp==vm==native==node incl. composed/decomposed round-trip + NFKC/NFKD compatibility decomposition + RangeError; parity added. Refs #437.