### PR TITLE
ci(npm-release): pin npm upgrade to 11.x, not @latest

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -96,17 +96,26 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm for OIDC trusted publishing (needs >= 11.5.1)
         run: |
-          # Pinned to the 11.x line, NOT `npm@latest`: npm 12.0.0 (2026-07-09) raised its
-          # own engines.node floor to `^22.22.2 || ^24.15.0 || >=26.0.0`, which excludes the
-          # Node 22.22.0 this runner has hosted-tool-cached — `npm install -g npm@latest`
-          # then fails with EBADENGINE before any package publishes. 11.x's floor
-          # (`^20.17.0 || >=22.9.0`) is satisfied by the runner's Node 22, and 11.18.0+
-          # still satisfies the >=11.5.1 OIDC trusted-publishing requirement.
+          # Pinned to the 11.x line, NOT `npm@latest` / 12.x. Two independent reasons, both
+          # confirmed by local reproduction on 2026-07-09:
+          #  1. npm 12.0.0 raised its own engines.node floor to
+          #     `^22.22.2 || ^24.15.0 || >=26.0.0`. Node 24 (bumped above, was 22) clears
+          #     that on its own, so this is no longer the blocker it was on Node 22.
+          #  2. npm 12.0.0 is independently BROKEN for publishing: its own package.json lists
+          #     `sigstore` in `bundleDependencies`, but the published tarball does not contain
+          #     it, and `libnpmpublish`'s publish path requires it unconditionally at module
+          #     load (regardless of NPM_CONFIG_PROVENANCE) — every `npm publish` crashes with
+          #     `Cannot find module 'sigstore'`, even under Node 24.18.0 (whose bundled npm IS
+          #     12.0.0). Reproduced via `npm publish --dry-run` with provenance off, both on
+          #     Node 24.8.0 and Node 24.18.0. npm 11.18.0 (latest 11.x) has sigstore bundled
+          #     correctly and publishes cleanly, and still satisfies the >=11.5.1 OIDC
+          #     trusted-publishing requirement. Revisit floating to `@latest` once upstream
+          #     ships a patched 12.0.x.
           npm install -g "npm@^11"
           npm --version
 

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -101,7 +101,13 @@ jobs:
 
       - name: Upgrade npm for OIDC trusted publishing (needs >= 11.5.1)
         run: |
-          npm install -g npm@latest
+          # Pinned to the 11.x line, NOT `npm@latest`: npm 12.0.0 (2026-07-09) raised its
+          # own engines.node floor to `^22.22.2 || ^24.15.0 || >=26.0.0`, which excludes the
+          # Node 22.22.0 this runner has hosted-tool-cached — `npm install -g npm@latest`
+          # then fails with EBADENGINE before any package publishes. 11.x's floor
+          # (`^20.17.0 || >=22.9.0`) is satisfied by the runner's Node 22, and 11.18.0+
+          # still satisfies the >=11.5.1 OIDC trusted-publishing requirement.
+          npm install -g "npm@^11"
           npm --version
 
       - name: Determine version and whether it is already published


### PR DESCRIPTION
## Summary

Fixes the total failure of the [v2.36.1 npm-release run](https://github.com/tishlang/tish/actions/runs/29044599800) — every one of the 6+ package-publish jobs failed at the identical step, "Upgrade npm for OIDC trusted publishing", with:

```
npm error code EBADENGINE
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.9.4","node":"v22.22.0"}
```

**Not a tish code change.** npm shipped a new major, `npm@12.0.0`, today, which raised its own `engines.node` floor above what our `actions/setup-node@v4` (was `node-version: "22"`) runner had hosted-tool-cached (`22.22.0`, just below the new `^22.22.2` floor). `npm install -g npm@latest` resolved to 12.0.0 and refused to install before any package got a chance to publish.

## Fix — and an upstream landmine avoided

Two changes:
1. Bump the release runner's Node to **24** (was 22) — more headroom against this class of engine-floor bump recurring.
2. Keep npm pinned to **`^11`**, NOT `@latest`/12.x.

(2) matters more than it looks. I initially assumed "bump to Node 24 + npm@latest" would fully future-proof this, but **local reproduction shows npm 12.0.0 is independently broken for publishing, regardless of Node version**:
- `npm`'s own `package.json` lists `sigstore` under `bundleDependencies`, but the published 12.0.0 tarball does not actually contain it.
- `libnpmpublish`'s publish path (`lib/publish.js` → `require('./provenance')` → `require('sigstore')`) requires it **unconditionally at module load** — so every `npm publish` crashes with `Cannot find module 'sigstore'`, even with `NPM_CONFIG_PROVENANCE=false` (which this workflow already sets), and even under Node 24.18.0 (whose own bundled npm is 12.0.0).
- Confirmed via `npm publish --dry-run` against a throwaway package, on both Node 24.8.0 and Node 24.18.0, with provenance explicitly off — both crash identically.
- npm `11.18.0` (latest 11.x) has `sigstore` bundled correctly, a real `publish --dry-run` succeeds cleanly, and it still satisfies the workflow's own `>=11.5.1` OIDC trusted-publishing requirement.

So: Node 24 (forward-looking, no downside) + npm held at `11.x` until upstream ships a patched `12.0.x` — full rationale is in the workflow comment for whoever revisits this.

## Verify

- YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`).
- No other workflow has the `npm@latest` pattern (grepped `.github/workflows/*.yml`).
- Local end-to-end validation of the exact fix (Node 24.18.0 via `fnm`, then the real CI command `npm install -g "npm@^11"`, then `npm publish --dry-run` with provenance off): clean, no errors.
- Once merged, the v2.36.1 release needs to be re-triggered (`release: edited` — the workflow's `on:` includes `edited`) to actually publish the packages; each job already skips if its exact version is published, so a re-run stays green for anything that happens to have gotten through.