### PR TITLE
ci(npm-release): drop duplicate vite-plugin-tish matrix entry

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -74,10 +74,6 @@ jobs:
             npm: "@tishlang/create-tish-app"
             type: source
             dir: create-tish-app
-          - label: "@tishlang/vite-plugin-tish"
-            npm: "@tishlang/vite-plugin-tish"
-            type: source
-            dir: vite-plugin-tish
           # Unscoped alias of create-tish-app — published as its own package, non-fatal.
           - label: "create-tish-app (unscoped)"
             npm: "create-tish-app"


### PR DESCRIPTION
**Fixes the duplicate publish job.** The `npm-release` matrix listed `@tishlang/vite-plugin-tish` twice (identical `type: source` / `dir: vite-plugin-tish`), so the release spawned **two** identical `Publish @tishlang/vite-plugin-tish` jobs. Removed the duplicate.

**Note — this does NOT fix the E404.** That's a separate, registry-side issue: the workflow uses npm **OIDC trusted publishing**, and per the AUTH note at the top of this file, each package needs a one-time **Trusted Publisher** config on npmjs.com or "a publish fails with E404/E422". `@tishlang/vite-plugin-tish` (currently 0.1.0 on npm) is missing that config; the other @tishlang packages have it, which is why only this one 404s. Configuring the trusted publisher (npmjs.com → the package → Settings → Trusted Publisher → GitHub Actions: org `tishlang`, repo `tish`, workflow `npm-release.yml`) then re-running the job resolves the publish.