### PR TITLE
feat(string): String.prototype.matchAll

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -7067,6 +7067,13 @@ impl Codegen {
                                 obj_expr, regexp
                             ));
                         }
+                        "matchAll" if self.has_feature("regex") => {
+                            let regexp = arg_exprs.first().cloned().unwrap_or_else(|| "Value::Null".to_string());
+                            return Ok(format!(
+                                "tishlang_runtime::string_match_all_regex(&{}, &{})",
+                                obj_expr, regexp
+                            ));
+                        }
                         "search" if self.has_feature("regex") => {
                             let regexp = arg_exprs.first().cloned().unwrap_or_else(|| "Value::Null".to_string());
                             return Ok(format!(

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -2818,6 +2818,35 @@ impl Evaluator {
                                 return Ok(Value::Null);
                             }
                             #[cfg(feature = "regex")]
+                            "matchAll" => {
+                                let regexp = arg_vals.first().cloned().unwrap_or(Value::Null);
+                                match crate::regex::string_match_all(s, &regexp) {
+                                    Ok(matches) => {
+                                        let core_matches: Vec<tishlang_core::Value> = matches
+                                            .iter()
+                                            .map(|m| {
+                                                crate::value_convert::eval_to_core(m)
+                                                    .unwrap_or(tishlang_core::Value::Null)
+                                            })
+                                            .collect();
+                                        let it = tishlang_builtins::iterator::array_iterator(
+                                            core_matches,
+                                        );
+                                        return Ok(crate::value_convert::core_to_eval(it));
+                                    }
+                                    Err(()) => {
+                                        let err = crate::natives::type_error_construct(&[
+                                            Value::String(
+                                                "String.prototype.matchAll called with a non-global RegExp argument"
+                                                    .into(),
+                                            ),
+                                        ])
+                                        .unwrap_or(Value::Null);
+                                        return Err(EvalError::Throw(err));
+                                    }
+                                }
+                            }
+                            #[cfg(feature = "regex")]
                             "search" => {
                                 if let Some(regexp) = arg_vals.first() {
                                     return Ok(crate::regex::string_search(s, regexp));

--- a/crates/tish_eval/src/regex.rs
+++ b/crates/tish_eval/src/regex.rs
@@ -147,6 +147,34 @@ pub fn string_match(input: &str, regexp: &Value) -> Value {
     }
 }
 
+/// `String.prototype.matchAll(regexp)` — collects every match as an exec-style match object (reusing
+/// `regexp_exec`). Returns `Err(())` if a non-global RegExp is passed (the caller raises a TypeError);
+/// a non-RegExp argument is coerced to a global regex. The caller wraps the results in an iterator.
+pub fn string_match_all(input: &str, regexp: &Value) -> Result<Vec<Value>, ()> {
+    let re_cell = match regexp {
+        Value::RegExp(re) => re.clone(),
+        other => match TishRegExp::new(&other.to_string(), "g") {
+            Ok(re) => Rc::new(RefCell::new(re)),
+            Err(_) => return Ok(Vec::new()),
+        },
+    };
+    if !re_cell.borrow().flags.global {
+        return Err(());
+    }
+    let mut results = Vec::new();
+    let mut re = re_cell.borrow_mut();
+    re.last_index = 0;
+    loop {
+        let m = regexp_exec(&mut re, input);
+        if matches!(m, Value::Null) {
+            break;
+        }
+        results.push(m);
+    }
+    re.last_index = 0;
+    Ok(results)
+}
+
 /// String.prototype.replace(searchValue, replaceValue)
 pub fn string_replace(input: &str, search: &Value, replace: &Value) -> Value {
     let replacement = match replace {

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -1883,6 +1883,48 @@ pub fn string_match_regex(s: &Value, regexp: &Value) -> Value {
     }
 }
 
+/// `String.prototype.matchAll(regexp)` — an ITERATOR over every match, each an exec-style match object
+/// (`{ "0", ...groups, index, input, groups }`). Per ECMA the regexp must be global, else a `TypeError`
+/// is parked; a non-RegExp argument is coerced to a global regex. Reuses `regexp_exec_impl` so the
+/// match objects are byte-identical to `exec`/`match`, then wraps them in the shared iterator.
+#[cfg(feature = "regex")]
+pub fn string_match_all_regex(s: &Value, regexp: &Value) -> Value {
+    let input = match s {
+        Value::String(s) => s.as_ref(),
+        _ => return Value::Null,
+    };
+    let re_cell = match regexp {
+        Value::RegExp(re) => re.clone(),
+        other => {
+            let pattern = other.to_display_string();
+            match tishlang_core::TishRegExp::new(&pattern, "g") {
+                Ok(re) => tishlang_core::VmRef::new(re),
+                Err(_) => return Value::Null,
+            }
+        }
+    };
+    if !re_cell.borrow().flags.global {
+        tishlang_core::set_pending_throw(tishlang_core::type_error(
+            "String.prototype.matchAll called with a non-global RegExp argument",
+        ));
+        return Value::Null;
+    }
+    let mut results: Vec<Value> = Vec::new();
+    {
+        let mut re = re_cell.borrow_mut();
+        re.last_index = 0;
+        loop {
+            let m = regexp_exec_impl(&mut re, input);
+            if matches!(m, Value::Null) {
+                break;
+            }
+            results.push(m);
+        }
+        re.last_index = 0;
+    }
+    tishlang_builtins::iterator::array_iterator(results)
+}
+
 #[cfg(feature = "regex")]
 fn string_replace_regex_or_callback(s: &Value, search: &Value, replacement: &Value) -> Value {
     let input = match s {

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -4315,6 +4315,11 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                     tishlang_runtime::string_match_regex(&Value::String(s_clone.clone()), re)
                 }),
                 #[cfg(feature = "regex")]
+                "matchAll" => make_native_fn(move |args: &[Value]| {
+                    let re = args.first().unwrap_or(&Value::Null);
+                    tishlang_runtime::string_match_all_regex(&Value::String(s_clone.clone()), re)
+                }),
+                #[cfg(feature = "regex")]
                 "search" => make_native_fn(move |args: &[Value]| {
                     let re = args.first().unwrap_or(&Value::Null);
                     tishlang_runtime::string_search_regex(&Value::String(s_clone.clone()), re)

--- a/tests/core/parity_builtins.js
+++ b/tests/core/parity_builtins.js
@@ -134,3 +134,14 @@ console.log("normDefault", "\u00e9".normalize() === "\u00e9".normalize("NFC"));
 console.log("normNFKC", "\ufb01".normalize("NFKC"), "\ufb01".normalize("NFKD"));
 let _nerr = "none"; try { "x".normalize("BOGUS"); } catch (e) { _nerr = e.name; }
 console.log("normErr", _nerr);
+// String.matchAll — iterator of exec-style match objects (#437)
+let _ma = [..."a1b2c3".matchAll(/([a-z])(\d)/g)];
+console.log("maCount", _ma.length, _ma[0][0], _ma[0][1], _ma[0][2], _ma[0].index);
+console.log("maAll", _ma.map(m => m[1] + "=" + m[2]).join(","));
+let _mao = [];
+for (const m of "x9y8".matchAll(/(\d)/g)) { _mao.push(m[1]); }
+console.log("maForof", _mao.join(","));
+console.log("maEmpty", [..."abc".matchAll(/\d/g)].length);
+console.log("maIdx", [..."aXbXc".matchAll(/X/g)].map(m => m.index).join(","));
+let _maerr = "none"; try { [..."ab".matchAll(/a/)]; } catch (e) { _maerr = e.name; }
+console.log("maErr", _maerr);

--- a/tests/core/parity_builtins.tish
+++ b/tests/core/parity_builtins.tish
@@ -134,3 +134,14 @@ console.log("normDefault", "\u00e9".normalize() === "\u00e9".normalize("NFC"));
 console.log("normNFKC", "\ufb01".normalize("NFKC"), "\ufb01".normalize("NFKD"));
 let _nerr = "none"; try { "x".normalize("BOGUS"); } catch (e) { _nerr = e.name; }
 console.log("normErr", _nerr);
+// String.matchAll — iterator of exec-style match objects (#437)
+let _ma = [..."a1b2c3".matchAll(/([a-z])(\d)/g)];
+console.log("maCount", _ma.length, _ma[0][0], _ma[0][1], _ma[0][2], _ma[0].index);
+console.log("maAll", _ma.map(m => m[1] + "=" + m[2]).join(","));
+let _mao = [];
+for (const m of "x9y8".matchAll(/(\d)/g)) { _mao.push(m[1]); }
+console.log("maForof", _mao.join(","));
+console.log("maEmpty", [..."abc".matchAll(/\d/g)].length);
+console.log("maIdx", [..."aXbXc".matchAll(/X/g)].map(m => m.index).join(","));
+let _maerr = "none"; try { [..."ab".matchAll(/a/)]; } catch (e) { _maerr = e.name; }
+console.log("maErr", _maerr);

--- a/tests/core/parity_builtins.tish.expected
+++ b/tests/core/parity_builtins.tish.expected
@@ -103,3 +103,9 @@ normNFD true 2
 normDefault true
 normNFKC fi fi
 normErr RangeError
+maCount 3 a1 a 1 0
+maAll a=1,b=2,c=3
+maForof 9,8
+maEmpty 0
+maIdx 1,3
+maErr TypeError

--- a/tests/main.js
+++ b/tests/main.js
@@ -3489,6 +3489,17 @@ console.log("normDefault", "\u00e9".normalize() === "\u00e9".normalize("NFC"));
 console.log("normNFKC", "\ufb01".normalize("NFKC"), "\ufb01".normalize("NFKD"));
 let _nerr = "none"; try { "x".normalize("BOGUS"); } catch (e) { _nerr = e.name; }
 console.log("normErr", _nerr);
+// String.matchAll — iterator of exec-style match objects (#437)
+let _ma = [..."a1b2c3".matchAll(/([a-z])(\d)/g)];
+console.log("maCount", _ma.length, _ma[0][0], _ma[0][1], _ma[0][2], _ma[0].index);
+console.log("maAll", _ma.map(m => m[1] + "=" + m[2]).join(","));
+let _mao = [];
+for (const m of "x9y8".matchAll(/(\d)/g)) { _mao.push(m[1]); }
+console.log("maForof", _mao.join(","));
+console.log("maEmpty", [..."abc".matchAll(/\d/g)].length);
+console.log("maIdx", [..."aXbXc".matchAll(/X/g)].map(m => m.index).join(","));
+let _maerr = "none"; try { [..."ab".matchAll(/a/)]; } catch (e) { _maerr = e.name; }
+console.log("maErr", _maerr);
 }
 
 {

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3542,6 +3542,17 @@ console.log("normDefault", "\u00e9".normalize() === "\u00e9".normalize("NFC"));
 console.log("normNFKC", "\ufb01".normalize("NFKC"), "\ufb01".normalize("NFKD"));
 let _nerr = "none"; try { "x".normalize("BOGUS"); } catch (e) { _nerr = e.name; }
 console.log("normErr", _nerr);
+// String.matchAll — iterator of exec-style match objects (#437)
+let _ma = [..."a1b2c3".matchAll(/([a-z])(\d)/g)];
+console.log("maCount", _ma.length, _ma[0][0], _ma[0][1], _ma[0][2], _ma[0].index);
+console.log("maAll", _ma.map(m => m[1] + "=" + m[2]).join(","));
+let _mao = [];
+for (const m of "x9y8".matchAll(/(\d)/g)) { _mao.push(m[1]); }
+console.log("maForof", _mao.join(","));
+console.log("maEmpty", [..."abc".matchAll(/\d/g)].length);
+console.log("maIdx", [..."aXbXc".matchAll(/X/g)].map(m => m.index).join(","));
+let _maerr = "none"; try { [..."ab".matchAll(/a/)]; } catch (e) { _maerr = e.name; }
+console.log("maErr", _maerr);
 }
 __perf_run_core_parity_builtins()
 


### PR DESCRIPTION
From the #437 missing-builtins list. Iterator over every match (exec-style match objects with 0/groups/index) across interp/vm/native, reusing regexp_exec for byte-identical match objects. Non-global RegExp parks a catchable TypeError; non-RegExp arg coerced to global regex. Validated interp==vm==native==node incl. groups/for-of/indices/empty/string-arg/TypeError; parity added. Refs #437.