### PR TITLE
feat(lang): auto-invoke top-level main() entry point (#469)

### DIFF
--- a/crates/tish_ast/src/ast.rs
+++ b/crates/tish_ast/src/ast.rs
@@ -175,6 +175,64 @@ pub struct Program {
     pub statements: Vec<Statement>,
 }
 
+/// #469: adopt a Go/Rust/Swift-style `main` entry point.
+///
+/// tish runs top-level statements (JS module semantics), so `fn main() { … }` on its own defines a
+/// function that is never called — a footgun for devs coming from compiled languages (the native
+/// server case: `fn main() { serve(...) }` silently exits). This appends a synthetic `main()`
+/// invocation to the ENTRY program's top-level statements so a defined `main` actually runs: top-level
+/// statements still execute first (module init), then `main`.
+///
+/// Deliberately conservative to avoid a double-invocation: it fires ONLY when a top-level `main`
+/// function is declared AND the program does not already invoke `main()` itself at top level (the
+/// JS-habit `fn main(){…}; main()` shape). This must be applied to the entry module only (not imported
+/// modules) and identically for every backend — call it from `merge_modules` so interp/vm/native/js
+/// stay consistent by construction.
+///
+/// The synthetic call is a plain `main()` (never `await main()`), even for `async fn main`: a blocking
+/// server main never returns anyway, and the interpreter cannot `await` a user async function's result
+/// (a separate pre-existing gap), so an unwrapped call is the one form that behaves identically on
+/// every backend.
+///
+/// Note: this is a tish-specific divergence from JS/node (node does not auto-call `main`); test it via
+/// interp==vm==native cross-checks, and pair any `.tish` fixture with a `.js` that calls `main()`
+/// explicitly so the node reference matches.
+pub fn append_main_entry(statements: &mut Vec<Statement>) {
+    // A top-level `fn main` / `async fn main` declaration.
+    let has_main = statements.iter().any(|s| {
+        matches!(s, Statement::FunDecl { name, .. } if &**name == "main")
+    });
+    if !has_main {
+        return;
+    }
+    // Already invoked at top level? Then the user is driving it — don't double-call.
+    fn is_main_call(expr: &Expr) -> bool {
+        match expr {
+            Expr::Call { callee, .. } => {
+                matches!(callee.as_ref(), Expr::Ident { name, .. } if &**name == "main")
+            }
+            Expr::Await { operand, .. } => is_main_call(operand),
+            _ => false,
+        }
+    }
+    let already_called = statements
+        .iter()
+        .any(|s| matches!(s, Statement::ExprStmt { expr, .. } if is_main_call(expr)));
+    if already_called {
+        return;
+    }
+    let span = Span::default();
+    let call = Expr::Call {
+        callee: Box::new(Expr::Ident {
+            name: Arc::from("main"),
+            span,
+        }),
+        args: Vec::new(),
+        span,
+    };
+    statements.push(Statement::ExprStmt { expr: call, span });
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Statement {
     Block {

--- a/crates/tish_compile/src/resolve.rs
+++ b/crates/tish_compile/src/resolve.rs
@@ -1711,6 +1711,14 @@ pub(crate) fn rewrite_expr_scope(expr: &mut Expr, active: &HashMap<String, Arc<s
 /// Import statements are rewritten as bindings from already-emitted dep exports.
 /// Export statements are unwrapped (the inner declaration is emitted).
 pub fn merge_modules(mut modules: Vec<ResolvedModule>) -> Result<MergedProgram, String> {
+    // #469: give the ENTRY module a Go/Rust/Swift-style `main` entry point. The entry is the last
+    // module (post-order dependency load order), and this runs BEFORE private-binding isolation so the
+    // synthetic `main()` call is renamed in lockstep with the `main` declaration if isolation renames
+    // it. Every backend consumes the merged program, so this keeps interp/vm/native/js consistent.
+    if let Some(entry) = modules.last_mut() {
+        tishlang_ast::append_main_entry(&mut entry.program.statements);
+    }
+
     // #97: isolate module-private top-level bindings before they are flattened together.
     isolate_private_top_level_bindings(&mut modules);
 

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -27,6 +27,8 @@ Tish is a minimal JS/TS-like language: same source runs in a **tree-walking inte
 
 **Functions:** `fn name(a, b) { … }`, single-expr body `fn f(x) = x * 2`, arrows `let g = (a, b) => a + b`, `async fn …` with `await`.
 
+**Entry point (`main`):** a program is its top-level statements (module semantics) — they run top to bottom. As a convenience for compiled-language habits, if the top level declares a `main` function (`fn main` / `async fn main`) and never calls it itself, tish **auto-invokes `main()`** after the top-level statements (so `fn main() { serve(8080, handler) }` on its own actually runs). Auto-invocation is suppressed if you already call `main()` yourself. Consistent across every backend (interpreter, VM, native, JS). This is a tish convention — plain JavaScript does not auto-call `main`.
+
 **Control flow:** `if`/`else`, `while`, `do`/`while`, C-style `for` (comma-separated init declarators: `for (let i = 0, n = len; …)`), `for (let|const x of …)` over arrays, strings, and **iterators** (e.g. `Map`/`Set` `.values()` / `.keys()` / `.entries()`), `switch`, `try`/`catch`.
 
 **Blocks:** `{ … }` **or** indentation (lexer emits `Indent`/`Dedent`). **1 tab = 1 level; 2 spaces = 1 level.** **Debug:** set **`TISH_IGNORE_INDENT=1`** (or `tish dump-ast --ignore-indent`) to ignore indentation and delimit blocks by braces only — handy for isolating whether a nested-block transpilation issue comes from indentation grouping.
@@ -77,7 +79,7 @@ Requires **`http` feature**.
 - **`fetchAll(requests[])`** → **`Promise`** array of the same response shape.
 - **`serve(port, handler)`** — server **`req.body`** / response **`body`** are **strings** (not the client stream shape).
 
-**Top-level `await`:** interpreter `tish run …` (module programs). **Native compile:** `async fn main()` + `await` inside.
+**Top-level `await`:** supported by the interpreter (`tish run …`, module programs) and inside an `async fn main` entry (which the native backend lowers to the generated binary's `async fn main`). The interpreter cannot yet `await` a *user* async function's result — use `await` on the built-in promises (`fetch`, `reader.read()`, …).
 
 **See also:** [`tish_runtime/tests/fetch_readable_stream.rs`](https://github.com/tishlang/tish/blob/main/crates/tish_runtime/tests/fetch_readable_stream.rs) (chunked client body over `getReader()`).
 

--- a/scripts/generate_perf_ci_main.sh
+++ b/scripts/generate_perf_ci_main.sh
@@ -20,9 +20,11 @@ list_pairs_to_stdout() {
       base=$(basename "$tish" .tish)
       # recursion_stress: pathological depth. jit_probe: on-demand JIT diagnostic with a
       # multi-million-iteration loop (would dominate the suite). jit_regression: correctness
-      # guard, not a benchmark. None belong in the bundled perf run.
+      # guard, not a benchmark. main_entry: declares a top-level `fn main` that tish auto-invokes
+      # (#469) — bundling it would auto-run main in the concatenated program and collide with any
+      # other `main`. None belong in the bundled perf run.
       case "$base" in
-        recursion_stress | jit_probe | jit_regression) continue ;;
+        recursion_stress | jit_probe | jit_regression | main_entry) continue ;;
       esac
       js=""
       if [[ -f "$d/${base}.mjs" ]]; then

--- a/tests/core/main_entry.js
+++ b/tests/core/main_entry.js
@@ -1,0 +1,12 @@
+// #469: a top-level `main` is auto-invoked (Go/Rust/Swift-style entry). Top-level statements run
+// first (module init), then `main`. tish-specific: the paired .js calls main() explicitly so the
+// node reference matches (node does not auto-call main).
+console.log("init")
+let counter = 0
+function bump() { counter = counter + 1 }
+function main() {
+  bump()
+  bump()
+  console.log("main", counter)
+}
+main()

--- a/tests/core/main_entry.tish
+++ b/tests/core/main_entry.tish
@@ -1,0 +1,11 @@
+// #469: a top-level `main` is auto-invoked (Go/Rust/Swift-style entry). Top-level statements run
+// first (module init), then `main`. tish-specific: the paired .js calls main() explicitly so the
+// node reference matches (node does not auto-call main).
+console.log("init")
+let counter = 0
+fn bump() { counter = counter + 1 }
+fn main() {
+  bump()
+  bump()
+  console.log("main", counter)
+}

--- a/tests/core/main_entry.tish.expected
+++ b/tests/core/main_entry.tish.expected
@@ -1,0 +1,2 @@
+init
+main 2


### PR DESCRIPTION
Part 1 of resolving #469.

**Root cause of the #469 headline** ("native `serve` exits immediately, code 0"): the repro wraps `serve` in `fn main() { ... }`, but tish runs top-level statements and never auto-called `main` — consistent across interp/vm/native/node, but a footgun for compiled-language devs. (`serve` itself works fine at top level; the other two #469 sub-issues — inline `fn`-expr args, `--feature http-hyper` — are already fixed on main.)

**Fix:** adopt a Go/Rust/Swift-style `main` entry via a shared AST transform (`tishlang_ast::append_main_entry`) applied in `merge_modules`, so **interp/vm/native/js are consistent by construction**. Fires only when a top-level `main` is declared and never called by the program itself (no double-invoke); top-level statements run first, then `main`; `async fn main` is called unwrapped.

Verified: `fn main(){ serve(...) }` native binary now binds + serves; interp==vm==native==js==node; new `tests/core/main_entry` fixture; native/js/interpreter/interp_vm mvp tests pass; parity 94/0; native bundle builds; docs updated. Refs #469.