### PR TITLE
test(http): CI serve smoke gate (both backends) + hyper hardening (#469)

### DIFF
--- a/.github/workflows/native-smoke.yml
+++ b/.github/workflows/native-smoke.yml
@@ -6,7 +6,7 @@
 # Runs on Linux (the deployment / hyper-per-core target). No load generation here — this is a
 # correctness gate (routes return the right bodies, the process stays up), not a benchmark; throughput
 # lives in http-perf.yml.
-name: Serve smoke (both HTTP backends)
+name: Native smoke (CLI + fs + HTTP×2)
 
 on:
   push:
@@ -19,16 +19,18 @@ on:
       - "crates/tish_vm/**"
       - "crates/tish_core/**"
       - "tests/http/**"
+      - "tests/native_smoke/**"
       - "scripts/test_serve_smoke.sh"
-      - ".github/workflows/serve-smoke.yml"
+      - "scripts/test_native_smoke.sh"
+      - ".github/workflows/native-smoke.yml"
 
 concurrency:
-  group: serve-smoke-${{ github.ref }}
+  group: native-smoke-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  serve-smoke:
-    name: Native serve — tiny_http + hyper
+  native-smoke:
+    name: Native apps — CLI + fs + serve (tiny_http + hyper)
     runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 30
     env:
@@ -48,5 +50,5 @@ jobs:
       - name: Build tish (release)
         run: cargo build --release -p tishlang --bin tish
 
-      - name: Serve smoke — tiny_http + hyper
-        run: bash scripts/test_serve_smoke.sh
+      - name: Native smoke — CLI + fs + serve (both backends)
+        run: bash scripts/test_native_smoke.sh

--- a/.github/workflows/serve-smoke.yml
+++ b/.github/workflows/serve-smoke.yml
@@ -1,0 +1,52 @@
+# Serve correctness smoke test — the standing CI guard that `serve(port, handler)` actually binds and
+# serves on BOTH HTTP backends (tiny_http default + hyper), compiled to a native Rust binary. Guards
+# issue #469 (native serve was silently exiting) and keeps the hyper backend from bit-rotting, since
+# it is compiled only under `--feature http-hyper` and so is invisible to the default build/tests.
+#
+# Runs on Linux (the deployment / hyper-per-core target). No load generation here — this is a
+# correctness gate (routes return the right bodies, the process stays up), not a benchmark; throughput
+# lives in http-perf.yml.
+name: Serve smoke (both HTTP backends)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "crates/tish_runtime/**"
+      - "crates/tish_compile/**"
+      - "crates/tish_eval/**"
+      - "crates/tish_vm/**"
+      - "crates/tish_core/**"
+      - "tests/http/**"
+      - "scripts/test_serve_smoke.sh"
+      - ".github/workflows/serve-smoke.yml"
+
+concurrency:
+  group: serve-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  serve-smoke:
+    name: Native serve — tiny_http + hyper
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    timeout-minutes: 30
+    env:
+      # Fleet-safe target-cpu (#223): the default `native` SIGILLs on the virtualized fleet.
+      # No sccache: it flakes the `tish build --native-backend rust` server compile (see http-perf.yml).
+      RUSTFLAGS: "-C target-cpu=x86-64-v3"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Build tish (release)
+        run: cargo build --release -p tishlang --bin tish
+
+      - name: Serve smoke — tiny_http + hyper
+        run: bash scripts/test_serve_smoke.sh

--- a/crates/tish_runtime/src/http_hyper.rs
+++ b/crates/tish_runtime/src/http_hyper.rs
@@ -10,7 +10,7 @@
 //!   N OS threads (one per CPU, pinned via core_affinity)
 //!    ├─ single-threaded tokio runtime per thread
 //!    ├─ SO_REUSEPORT-bound TcpListener per thread
-//!    └─ hyper HTTP/1.1 + HTTP/2 server
+//!    └─ hyper HTTP/1.1 server (`http1::Builder`)
 //!          │
 //!          ├─ async per-connection state machine (no OS thread)
 //!          ├─ static-route fast path (lock-free ArcSwap<HashMap> from
@@ -23,12 +23,16 @@
 //!
 //! * Removes tiny_http's thread-per-connection model (the bottleneck on
 //!   every macOS/Linux Tish HTTP server at >50k concurrent connections).
-//! * Gives HTTP/2 + TLS-ready surface for free (hyper handles the state
-//!   machine; we only have to convert our `RequestPrimitive` to/from
-//!   `http::Request` / `http::Response`).
 //! * Shared async context with `reqwest`, `tokio-postgres`, `tokio` in
 //!   general — the tokio runtime is reused for client fetch, db, and
 //!   server accept.
+//!
+//! ## Protocol support
+//!
+//! HTTP/1.1 only today (the accept loop uses `http1::Builder`). The `hyper` dependency enables the
+//! `http2` feature, so upgrading to an `hyper_util::server::conn::auto` builder (h2c prior-knowledge,
+//! and HTTP/2 over TLS once ALPN is wired) is a contained follow-up — tracked separately. Do NOT
+//! advertise HTTP/2 until that lands.
 //!
 //! ## Integration with the Tish VM
 //!
@@ -312,7 +316,9 @@ async fn handle_request(
 
     // Slow path: cross the mpsc to the VM thread.
     let (method, url, path, query, headers, body_bytes) = extract_request(req).await;
-    let body = String::from_utf8(body_bytes).unwrap_or_default();
+    // Lossy UTF-8 decode to match the tiny_http path (`http.rs`): a body with invalid UTF-8 becomes
+    // replacement chars, NOT an empty string — `req.body` is a String and both backends must agree.
+    let body = String::from_utf8_lossy(&body_bytes).into_owned();
     let prim = RequestPrimitive::new_pub(method, url, path, query, headers, body);
 
     let (resp_tx, resp_rx) = std_mpsc::sync_channel::<ResponsePrimitive>(1);

--- a/docs/concurrency-model.md
+++ b/docs/concurrency-model.md
@@ -194,7 +194,7 @@ accepted the connection** — no cross-thread queue (`worker_loop_direct`, `http
 `let response_value = handler(&[req_value]);` is the bytecode VM executing the user handler to
 completion on that thread. N threads/processes ⇒ N requests truly in parallel. (The opt-in hyper
 backend funnels to a single VM dispatcher thread reached over an mpsc channel,
-`http_hyper.rs:187-198`.)
+`http_hyper.rs` `serve`'s dispatcher loop.)
 
 ### 3d. Async I/O inside a handler
 

--- a/docs/http-techempower-status.md
+++ b/docs/http-techempower-status.md
@@ -95,6 +95,7 @@ verify" section gives the exact commands.
 | `tiny_http`, **native AOT** (`tish build --native-backend rust`): `/plaintext` + `/json`, 32/32 return 200 | manual repro below | ✅ 32/32 200 (snapshot) |
 | `scripts/test_http_concurrency.sh` shared-counter regression passes, no deadlock (PREFORK=0, contended): script exits 0 | `./scripts/test_http_concurrency.sh -n 8` | ✅ pass, no deadlock (snapshot) |
 | `hyper` backend, native AOT (`--feature http-hyper --feature process`): 32/32 return 200, 0 panics | manual repro below | ✅ 32/32 200, 0 panics *(after the fixes below)* (snapshot) |
+| **Serve smoke — BOTH backends bind + serve static/json/dynamic routes on native AOT** | **CI: `.github/workflows/serve-smoke.yml` on every relevant PR + main** (`scripts/test_serve_smoke.sh`) | ✅ automated (tiny_http + hyper) |
 | Full TFB app `tish build src/main.tish` (DB endpoints) builds: exits 0 | `tish-techempower` build | ✅ builds *(after the fixes below)* (snapshot) |
 | All 7 endpoints vs local Postgres (`/db`,`/queries`,`/cached-queries`,`/updates`,`/fortunes`): correct rows, writes, HTML+XSS-escaped fortunes, no panics | manual repro below | ✅ correct (snapshot) |
 | **HTTP throughput is within the http perf gate vs the JS control** | `scripts/run_http_perf.sh`; validated on each run, not a recorded number | not measured in this analysis — run `scripts/run_http_perf.sh` to obtain |

--- a/scripts/test_native_smoke.sh
+++ b/scripts/test_native_smoke.sh
@@ -22,16 +22,19 @@ fi
 
 # build_run NAME FIXTURE "<build feature flags>" "<run env>" "<expected stdout>"
 build_run() {
-  local name="$1" fixture="$2" flags="$3" run_env="$4" expected="$5"
+  local name="$1" fixture="$2" run_env="$3" expected="$4"; shift 4
+  local -a flags=("$@")   # feature flags as an array — properly quoted, no word-split
   local bin="target/native_smoke_${name}"
   echo "──────── ${name} (${fixture}) ────────"
-  # shellcheck disable=SC2086
-  if ! "$TISH" build "$fixture" -o "$bin" --target native --native-backend rust ${flags} >"$bin.build.log" 2>&1; then
+  if ! "$TISH" build "$fixture" -o "$bin" --target native --native-backend rust "${flags[@]}" >"$bin.build.log" 2>&1; then
     echo "  ✗ BUILD FAILED"; tail -30 "$bin.build.log"; FAIL=1; return
   fi
   local got rc
-  # shellcheck disable=SC2086
-  got=$(env ${run_env} "$bin" 2>&1); rc=$?
+  if [[ -n "$run_env" ]]; then
+    got=$(env "$run_env" "$bin" 2>&1); rc=$?   # run_env is a single KEY=VAL
+  else
+    got=$("$bin" 2>&1); rc=$?
+  fi
   if [[ "$rc" != 0 ]]; then
     echo "  ✗ NON-ZERO EXIT ($rc)"; echo "$got"; FAIL=1
   fi
@@ -44,19 +47,21 @@ build_run() {
 }
 
 # 1. CLI app
-build_run "cli" "tests/native_smoke/cli_app.tish" "--feature process" "SMOKE_NAME=ci" \
+build_run "cli" "tests/native_smoke/cli_app.tish" "SMOKE_NAME=ci" \
 "sorted: 1,2,3,5,8,9
 sum: 28
 fib10: 55
 upper: NATIVE
-hello: ci"
+hello: ci" \
+--feature process
 
 # 2. fs app
 FSTMP="target/native_smoke_fs_$$.json"
-build_run "fs" "tests/native_smoke/fs_app.tish" "--feature fs --feature process" "SMOKE_FILE=$FSTMP" \
+build_run "fs" "tests/native_smoke/fs_app.tish" "SMOKE_FILE=$FSTMP" \
 "fs-version: 3
 fs-count: 3
-fs-join: alpha-beta-gamma"
+fs-join: alpha-beta-gamma" \
+--feature fs --feature process
 rm -f "$FSTMP"
 
 # 3. HTTP serve — both backends (delegates to the serve smoke).

--- a/scripts/test_native_smoke.sh
+++ b/scripts/test_native_smoke.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Native-app hardening smoke test — builds real tish programs to native Rust binaries and asserts they
+# actually RUN correctly end to end. Guards the classes of breakage seen recently (issue #469: native
+# `serve` silently exiting; auto-invoked `main`; feature-gated globals in a `main` closure):
+#
+#   1. CLI app   — recursion, array/string builtins, process.env, `fn main()` entry, clean exit.
+#   2. fs app    — write a file, read it back, JSON round-trip.
+#   3. HTTP serve — both backends (tiny_http + hyper) via scripts/test_serve_smoke.sh.
+#
+# Run locally: cargo build --release -p tishlang --bin tish && scripts/test_native_smoke.sh
+# Exits non-zero on ANY failure. Wired into CI (.github/workflows/native-smoke.yml).
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+TISH=${TISH:-target/release/tish}
+FAIL=0
+
+if [[ ! -x "$TISH" ]]; then
+  echo "ERROR: $TISH not found — build it first (cargo build --release -p tishlang --bin tish)"
+  exit 2
+fi
+
+# build_run NAME FIXTURE "<build feature flags>" "<run env>" "<expected stdout>"
+build_run() {
+  local name="$1" fixture="$2" flags="$3" run_env="$4" expected="$5"
+  local bin="target/native_smoke_${name}"
+  echo "──────── ${name} (${fixture}) ────────"
+  # shellcheck disable=SC2086
+  if ! "$TISH" build "$fixture" -o "$bin" --target native --native-backend rust ${flags} >"$bin.build.log" 2>&1; then
+    echo "  ✗ BUILD FAILED"; tail -30 "$bin.build.log"; FAIL=1; return
+  fi
+  local got rc
+  # shellcheck disable=SC2086
+  got=$(env ${run_env} "$bin" 2>&1); rc=$?
+  if [[ "$rc" != 0 ]]; then
+    echo "  ✗ NON-ZERO EXIT ($rc)"; echo "$got"; FAIL=1
+  fi
+  if [[ "$got" == "$expected" ]]; then
+    echo "  ✓ output as expected (exit ${rc})"
+  else
+    echo "  ✗ OUTPUT MISMATCH"; echo "  --- got ---"; echo "$got"; echo "  --- want ---"; echo "$expected"; FAIL=1
+  fi
+  rm -f "$bin" "$bin.build.log"
+}
+
+# 1. CLI app
+build_run "cli" "tests/native_smoke/cli_app.tish" "--feature process" "SMOKE_NAME=ci" \
+"sorted: 1,2,3,5,8,9
+sum: 28
+fib10: 55
+upper: NATIVE
+hello: ci"
+
+# 2. fs app
+FSTMP="target/native_smoke_fs_$$.json"
+build_run "fs" "tests/native_smoke/fs_app.tish" "--feature fs --feature process" "SMOKE_FILE=$FSTMP" \
+"fs-version: 3
+fs-count: 3
+fs-join: alpha-beta-gamma"
+rm -f "$FSTMP"
+
+# 3. HTTP serve — both backends (delegates to the serve smoke).
+echo "──────── http serve (both backends) ────────"
+if TISH="$TISH" bash scripts/test_serve_smoke.sh; then
+  echo "  ✓ serve smoke passed"
+else
+  echo "  ✗ serve smoke FAILED"; FAIL=1
+fi
+
+echo "════════════════════════════════"
+if [[ "$FAIL" == 0 ]]; then
+  echo "ALL NATIVE SMOKE TESTS PASSED (cli + fs + http×2)"
+else
+  echo "NATIVE SMOKE FAILURES — see above"
+fi
+exit "$FAIL"

--- a/scripts/test_serve_smoke.sh
+++ b/scripts/test_serve_smoke.sh
@@ -23,21 +23,24 @@ fi
 
 # test_backend NAME "<extra build feature flags>" "<runtime env, e.g. TISH_HTTP_BACKEND=hyper>"
 test_backend() {
-  local name="$1" build_flags="$2" run_env="$3"
+  local name="$1" run_env="$2"; shift 2
+  local -a extra_flags=("$@")   # e.g. (--feature http-hyper --feature process) — array, no word-split
   local bin="target/serve_smoke_${name}"
   local log="target/serve_smoke_${name}.log"
   echo "──────── backend: ${name} ────────"
 
-  echo "  build: tish build ... --feature http ${build_flags}"
-  # shellcheck disable=SC2086
-  if ! "$TISH" build "$FIX" -o "$bin" --target native --native-backend rust --feature http ${build_flags} >"$log.build" 2>&1; then
+  echo "  build: tish build ... --feature http ${extra_flags[*]}"
+  if ! "$TISH" build "$FIX" -o "$bin" --target native --native-backend rust --feature http "${extra_flags[@]}" >"$log.build" 2>&1; then
     echo "  ✗ BUILD FAILED"; tail -30 "$log.build"; FAIL=1; return
   fi
 
   local port=$(( (RANDOM % 2000) + 8300 ))
   echo "  serve on :${port} (${run_env:-default})"
-  # shellcheck disable=SC2086
-  env PORT="$port" ${run_env} "$bin" >"$log" 2>&1 &
+  if [[ -n "$run_env" ]]; then
+    env PORT="$port" "$run_env" "$bin" >"$log" 2>&1 &   # run_env is a single KEY=VAL
+  else
+    env PORT="$port" "$bin" >"$log" 2>&1 &
+  fi
   local pid=$!
 
   # Wait up to ~10s for the port to accept connections.
@@ -76,8 +79,8 @@ test_backend() {
 
 # `--feature process` is included because a realistic server reads its port from `process.env`
 # (the fixture does), and it exercises the process global captured into the `main` closure.
-test_backend "tiny_http" "--feature process"                     ""
-test_backend "hyper"     "--feature http-hyper --feature process" "TISH_HTTP_BACKEND=hyper"
+test_backend "tiny_http" ""                       --feature process
+test_backend "hyper"     "TISH_HTTP_BACKEND=hyper" --feature http-hyper --feature process
 
 echo "────────────────────────────────"
 if [[ "$FAIL" == 0 ]]; then

--- a/scripts/test_serve_smoke.sh
+++ b/scripts/test_serve_smoke.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Serve correctness smoke test — builds a native tish HTTP server and validates BOTH backends:
+#   * tiny_http (default)
+#   * hyper     (--feature http-hyper + TISH_HTTP_BACKEND=hyper)
+#
+# For each backend: build the native binary, start it, wait for the port to bind, assert a static
+# route, a JSON route, and a dynamic (VM-dispatched) route, confirm the process stays alive, then
+# shut it down. Exits non-zero on ANY failure. This is the standing CI guard that `serve` actually
+# binds and serves on both paths (issue #469 — native serve was silently exiting).
+#
+# Usage: scripts/test_serve_smoke.sh          (needs a release `tish` built, curl)
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+TISH=${TISH:-target/release/tish}
+FIX=tests/http/serve_smoke.tish
+FAIL=0
+
+if [[ ! -x "$TISH" ]]; then
+  echo "ERROR: $TISH not found — build it first (cargo build --release -p tishlang --bin tish)"
+  exit 2
+fi
+
+# test_backend NAME "<extra build feature flags>" "<runtime env, e.g. TISH_HTTP_BACKEND=hyper>"
+test_backend() {
+  local name="$1" build_flags="$2" run_env="$3"
+  local bin="target/serve_smoke_${name}"
+  local log="target/serve_smoke_${name}.log"
+  echo "──────── backend: ${name} ────────"
+
+  echo "  build: tish build ... --feature http ${build_flags}"
+  # shellcheck disable=SC2086
+  if ! "$TISH" build "$FIX" -o "$bin" --target native --native-backend rust --feature http ${build_flags} >"$log.build" 2>&1; then
+    echo "  ✗ BUILD FAILED"; tail -30 "$log.build"; FAIL=1; return
+  fi
+
+  local port=$(( (RANDOM % 2000) + 8300 ))
+  echo "  serve on :${port} (${run_env:-default})"
+  # shellcheck disable=SC2086
+  env PORT="$port" ${run_env} "$bin" >"$log" 2>&1 &
+  local pid=$!
+
+  # Wait up to ~10s for the port to accept connections.
+  local up=0
+  for _ in $(seq 1 100); do
+    curl -sf "http://127.0.0.1:${port}/plaintext" >/dev/null 2>&1 && { up=1; break; }
+    kill -0 "$pid" 2>/dev/null || break
+    sleep 0.1
+  done
+  if [[ "$up" != 1 ]]; then
+    echo "  ✗ SERVER NEVER BOUND :${port}"; echo "  --- server log ---"; cat "$log"
+    kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null; FAIL=1; return
+  fi
+
+  check() {
+    local path="$1" want="$2"
+    local got; got=$(curl -s "http://127.0.0.1:${port}${path}")
+    if [[ "$got" == "$want" ]]; then
+      echo "  ✓ ${path} → '${got}'"
+    else
+      echo "  ✗ ${path}: got '${got}' want '${want}'"; FAIL=1
+    fi
+  }
+  check "/plaintext" "Hello, World!"
+  check "/json"      '{"message":"Hello, World!"}'
+  check "/foo/bar"   "echo:/foo/bar"
+
+  if kill -0 "$pid" 2>/dev/null; then
+    echo "  ✓ process still serving"
+  else
+    echo "  ✗ process exited during test"; cat "$log"; FAIL=1
+  fi
+
+  kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+}
+
+# `--feature process` is included because a realistic server reads its port from `process.env`
+# (the fixture does), and it exercises the process global captured into the `main` closure.
+test_backend "tiny_http" "--feature process"                     ""
+test_backend "hyper"     "--feature http-hyper --feature process" "TISH_HTTP_BACKEND=hyper"
+
+echo "────────────────────────────────"
+if [[ "$FAIL" == 0 ]]; then
+  echo "ALL SERVE SMOKE TESTS PASSED (both http backends)"
+else
+  echo "SERVE SMOKE FAILURES — see above"
+fi
+exit "$FAIL"

--- a/tests/http/serve_smoke.tish
+++ b/tests/http/serve_smoke.tish
@@ -1,0 +1,19 @@
+// Serve smoke fixture — run by scripts/test_serve_smoke.sh against BOTH http backends
+// (tiny_http default + hyper). Uses the `fn main() { serve(...) }` entry idiom (#469 auto-main),
+// a static route, a JSON route, and a dynamic echo route (exercises the VM handler dispatch).
+import { serve } from 'http'
+
+fn handler(req) {
+  if (req.path === "/plaintext") {
+    return { status: 200, headers: { "content-type": "text/plain" }, body: "Hello, World!" }
+  }
+  if (req.path === "/json") {
+    return { status: 200, headers: { "content-type": "application/json" }, body: JSON.stringify({ message: "Hello, World!" }) }
+  }
+  return { status: 200, headers: { "content-type": "text/plain" }, body: "echo:" + req.path }
+}
+
+fn main() {
+  let port = "PORT" in process.env ? parseInt(process.env.PORT) : 8080
+  serve(port, handler)
+}

--- a/tests/native_smoke/cli_app.tish
+++ b/tests/native_smoke/cli_app.tish
@@ -1,0 +1,15 @@
+// Native CLI smoke — computation, recursion, array/string builtins, process.env, clean exit.
+// Uses the `fn main()` entry idiom (#469 auto-main). Build: --feature process.
+fn fib(n) {
+  if (n < 2) { return n }
+  return fib(n - 1) + fib(n - 2)
+}
+fn main() {
+  let nums = [5, 3, 8, 1, 9, 2]
+  console.log("sorted:", nums.toSorted((a, b) => a - b).join(","))
+  console.log("sum:", nums.reduce((a, b) => a + b, 0))
+  console.log("fib10:", fib(10))
+  console.log("upper:", "native".toUpperCase())
+  let name = "SMOKE_NAME" in process.env ? process.env.SMOKE_NAME : "world"
+  console.log("hello:", name)
+}

--- a/tests/native_smoke/fs_app.tish
+++ b/tests/native_smoke/fs_app.tish
@@ -1,0 +1,11 @@
+// Native fs smoke — write a file, read it back, JSON round-trip, assert. Build: --feature fs process.
+import { readFile, writeFile } from 'tish:fs'
+fn main() {
+  let path = "SMOKE_FILE" in process.env ? process.env.SMOKE_FILE : "native_smoke_fs.tmp"
+  let data = { version: 3, items: ["alpha", "beta", "gamma"] }
+  writeFile(path, JSON.stringify(data))
+  let back = JSON.parse(readFile(path))
+  console.log("fs-version:", back.version)
+  console.log("fs-count:", back.items.length)
+  console.log("fs-join:", back.items.join("-"))
+}


### PR DESCRIPTION
Part 2 of #469 (stacked on #470 auto-main — the smoke fixture uses `fn main(){ serve() }`).

**CI gate (the biggest production-readiness gap):** the hyper backend is compiled only under `--feature http-hyper`, so nothing in CI exercised it. `scripts/test_serve_smoke.sh` builds a native tish server and asserts **both** backends (tiny_http + hyper via `TISH_HTTP_BACKEND=hyper`) bind and serve a static, a JSON, and a dynamic VM-dispatched route, and stay alive — wired as `.github/workflows/serve-smoke.yml` on relevant PRs + main (Linux).

**Hyper hardening:**
- Non-UTF-8 request body now decodes lossily (was dropped to empty), matching the tiny_http path so `req.body` agrees on both backends. (Body size already capped via `Limited`.)
- Removed the false "HTTP/1.1 + HTTP/2" claim — the accept loop is `http1::Builder` only. Real HTTP/2 (h2c) tracked in #471.

Validated locally: smoke passes for both backends (static/json/dynamic routes, process stays up); `tishlang_runtime --features http,http-hyper` compiles. Refs #469, #471.