### PR TITLE
fix(index): coerce canonical integer string array keys (#432)

### DIFF
--- a/crates/tish_core/src/lib.rs
+++ b/crates/tish_core/src/lib.rs
@@ -189,6 +189,18 @@ pub fn type_error(message: impl Into<String>) -> Value {
     Value::object(e)
 }
 
+/// A string key names a canonical array index iff it is a non-negative integer whose decimal form
+/// round-trips and is below the array-index ceiling (`2³²−1`): `"0"`, `"12"` → `Some`; `"01"`, `"-1"`,
+/// `"1.5"`, `"foo"`, `" 1"`, `""` → `None`. Shared so `arr["0"] === arr[0]` on every backend (#432).
+pub fn str_to_array_index(s: &str) -> Option<usize> {
+    let i: usize = s.parse().ok()?;
+    if i < 4_294_967_295 && i.to_string() == s {
+        Some(i)
+    } else {
+        None
+    }
+}
+
 /// A catchable `RangeError` with an arbitrary message (`{ name: "RangeError", message }`), matching the
 /// VM/interpreter/node shape. Used to PARK a pending throw from a shared builtin that returns a plain
 /// `Value` (e.g. `[1,2].with(5, x)` with an out-of-range index).

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -3319,6 +3319,12 @@ impl Evaluator {
                     Value::Array(arr) => {
                         let idx = match &idx_val {
                             Value::Number(n) => *n as usize,
+                            // Canonical integer string key → index (#432); a non-index string key
+                            // can't live in a Vec-backed array, so the write is a no-op.
+                            Value::String(s) => match tishlang_core::str_to_array_index(s) {
+                                Some(i) => i,
+                                None => return Ok(val),
+                            },
                             _ => return Err(EvalError::Error(format!(
                                 "Array index must be a number, got {:?}",
                                 idx_val
@@ -4592,6 +4598,12 @@ impl Evaluator {
             Value::Array(arr) => {
                 let idx = match index {
                     Value::Number(n) => *n as usize,
+                    // A canonical integer string key ("0","1",…) indexes the array (#432), so
+                    // `arr["0"] === arr[0]`; any other key reads Null.
+                    Value::String(s) => match tishlang_core::str_to_array_index(s) {
+                        Some(i) => i,
+                        None => return Ok(Value::Null),
+                    },
                     _ => return Ok(Value::Null),
                 };
                 Ok(arr.borrow().get(idx).cloned().unwrap_or(Value::Null))

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -1361,6 +1361,11 @@ pub fn get_index(obj: &Value, index: &Value) -> Value {
         Value::Array(arr) => {
             let idx = match index {
                 Value::Number(n) => *n as usize,
+                // Canonical integer string key ("0","1",…) indexes the array (#432); other keys → Null.
+                Value::String(s) => match tishlang_core::str_to_array_index(s) {
+                    Some(i) => i,
+                    None => return Value::Null,
+                },
                 _ => return Value::Null,
             };
             arr.borrow().get(idx).cloned().unwrap_or(Value::Null)
@@ -1369,6 +1374,10 @@ pub fn get_index(obj: &Value, index: &Value) -> Value {
         Value::NumberArray(arr) => {
             let idx = match index {
                 Value::Number(n) => *n as usize,
+                Value::String(s) => match tishlang_core::str_to_array_index(s) {
+                    Some(i) => i,
+                    None => return Value::Null,
+                },
                 _ => return Value::Null,
             };
             arr.borrow().get(idx).copied().map(Value::Number).unwrap_or(Value::Null)
@@ -1469,6 +1478,11 @@ pub fn set_index(obj: &Value, idx: &Value, val: Value) -> Value {
         Value::Array(arr) => {
             let index = match idx {
                 Value::Number(n) => *n as usize,
+                // Canonical integer string key → index (#432); a non-index string key is a no-op write.
+                Value::String(s) => match tishlang_core::str_to_array_index(s) {
+                    Some(i) => i,
+                    None => return val,
+                },
                 _ => panic!("Array index must be number"),
             };
             let mut arr_mut = arr.borrow_mut();
@@ -1485,6 +1499,11 @@ pub fn set_index(obj: &Value, idx: &Value, val: Value) -> Value {
         Value::NumberArray(arr) => {
             let index = match idx {
                 Value::Number(n) => *n as usize,
+                // Canonical integer string key → index (#432); a non-index string key is a no-op write.
+                Value::String(s) => match tishlang_core::str_to_array_index(s) {
+                    Some(i) => i,
+                    None => return val,
+                },
                 _ => panic!("Array index must be number"),
             };
             let mut arr_mut = arr.borrow_mut();

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -4494,12 +4494,13 @@ fn get_index(obj: &Value, idx: &Value) -> Result<Value, String> {
         Value::NumberArray(a) => {
             let i = match idx {
                 Value::Number(n) => *n as usize,
-                _ => {
-                    return Err(format!(
-                        "Array index must be number, got {}",
-                        idx.type_name()
-                    ))
-                }
+                // A canonical integer string key ("0","1",…) indexes the array (#432); any other key
+                // reads Null (JS reads a missing property as undefined) rather than throwing.
+                Value::String(s) => match tishlang_core::str_to_array_index(s) {
+                    Some(i) => i,
+                    None => return Ok(Value::Null),
+                },
+                _ => return Ok(Value::Null),
             };
             // NaN is used as the hole marker (sparse-array positions); reads return Null.
             Ok(a.borrow()
@@ -4516,12 +4517,12 @@ fn get_index(obj: &Value, idx: &Value) -> Result<Value, String> {
         Value::Array(a) => {
             let i = match idx {
                 Value::Number(n) => *n as usize,
-                _ => {
-                    return Err(format!(
-                        "Array index must be number, got {}",
-                        idx.type_name()
-                    ));
-                }
+                // Canonical integer string key → index (#432); any other key reads Null, not a throw.
+                Value::String(s) => match tishlang_core::str_to_array_index(s) {
+                    Some(i) => i,
+                    None => return Ok(Value::Null),
+                },
+                _ => return Ok(Value::Null),
             };
             Ok(a.borrow().get(i).cloned().unwrap_or(Value::Null))
         }
@@ -4608,6 +4609,12 @@ fn set_index(obj: &Value, idx: &Value, val: Value) -> Result<(), String> {
         Value::NumberArray(a) => {
             let i = match idx {
                 Value::Number(n) => *n as usize,
+                // Canonical integer string key → index (#432); a non-index string key can't be stored
+                // in a Vec-backed array, so the write is a no-op (rather than a throw).
+                Value::String(s) => match tishlang_core::str_to_array_index(s) {
+                    Some(i) => i,
+                    None => return Ok(()),
+                },
                 _ => {
                     return Err(format!(
                         "Array index must be number, got {}",
@@ -4648,6 +4655,11 @@ fn set_index(obj: &Value, idx: &Value, val: Value) -> Result<(), String> {
         Value::Array(a) => {
             let i = match idx {
                 Value::Number(n) => *n as usize,
+                // Canonical integer string key → index (#432); a non-index string key is a no-op write.
+                Value::String(s) => match tishlang_core::str_to_array_index(s) {
+                    Some(i) => i,
+                    None => return Ok(()),
+                },
                 _ => {
                     return Err(format!(
                         "Array index must be number, got {}",

--- a/tests/core/parity_builtins.js
+++ b/tests/core/parity_builtins.js
@@ -145,3 +145,11 @@ console.log("maEmpty", [..."abc".matchAll(/\d/g)].length);
 console.log("maIdx", [..."aXbXc".matchAll(/X/g)].map(m => m.index).join(","));
 let _maerr = "none"; try { [..."ab".matchAll(/a/)]; } catch (e) { _maerr = e.name; }
 console.log("maErr", _maerr);
+// Array string-key indexing coerces canonical integer keys (#432)
+let _ai = [10, 20, 30];
+console.log("aidx", _ai["0"], _ai["1"], _ai["2"], _ai["0"] === _ai[0]);
+let _aik = "";
+for (let k in _ai) { _aik = _aik + k + ":" + _ai[k] + " "; }
+console.log("aforin", _aik);
+_ai["1"] = 99;
+console.log("awrite", _ai[1], JSON.stringify(_ai));

--- a/tests/core/parity_builtins.tish
+++ b/tests/core/parity_builtins.tish
@@ -145,3 +145,11 @@ console.log("maEmpty", [..."abc".matchAll(/\d/g)].length);
 console.log("maIdx", [..."aXbXc".matchAll(/X/g)].map(m => m.index).join(","));
 let _maerr = "none"; try { [..."ab".matchAll(/a/)]; } catch (e) { _maerr = e.name; }
 console.log("maErr", _maerr);
+// Array string-key indexing coerces canonical integer keys (#432)
+let _ai = [10, 20, 30];
+console.log("aidx", _ai["0"], _ai["1"], _ai["2"], _ai["0"] === _ai[0]);
+let _aik = "";
+for (let k in _ai) { _aik = _aik + k + ":" + _ai[k] + " "; }
+console.log("aforin", _aik);
+_ai["1"] = 99;
+console.log("awrite", _ai[1], JSON.stringify(_ai));

--- a/tests/core/parity_builtins.tish.expected
+++ b/tests/core/parity_builtins.tish.expected
@@ -109,3 +109,6 @@ maForof 9,8
 maEmpty 0
 maIdx 1,3
 maErr TypeError
+aidx 10 20 30 true
+aforin 0:10 1:20 2:30 
+awrite 99 [10,99,30]

--- a/tests/main.js
+++ b/tests/main.js
@@ -3500,6 +3500,14 @@ console.log("maEmpty", [..."abc".matchAll(/\d/g)].length);
 console.log("maIdx", [..."aXbXc".matchAll(/X/g)].map(m => m.index).join(","));
 let _maerr = "none"; try { [..."ab".matchAll(/a/)]; } catch (e) { _maerr = e.name; }
 console.log("maErr", _maerr);
+// Array string-key indexing coerces canonical integer keys (#432)
+let _ai = [10, 20, 30];
+console.log("aidx", _ai["0"], _ai["1"], _ai["2"], _ai["0"] === _ai[0]);
+let _aik = "";
+for (let k in _ai) { _aik = _aik + k + ":" + _ai[k] + " "; }
+console.log("aforin", _aik);
+_ai["1"] = 99;
+console.log("awrite", _ai[1], JSON.stringify(_ai));
 }
 
 {

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3553,6 +3553,14 @@ console.log("maEmpty", [..."abc".matchAll(/\d/g)].length);
 console.log("maIdx", [..."aXbXc".matchAll(/X/g)].map(m => m.index).join(","));
 let _maerr = "none"; try { [..."ab".matchAll(/a/)]; } catch (e) { _maerr = e.name; }
 console.log("maErr", _maerr);
+// Array string-key indexing coerces canonical integer keys (#432)
+let _ai = [10, 20, 30];
+console.log("aidx", _ai["0"], _ai["1"], _ai["2"], _ai["0"] === _ai[0]);
+let _aik = "";
+for (let k in _ai) { _aik = _aik + k + ":" + _ai[k] + " "; }
+console.log("aforin", _aik);
+_ai["1"] = 99;
+console.log("awrite", _ai[1], JSON.stringify(_ai));
 }
 __perf_run_core_parity_builtins()
 


### PR DESCRIPTION
Closes #432 (part 1) — array indexing with string keys diverged across backends (vm threw, interp returned null, node coerced).

Array index reads/writes now coerce a canonical integer-valued string key to the numeric index across interp/vm/native, so `arr["0"] === arr[0]` on every backend and for-in over an array (which yields string keys) works. A non-canonical string key (`"01"`, `"1.5"`, `"foo"`, `"-1"`) or other non-index type reads Null (matching interp/node's undefined) and is a no-op on write, instead of the vm's previous throw. Shared `tishlang_core::str_to_array_index` helper.

Part 2 (for-in over a native-typed array) now also passes on native (verified across bare + heavily-numeric variants), so this closes the issue.

Validated interp==vm==native and against node; parity cases added.