### PR TITLE
fix(native): clone Map key/value on set instead of moving (#442)

### DIFF
--- a/crates/tish_builtins/src/collections.rs
+++ b/crates/tish_builtins/src/collections.rs
@@ -175,9 +175,13 @@ pub fn map_get(map: &Value, key: &Value) -> Value {
 }
 
 /// Direct `Map.prototype.set` (mutates in place; returns `undefined` = `Null`).
-pub fn map_set(map: &Value, key: Value, val: Value) -> Value {
+///
+/// Takes the key/val by reference and clones on insert (the map owns its entries). Passing by
+/// reference lets the native emitter BORROW the caller's place instead of moving it, so
+/// `m.set(k, v); …use k…` no longer produces `E0382 use of moved value` in the generated Rust (#442).
+pub fn map_set(map: &Value, key: &Value, val: &Value) -> Value {
     if let Some(s) = map_store(map) {
-        s.borrow_mut().insert(Key(key), val);
+        s.borrow_mut().insert(Key(key.clone()), val.clone());
     }
     Value::Null
 }

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -6819,9 +6819,15 @@ impl Codegen {
                                     return Ok(format!("tish_map_get({}, {})", map_ref, key_ref));
                                 }
                                 "set" if args.len() == 2 => {
+                                    // Borrow the key/val places (like `get`/`has`) so a keyed local
+                                    // isn't MOVED into the call and can still be used afterward — the
+                                    // runtime `map_set` clones on insert (#442). `&Value` args also
+                                    // route native-typed operands through the boxed path correctly.
+                                    let key_ref = self.emit_borrowed_arg(&args[0])?;
+                                    let val_ref = self.emit_borrowed_arg(&args[1])?;
                                     return Ok(format!(
                                         "tish_map_set({}, {}, {})",
-                                        map_ref, arg_exprs[0], arg_exprs[1]
+                                        map_ref, key_ref, val_ref
                                     ));
                                 }
                                 "values" if args.is_empty() => {

--- a/tests/core/parity_builtins.js
+++ b/tests/core/parity_builtins.js
@@ -153,3 +153,17 @@ for (let k in _ai) { _aik = _aik + k + ":" + _ai[k] + " "; }
 console.log("aforin", _aik);
 _ai["1"] = 99;
 console.log("awrite", _ai[1], JSON.stringify(_ai));
+// Map with object key + key/value reused after set — native E0382 regression (#442)
+let _mk = new Map();
+let _mkey = { id: 1 };
+_mk.set(_mkey, "v");
+console.log("mapObjKey", _mk.get(_mkey), _mkey.id, _mk.size);
+let _mk2 = new Map();
+let _mv = [1, 2, 3];
+_mk2.set("a", _mv);
+console.log("mapReuse", _mk2.get("a")[0], _mv.length);
+let _mo1 = {};
+let _mo2 = {};
+_mk.set(_mo1, "A");
+_mk.set(_mo2, "B");
+console.log("mapObjIdentity", _mk.get(_mo1), _mk.get(_mo2), _mk.get(_mo1) === "A");

--- a/tests/core/parity_builtins.tish
+++ b/tests/core/parity_builtins.tish
@@ -153,3 +153,17 @@ for (let k in _ai) { _aik = _aik + k + ":" + _ai[k] + " "; }
 console.log("aforin", _aik);
 _ai["1"] = 99;
 console.log("awrite", _ai[1], JSON.stringify(_ai));
+// Map with object key + key/value reused after set — native E0382 regression (#442)
+let _mk = new Map();
+let _mkey = { id: 1 };
+_mk.set(_mkey, "v");
+console.log("mapObjKey", _mk.get(_mkey), _mkey.id, _mk.size);
+let _mk2 = new Map();
+let _mv = [1, 2, 3];
+_mk2.set("a", _mv);
+console.log("mapReuse", _mk2.get("a")[0], _mv.length);
+let _mo1 = {};
+let _mo2 = {};
+_mk.set(_mo1, "A");
+_mk.set(_mo2, "B");
+console.log("mapObjIdentity", _mk.get(_mo1), _mk.get(_mo2), _mk.get(_mo1) === "A");

--- a/tests/core/parity_builtins.tish.expected
+++ b/tests/core/parity_builtins.tish.expected
@@ -112,3 +112,6 @@ maErr TypeError
 aidx 10 20 30 true
 aforin 0:10 1:20 2:30 
 awrite 99 [10,99,30]
+mapObjKey v 1 1
+mapReuse 1 3
+mapObjIdentity A B true

--- a/tests/main.js
+++ b/tests/main.js
@@ -3508,6 +3508,20 @@ for (let k in _ai) { _aik = _aik + k + ":" + _ai[k] + " "; }
 console.log("aforin", _aik);
 _ai["1"] = 99;
 console.log("awrite", _ai[1], JSON.stringify(_ai));
+// Map with object key + key/value reused after set — native E0382 regression (#442)
+let _mk = new Map();
+let _mkey = { id: 1 };
+_mk.set(_mkey, "v");
+console.log("mapObjKey", _mk.get(_mkey), _mkey.id, _mk.size);
+let _mk2 = new Map();
+let _mv = [1, 2, 3];
+_mk2.set("a", _mv);
+console.log("mapReuse", _mk2.get("a")[0], _mv.length);
+let _mo1 = {};
+let _mo2 = {};
+_mk.set(_mo1, "A");
+_mk.set(_mo2, "B");
+console.log("mapObjIdentity", _mk.get(_mo1), _mk.get(_mo2), _mk.get(_mo1) === "A");
 }
 
 {

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3561,6 +3561,20 @@ for (let k in _ai) { _aik = _aik + k + ":" + _ai[k] + " "; }
 console.log("aforin", _aik);
 _ai["1"] = 99;
 console.log("awrite", _ai[1], JSON.stringify(_ai));
+// Map with object key + key/value reused after set — native E0382 regression (#442)
+let _mk = new Map();
+let _mkey = { id: 1 };
+_mk.set(_mkey, "v");
+console.log("mapObjKey", _mk.get(_mkey), _mkey.id, _mk.size);
+let _mk2 = new Map();
+let _mv = [1, 2, 3];
+_mk2.set("a", _mv);
+console.log("mapReuse", _mk2.get("a")[0], _mv.length);
+let _mo1 = {};
+let _mo2 = {};
+_mk.set(_mo1, "A");
+_mk.set(_mo2, "B");
+console.log("mapObjIdentity", _mk.get(_mo1), _mk.get(_mo2), _mk.get(_mo1) === "A");
 }
 __perf_run_core_parity_builtins()
 


### PR DESCRIPTION
Closes #442. The native codegen emitted `tish_map_set(&m, key, val)` which MOVED the key/val operands, so a later use of a keyed local (`m.set(k, v); …use k…`, or a Map with an object key) failed to compile with `E0382 use of moved value`.

`map_set` now takes the key/val by reference and clones on insert (the map owns its entries), and the emitter borrows the places like `get`/`has` do. Shape 1 from the issue (try/catch closure capture) already builds on current main. Native compile + interp==vm==native==node validated; parity regression added (exercised on native via the batch build).