### PR TITLE
feat(process): execCapture/execFileCapture — capture subprocess output (#475)

### DIFF
--- a/crates/tish/tests/fixtures/process_capture.tish
+++ b/crates/tish/tests/fixtures/process_capture.tish
@@ -1,0 +1,16 @@
+// Issue #475: process.execCapture / execFileCapture return { code, stdout, stderr }.
+import { execFileCapture, execCapture } from "tish:process"
+
+let ok = execFileCapture("echo", ["hi"])
+console.log("ok=" + ok.code + "," + ok.stdout.trim() + "," + (ok.stderr === ""))
+
+let bad = execFileCapture("false", [])
+console.log("bad=" + bad.code)
+
+let miss = execFileCapture("/no/such/prog/xyz", [])
+console.log("miss=" + miss.code + "," + (miss.stderr !== ""))
+
+let shell = execCapture("echo a; echo b 1>&2")
+console.log("shell=" + shell.code + "," + shell.stdout.trim() + "," + shell.stderr.trim())
+
+console.log("done")

--- a/crates/tish/tests/process_capture.rs
+++ b/crates/tish/tests/process_capture.rs
@@ -1,0 +1,40 @@
+//! Issue #475: `process.execCapture` / `execFileCapture` return `{ code, stdout, stderr }` identically
+//! on every backend (interpreter, bytecode VM, native AOT).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn run_on(backend: &str) -> String {
+    let tish = PathBuf::from(env!("CARGO_BIN_EXE_tish"));
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("process_capture.tish");
+    let out = Command::new(&tish)
+        .args([
+            "run",
+            "--backend",
+            backend,
+            "--feature",
+            "process",
+            path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn tish run");
+    assert!(
+        out.status.success(),
+        "tish run --backend {backend} process_capture.tish failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+const EXPECTED: &str = "ok=0,hi,true\nbad=1\nmiss=-1,true\nshell=0,a,b\ndone\n";
+
+#[test]
+#[cfg(unix)]
+fn exec_capture_on_every_backend() {
+    for backend in ["vm", "interp", "native"] {
+        assert_eq!(run_on(backend), EXPECTED, "exec-capture mismatch on {backend}");
+    }
+}

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1690,9 +1690,11 @@ impl Codegen {
                     "cwd" => Some("Value::native(|args: &[Value]| tish_process_cwd(args))"),
                     "exec" => Some("Value::native(|args: &[Value]| tish_process_exec(args))"),
                     "execFile" => Some("Value::native(|args: &[Value]| tish_process_exec_file(args))"),
+                    "execCapture" => Some("Value::native(|args: &[Value]| tish_process_exec_capture(args))"),
+                    "execFileCapture" => Some("Value::native(|args: &[Value]| tish_process_exec_file_capture(args))"),
                     "argv" => Some("Value::Array(VmRef::new(std::env::args().map(|s| Value::String(s.into())).collect()))"),
                     "env" => Some("Value::object(std::env::vars().map(|(k,v)| (Arc::from(k.as_str()), Value::String(v.into()))).collect())"),
-                    "process" => Some("{ let mut m = ObjectMap::default(); m.insert(Arc::from(\"exit\"), Value::native(|args: &[Value]| tish_process_exit(args))); m.insert(Arc::from(\"cwd\"), Value::native(|args: &[Value]| tish_process_cwd(args))); m.insert(Arc::from(\"exec\"), Value::native(|args: &[Value]| tish_process_exec(args))); m.insert(Arc::from(\"execFile\"), Value::native(|args: &[Value]| tish_process_exec_file(args))); m.insert(Arc::from(\"argv\"), Value::Array(VmRef::new(std::env::args().map(|s| Value::String(s.into())).collect()))); m.insert(Arc::from(\"env\"), Value::object(std::env::vars().map(|(k,v)| (Arc::from(k.as_str()), Value::String(v.into()))).collect::<ObjectMap>())); Value::object(m) }"),
+                    "process" => Some("{ let mut m = ObjectMap::default(); m.insert(Arc::from(\"exit\"), Value::native(|args: &[Value]| tish_process_exit(args))); m.insert(Arc::from(\"cwd\"), Value::native(|args: &[Value]| tish_process_cwd(args))); m.insert(Arc::from(\"exec\"), Value::native(|args: &[Value]| tish_process_exec(args))); m.insert(Arc::from(\"execFile\"), Value::native(|args: &[Value]| tish_process_exec_file(args))); m.insert(Arc::from(\"execCapture\"), Value::native(|args: &[Value]| tish_process_exec_capture(args))); m.insert(Arc::from(\"execFileCapture\"), Value::native(|args: &[Value]| tish_process_exec_file_capture(args))); m.insert(Arc::from(\"argv\"), Value::Array(VmRef::new(std::env::args().map(|s| Value::String(s.into())).collect()))); m.insert(Arc::from(\"env\"), Value::object(std::env::vars().map(|(k,v)| (Arc::from(k.as_str()), Value::String(v.into()))).collect::<ObjectMap>())); Value::object(m) }"),
                     _ => None,
                 },
             "tish:ws" if self.has_feature("ws") => match export_name {
@@ -2246,7 +2248,7 @@ impl Codegen {
             self.write("use tishlang_ui::{fragment_value, install_thread_local_host, native_create_root, native_use_state, ui_h, ui_text, HeadlessHost};\n");
         }
         if self.has_feature("process") {
-            self.write("use tishlang_runtime::{process_exit as tish_process_exit, process_cwd as tish_process_cwd, process_exec as tish_process_exec, process_exec_file as tish_process_exec_file};\n");
+            self.write("use tishlang_runtime::{process_exit as tish_process_exit, process_cwd as tish_process_cwd, process_exec as tish_process_exec, process_exec_file as tish_process_exec_file, process_exec_capture as tish_process_exec_capture, process_exec_file_capture as tish_process_exec_file_capture};\n");
         }
         if self.has_feature("timers") {
             self.write("use tishlang_runtime::{timer_set_timeout as tish_timer_set_timeout, timer_clear_timeout as tish_timer_clear_timeout, timer_set_interval as tish_timer_set_interval, timer_clear_interval as tish_timer_clear_interval};\n");
@@ -2651,6 +2653,8 @@ impl Codegen {
             self.writeln("p.insert(Arc::from(\"cwd\"), Value::native(|args: &[Value]| tish_process_cwd(args)));");
             self.writeln("p.insert(Arc::from(\"exec\"), Value::native(|args: &[Value]| tish_process_exec(args)));");
             self.writeln("p.insert(Arc::from(\"execFile\"), Value::native(|args: &[Value]| tish_process_exec_file(args)));");
+            self.writeln("p.insert(Arc::from(\"execCapture\"), Value::native(|args: &[Value]| tish_process_exec_capture(args)));");
+            self.writeln("p.insert(Arc::from(\"execFileCapture\"), Value::native(|args: &[Value]| tish_process_exec_file_capture(args)));");
             self.writeln("let argv: Vec<Value> = std::env::args().map(|s| Value::String(s.into())).collect();");
             self.writeln("p.insert(Arc::from(\"argv\"), Value::Array(VmRef::new(argv)));");
             self.writeln("let mut env_obj = ObjectMap::default();");

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -320,6 +320,8 @@ impl Evaluator {
                 process_obj.insert("cwd".into(), Value::Native(natives::process_cwd));
                 process_obj.insert("exec".into(), Value::Native(natives::process_exec));
                 process_obj.insert("execFile".into(), Value::Native(natives::process_exec_file));
+                process_obj.insert("execCapture".into(), Value::Native(natives::process_exec_capture));
+                process_obj.insert("execFileCapture".into(), Value::Native(natives::process_exec_file_capture));
                 let argv: Vec<Value> = tishlang_core::process_argv()
                     .into_iter()
                     .map(|s| Value::String(s.into()))
@@ -1412,6 +1414,8 @@ impl Evaluator {
                     exports.insert("cwd".into(), Value::Native(natives::process_cwd));
                     exports.insert("exec".into(), Value::Native(natives::process_exec));
                     exports.insert("execFile".into(), Value::Native(natives::process_exec_file));
+                    exports.insert("execCapture".into(), Value::Native(natives::process_exec_capture));
+                    exports.insert("execFileCapture".into(), Value::Native(natives::process_exec_file_capture));
                     let argv: Vec<Value> = tishlang_core::process_argv()
                         .into_iter()
                         .map(|s| Value::String(s.into()))
@@ -1432,6 +1436,8 @@ impl Evaluator {
                     process_obj.insert("cwd".into(), Value::Native(natives::process_cwd));
                     process_obj.insert("exec".into(), Value::Native(natives::process_exec));
                     process_obj.insert("execFile".into(), Value::Native(natives::process_exec_file));
+                    process_obj.insert("execCapture".into(), Value::Native(natives::process_exec_capture));
+                    process_obj.insert("execFileCapture".into(), Value::Native(natives::process_exec_file_capture));
                     process_obj.insert("argv".into(), Value::Array(Rc::new(RefCell::new(argv))));
                     process_obj.insert("env".into(), Value::object(env_obj));
                     exports.insert(

--- a/crates/tish_eval/src/natives.rs
+++ b/crates/tish_eval/src/natives.rs
@@ -523,6 +523,60 @@ pub fn process_exec_file(args: &[Value]) -> Result<Value, String> {
     Ok(Value::Number(output.status.code().unwrap_or(1) as f64))
 }
 
+/// `{ code, stdout, stderr }` capture object (#475) — lossy-UTF-8 streams (fs convention). Insertion
+/// order (code, stdout, stderr) matches the vm/native builders so JSON.stringify agrees cross-backend.
+#[cfg(feature = "process")]
+fn process_capture_obj(code: i32, stdout: String, stderr: String) -> Value {
+    let mut m = crate::value::PropMap::default();
+    m.insert("code".into(), Value::Number(code as f64));
+    m.insert("stdout".into(), Value::String(stdout.into()));
+    m.insert("stderr".into(), Value::String(stderr.into()));
+    Value::object(m)
+}
+
+#[cfg(feature = "process")]
+fn process_capture_result(out: std::io::Result<std::process::Output>) -> Value {
+    match out {
+        Ok(o) => process_capture_obj(
+            o.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&o.stdout).into_owned(),
+            String::from_utf8_lossy(&o.stderr).into_owned(),
+        ),
+        Err(e) => process_capture_obj(-1, String::new(), e.to_string()),
+    }
+}
+
+/// `process.execCapture(cmd)` — `sh -c cmd`, capturing `{ code, stdout, stderr }` (#475).
+#[cfg(feature = "process")]
+pub fn process_exec_capture(args: &[Value]) -> Result<Value, String> {
+    use std::process::Command;
+    let cmd = args.first().map(|v| v.to_string()).unwrap_or_default();
+    if cmd.is_empty() {
+        return Ok(process_capture_obj(0, String::new(), String::new()));
+    }
+    Ok(process_capture_result(
+        Command::new("sh").arg("-c").arg(&cmd).output(),
+    ))
+}
+
+/// `process.execFileCapture(program, [args])` — no-shell run with output capture (safe for untrusted
+/// args, #384/#475). Returns `{ code, stdout, stderr }`.
+#[cfg(feature = "process")]
+pub fn process_exec_file_capture(args: &[Value]) -> Result<Value, String> {
+    use std::process::Command;
+    let program = args.first().map(|v| v.to_string()).unwrap_or_default();
+    if program.is_empty() {
+        return Ok(process_capture_obj(0, String::new(), String::new()));
+    }
+    let argv: Vec<String> = match args.get(1) {
+        Some(Value::Array(a)) => a.borrow().iter().map(|v| v.to_string()).collect(),
+        _ => Vec::new(),
+    };
+    Ok(process_capture_result(
+        Command::new(&program).args(&argv).output(),
+    ))
+}
+
 #[cfg(feature = "fs")]
 pub fn read_file(args: &[Value]) -> Result<Value, String> {
     let path = args.first().map(|v| v.to_string()).unwrap_or_default();

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -1049,9 +1049,75 @@ pub fn process_exec_file(args: &[Value]) -> Value {
     }
 }
 
+/// Build the `{ code: number, stdout: string, stderr: string }` capture object (#475). stdout/stderr
+/// are lossy-UTF-8 decoded, matching the `fs` string convention (invalid bytes → replacement chars,
+/// never dropped output).
+#[cfg(feature = "process")]
+fn process_capture_obj(code: i32, stdout: String, stderr: String) -> Value {
+    let mut m = tishlang_core::ObjectMap::default();
+    m.insert("code".into(), Value::Number(code as f64));
+    m.insert("stdout".into(), Value::String(stdout.into()));
+    m.insert("stderr".into(), Value::String(stderr.into()));
+    Value::object(m)
+}
+
+/// Build the capture object from a `Command::output()` result. `code` is the exit status, or `-1`
+/// when the process was killed by a signal or failed to spawn (spawn failure puts the OS error in
+/// `stderr`).
+#[cfg(feature = "process")]
+fn process_capture_result(out: std::io::Result<std::process::Output>) -> Value {
+    match out {
+        Ok(o) => process_capture_obj(
+            o.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&o.stdout).into_owned(),
+            String::from_utf8_lossy(&o.stderr).into_owned(),
+        ),
+        Err(e) => process_capture_obj(-1, String::new(), e.to_string()),
+    }
+}
+
+/// `process.execCapture(cmd)` — run `sh -c cmd` and CAPTURE its output as
+/// `{ code: number, stdout: string, stderr: string }` (Rust `Command::output`; Node
+/// `execSync`/`spawnSync({ encoding })`). Use `execFileCapture` for untrusted arguments — this shell
+/// form interprets metacharacters.
+#[cfg(feature = "process")]
+pub fn process_exec_capture(args: &[Value]) -> Value {
+    use std::process::Command;
+    let cmd = args
+        .first()
+        .map(|v| v.to_display_string())
+        .unwrap_or_default();
+    if cmd.is_empty() {
+        return process_capture_obj(0, String::new(), String::new());
+    }
+    process_capture_result(Command::new("sh").arg("-c").arg(&cmd).output())
+}
+
+/// `process.execFileCapture(program, [args])` — run a program directly, WITHOUT a shell, capturing
+/// output as `{ code, stdout, stderr }`. Arguments are passed verbatim, so shell metacharacters in
+/// untrusted data are never interpreted — the safe capturing counterpart for input-derived args
+/// (#384, #475). This is the primitive for shelling out to a CLI and reading its output (e.g.
+/// `git status --porcelain`).
+#[cfg(feature = "process")]
+pub fn process_exec_file_capture(args: &[Value]) -> Value {
+    use std::process::Command;
+    let program = args
+        .first()
+        .map(|v| v.to_display_string())
+        .unwrap_or_default();
+    if program.is_empty() {
+        return process_capture_obj(0, String::new(), String::new());
+    }
+    let argv: Vec<String> = match args.get(1) {
+        Some(Value::Array(a)) => a.borrow().iter().map(|v| v.to_display_string()).collect(),
+        _ => Vec::new(),
+    };
+    process_capture_result(Command::new(&program).args(&argv).output())
+}
+
 #[cfg(all(test, feature = "process", unix))]
 mod execfile_tests_384 {
-    use super::process_exec_file;
+    use super::{process_exec_file, process_exec_file_capture};
     use tishlang_core::{Value, VmRef};
 
     #[test]
@@ -1064,6 +1130,47 @@ mod execfile_tests_384 {
         assert!(matches!(process_exec_file(&[Value::String("echo".into()), args]), Value::Number(n) if n == 0.0));
         // empty program is a no-op returning 0, matching `exec`.
         assert!(matches!(process_exec_file(&[]), Value::Number(n) if n == 0.0));
+    }
+
+    // #475: `{ code, stdout, stderr }` capture.
+    fn fields(v: &Value) -> (f64, String, String) {
+        let Value::Object(o) = v else {
+            panic!("execFileCapture must return an object, got {v:?}")
+        };
+        let b = o.borrow();
+        let num = |k: &str| match b.strings.get(k) {
+            Some(Value::Number(n)) => *n,
+            _ => f64::NAN,
+        };
+        let string = |k: &str| match b.strings.get(k) {
+            Some(Value::String(s)) => s.to_string(),
+            _ => String::new(),
+        };
+        (num("code"), string("stdout"), string("stderr"))
+    }
+
+    #[test]
+    fn execfile_capture_returns_code_stdout_stderr() {
+        // Success: stdout captured, code 0, stderr empty.
+        let args = Value::Array(VmRef::new(vec![Value::String("captured".into())]));
+        let (code, out, err) =
+            fields(&process_exec_file_capture(&[Value::String("echo".into()), args]));
+        assert_eq!(code, 0.0);
+        assert_eq!(out.trim(), "captured");
+        assert_eq!(err, "");
+        // Non-zero exit is reported, not an error.
+        let (code, _, _) = fields(&process_exec_file_capture(&[Value::String("false".into())]));
+        assert_eq!(code, 1.0);
+        // Spawn failure → code -1 with the OS error in stderr (never panics).
+        let (code, out, err) =
+            fields(&process_exec_file_capture(&[Value::String("/no/such/prog/xyz".into())]));
+        assert_eq!(code, -1.0);
+        assert!(out.is_empty());
+        assert!(!err.is_empty());
+        // Empty program → 0 / empty (mirrors execFile).
+        let (code, out, err) = fields(&process_exec_file_capture(&[]));
+        assert_eq!(code, 0.0);
+        assert!(out.is_empty() && err.is_empty());
     }
 }
 

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -337,6 +337,12 @@ fn get_builtin_export(enabled: &HashSet<String>, spec: &str, export_name: &str) 
             "execFile" => Some(Value::native(|args: &[Value]| {
                 tishlang_runtime::process_exec_file(args)
             })),
+            "execCapture" => Some(Value::native(|args: &[Value]| {
+                tishlang_runtime::process_exec_capture(args)
+            })),
+            "execFileCapture" => Some(Value::native(|args: &[Value]| {
+                tishlang_runtime::process_exec_file_capture(args)
+            })),
             "argv" => Some(Value::Array(VmRef::new(
                 tishlang_core::process_argv()
                     .into_iter()
@@ -365,6 +371,16 @@ fn get_builtin_export(enabled: &HashSet<String>, spec: &str, export_name: &str) 
                 m.insert(
                     "execFile".into(),
                     Value::native(|args: &[Value]| tishlang_runtime::process_exec_file(args)),
+                );
+                m.insert(
+                    "execCapture".into(),
+                    Value::native(|args: &[Value]| tishlang_runtime::process_exec_capture(args)),
+                );
+                m.insert(
+                    "execFileCapture".into(),
+                    Value::native(|args: &[Value]| {
+                        tishlang_runtime::process_exec_file_capture(args)
+                    }),
                 );
                 m.insert(
                     "argv".into(),
@@ -958,6 +974,14 @@ fn init_globals(enabled: &HashSet<String>) -> ObjectMap {
         process_obj.insert(
             "execFile".into(),
             Value::native(|args: &[Value]| tishlang_runtime::process_exec_file(args)),
+        );
+        process_obj.insert(
+            "execCapture".into(),
+            Value::native(|args: &[Value]| tishlang_runtime::process_exec_capture(args)),
+        );
+        process_obj.insert(
+            "execFileCapture".into(),
+            Value::native(|args: &[Value]| tishlang_runtime::process_exec_file_capture(args)),
         );
         process_obj.insert(
             "argv".into(),

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -107,7 +107,7 @@ Both backends are guarded in CI (`scripts/test_serve_smoke.sh` / the *Native smo
 |------|---------|
 | `http` | `fetch`, `fetchAll`, `serve`, `Promise`, timers |
 | `fs` | `readFile`, `writeFile`, `readDir`, `mkdir` |
-| `process` | `process.exit`, `env`, `argv` |
+| `process` | `process.exit`, `env`, `argv`, `cwd`, `exec`/`execFile` (exit code), `execCapture`/`execFileCapture` (→ `{ code, stdout, stderr }`) |
 | `regex` | `RegExp` |
 | `full` | all of the above |
 


### PR DESCRIPTION
Closes #475.

`process.exec`/`execFile` returned only the exit code — no way to read a subprocess's stdout/stderr, which blocks the common "shell out to a CLI and read its output" pattern (`git status --porcelain`, `git rev-parse`, …). Adds capturing variants returning `{ code: number, stdout: string, stderr: string }` (Rust `Command::output`; Node `execSync`/`spawnSync({encoding})`):

- **`execFileCapture(program, [args])`** — runs the program directly, **no shell**; args passed verbatim, so shell metacharacters in untrusted/input-derived data are never interpreted (the safe form, #384).
- **`execCapture(cmd)`** — `sh -c` convenience form.

**Semantics:** stdout/stderr are lossy-UTF-8 decoded (matches the `fs` string convention — invalid bytes become replacement chars, never dropped); `code` is the exit status, or `-1` on signal-kill / spawn failure (OS error in `stderr`). Never throws.

**All backends, type-safe, performant:** wired across runtime + interpreter + VM + native codegen; a shared `{ code, stdout, stderr }` builder inserts keys in a fixed order so `JSON.stringify` agrees cross-backend. No panics/unwraps — proper `io::Result` handling.

**Validated:** interp==vm==native identical (echo / non-zero exit / spawn-fail / shell forms); runtime unit tests + a cross-backend integration test (`crates/tish/tests/process_capture.rs`, all three backends); parity 95/0; native batch green. Refs #475, #384.