### PR TITLE
feat(parser): support function expressions (#464)

### DIFF
--- a/crates/tish_compile_js/src/codegen.rs
+++ b/crates/tish_compile_js/src/codegen.rs
@@ -690,6 +690,14 @@ impl Codegen {
             }
             Expr::Call { callee, args, .. } => {
                 let c = self.emit_expr(callee)?;
+                // An arrow-function callee (an IIFE — `(function(x){…})(n)` lowers to an arrow, as does
+                // `((x)=>…)(n)`) must be parenthesized: without it the call `(args)` binds to the arrow
+                // BODY, not the whole arrow — a `SyntaxError` for a block body, wrong result otherwise.
+                let c = if matches!(&**callee, Expr::ArrowFunction { .. }) {
+                    format!("({})", c)
+                } else {
+                    c
+                };
                 let arg_strs: Result<Vec<_>, _> =
                     args.iter().map(|a| self.emit_call_arg(a)).collect();
                 let arg_strs = arg_strs?.join(", ");

--- a/crates/tish_parser/src/parser.rs
+++ b/crates/tish_parser/src/parser.rs
@@ -2508,11 +2508,20 @@ impl<'a> Parser<'a> {
                         .to_string(),
                 )
             }
-            // `fn` / `type` as a value reference or single-param arrow head (issue #55).
-            // `fn`/`type` function-expressions don't exist and statement-leading decls are
-            // handled in parse_statement, so treating them as identifiers here is additive.
+            // `fn` / `type` as a value reference or single-param arrow head (issue #55), OR a function
+            // EXPRESSION `function (…) {…}` / named `function f(…) {…}` (#464). statement-leading
+            // `function`/`type` decls are handled in parse_statement.
             TokenKind::Ident | TokenKind::Fn | TokenKind::Type => {
                 let name = t.literal.clone().ok_or("Expected ident")?;
+                let is_fn_kw = t.kind == TokenKind::Fn;
+                // Function expression: `function` (`Fn`) followed by `(` (anonymous) or an identifier
+                // (named) has no other valid meaning in value position. `t` is no longer read past
+                // here, so borrowing `self` for the peek is sound.
+                if is_fn_kw
+                    && matches!(self.peek_kind(), Some(TokenKind::LParen | TokenKind::Ident))
+                {
+                    return self.parse_function_expr_tail(&span, false);
+                }
                 // Check if this is a single-param arrow function: x => ...
                 if matches!(self.peek_kind(), Some(TokenKind::Arrow)) {
                     self.advance(); // consume =>
@@ -2763,6 +2772,48 @@ impl<'a> Parser<'a> {
                 end,
             },
         }))
+    }
+
+    /// Parse a `function` EXPRESSION after its `function` token has been consumed (#464):
+    /// `[name] (params) [: RetType] { body }`. Lowers to an `ArrowFunction` with a block body so every
+    /// backend reuses the existing arrow path. An optional name is parsed for source fidelity but not
+    /// bound in scope, so a named function expression cannot yet self-reference by that name (a
+    /// documented follow-up). `this`/`arguments` follow arrow semantics — fine for the common callback
+    /// / IIFE / assigned-callback uses.
+    fn parse_function_expr_tail(
+        &mut self,
+        start_span: &Span,
+        async_: bool,
+    ) -> Result<Expr, String> {
+        // Optional name (named function expression).
+        if matches!(self.peek_kind(), Some(TokenKind::Ident)) {
+            self.advance();
+        }
+        self.expect(TokenKind::LParen)?;
+        let mut params = Vec::new();
+        while !matches!(self.peek_kind(), Some(TokenKind::RParen)) {
+            params.push(self.parse_fun_param()?);
+            if !matches!(self.peek_kind(), Some(TokenKind::RParen)) {
+                self.expect(TokenKind::Comma)?;
+            }
+        }
+        self.expect(TokenKind::RParen)?;
+        // Optional return-type annotation (`: T`) — parsed and discarded (ArrowFunction carries none).
+        if matches!(self.peek_kind(), Some(TokenKind::Colon)) {
+            self.advance();
+            self.parse_type_annotation()?;
+        }
+        let block = self.parse_block()?;
+        let end = self.previous_span_end();
+        Ok(Expr::ArrowFunction {
+            async_,
+            params,
+            body: ArrowBody::Block(Box::new(block)),
+            span: Span {
+                start: start_span.start,
+                end,
+            },
+        })
     }
 
     /// Parse the body of an arrow function (either expression or block)

--- a/tests/core/parity_builtins.js
+++ b/tests/core/parity_builtins.js
@@ -167,3 +167,15 @@ let _mo2 = {};
 _mk.set(_mo1, "A");
 _mk.set(_mo2, "B");
 console.log("mapObjIdentity", _mk.get(_mo1), _mk.get(_mo2), _mk.get(_mo1) === "A");
+// function expressions in value position (#464)
+let _fe = [1, 2, 3];
+_fe.forEach(function(x) { console.log("feEach", x); });
+console.log("feMap", _fe.map(function(x) { return x * 2; }).join(","));
+let _feAssigned = function(n) { return n + 100; };
+console.log("feAssigned", _feAssigned(5));
+let _feNamed = function helper(n) { return n * 3; };
+console.log("feNamed", _feNamed(4));
+console.log("feIife", (function(x) { return x + 1; })(41));
+let _feBase = 10;
+let _feClosure = function(x) { return function(y) { return _feBase + x + y; }; };
+console.log("feClosure", _feClosure(1)(2));

--- a/tests/core/parity_builtins.tish
+++ b/tests/core/parity_builtins.tish
@@ -167,3 +167,15 @@ let _mo2 = {};
 _mk.set(_mo1, "A");
 _mk.set(_mo2, "B");
 console.log("mapObjIdentity", _mk.get(_mo1), _mk.get(_mo2), _mk.get(_mo1) === "A");
+// function expressions in value position (#464)
+let _fe = [1, 2, 3];
+_fe.forEach(function(x) { console.log("feEach", x); });
+console.log("feMap", _fe.map(function(x) { return x * 2; }).join(","));
+let _feAssigned = function(n) { return n + 100; };
+console.log("feAssigned", _feAssigned(5));
+let _feNamed = function helper(n) { return n * 3; };
+console.log("feNamed", _feNamed(4));
+console.log("feIife", (function(x) { return x + 1; })(41));
+let _feBase = 10;
+let _feClosure = function(x) { return function(y) { return _feBase + x + y; }; };
+console.log("feClosure", _feClosure(1)(2));

--- a/tests/core/parity_builtins.tish.expected
+++ b/tests/core/parity_builtins.tish.expected
@@ -115,3 +115,11 @@ awrite 99 [10,99,30]
 mapObjKey v 1 1
 mapReuse 1 3
 mapObjIdentity A B true
+feEach 1
+feEach 2
+feEach 3
+feMap 2,4,6
+feAssigned 105
+feNamed 12
+feIife 42
+feClosure 13

--- a/tests/main.js
+++ b/tests/main.js
@@ -3522,6 +3522,18 @@ let _mo2 = {};
 _mk.set(_mo1, "A");
 _mk.set(_mo2, "B");
 console.log("mapObjIdentity", _mk.get(_mo1), _mk.get(_mo2), _mk.get(_mo1) === "A");
+// function expressions in value position (#464)
+let _fe = [1, 2, 3];
+_fe.forEach(function(x) { console.log("feEach", x); });
+console.log("feMap", _fe.map(function(x) { return x * 2; }).join(","));
+let _feAssigned = function(n) { return n + 100; };
+console.log("feAssigned", _feAssigned(5));
+let _feNamed = function helper(n) { return n * 3; };
+console.log("feNamed", _feNamed(4));
+console.log("feIife", (function(x) { return x + 1; })(41));
+let _feBase = 10;
+let _feClosure = function(x) { return function(y) { return _feBase + x + y; }; };
+console.log("feClosure", _feClosure(1)(2));
 }
 
 {

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3575,6 +3575,18 @@ let _mo2 = {};
 _mk.set(_mo1, "A");
 _mk.set(_mo2, "B");
 console.log("mapObjIdentity", _mk.get(_mo1), _mk.get(_mo2), _mk.get(_mo1) === "A");
+// function expressions in value position (#464)
+let _fe = [1, 2, 3];
+_fe.forEach(function(x) { console.log("feEach", x); });
+console.log("feMap", _fe.map(function(x) { return x * 2; }).join(","));
+let _feAssigned = function(n) { return n + 100; };
+console.log("feAssigned", _feAssigned(5));
+let _feNamed = function helper(n) { return n * 3; };
+console.log("feNamed", _feNamed(4));
+console.log("feIife", (function(x) { return x + 1; })(41));
+let _feBase = 10;
+let _feClosure = function(x) { return function(y) { return _feBase + x + y; }; };
+console.log("feClosure", _feClosure(1)(2));
 }
 __perf_run_core_parity_builtins()
 


### PR DESCRIPTION
Closes #464. `function` in value position — anonymous `function (x){…}`, named `function f(x){…}`, IIFEs, callbacks, assigned, nested/closures — now parses (previously treated as an identifier → `Undefined variable: function`). It lowers to an `ArrowFunction` (block body) so every backend reuses the arrow path; `fn =>` and bare `fn` still fall through unchanged.

Also fixes a **pre-existing JS-backend bug**: an arrow/function-expression IIFE callee is now parenthesized (`((x)=>{…})(n)`), previously mis-emitted as `((x)=>{…}(n))` (a `SyntaxError` for block bodies).

Named function expressions don't bind their name for self-reference yet (documented follow-up). Validated across interp/vm/native/cranelift/wasi and js==node; parity + regression added.