### PR TITLE
feat(http): multipart/form-data uploads in native fetch (#482)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,6 +1751,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,6 +2591,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3850,6 +3867,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/tish_runtime/Cargo.toml
+++ b/crates/tish_runtime/Cargo.toml
@@ -79,7 +79,7 @@ ws = [
 tishlang_core = { path = "../tish_core", version = ">=0.1" }
 tishlang_builtins = { path = "../tish_builtins", version = ">=0.1" }
 tokio = { version = "1.50.0", features = ["rt-multi-thread", "macros", "time", "sync"], optional = true }
-reqwest = { version = "0.13.2", default-features = false, features = ["rustls", "json", "stream"], optional = true }
+reqwest = { version = "0.13.2", default-features = false, features = ["rustls", "json", "stream", "multipart"], optional = true }
 futures = { version = "0.3.32", optional = true }
 bytes = { version = "1", optional = true }
 tiny_http = { version = "0.12.0", optional = true }

--- a/crates/tish_runtime/src/http.rs
+++ b/crates/tish_runtime/src/http.rs
@@ -111,6 +111,57 @@ pub(crate) fn extract_body(options: Option<&Value>) -> Option<String> {
     })
 }
 
+/// A single `multipart/form-data` part extracted from a `fetch` options object's `multipart` array.
+pub(crate) enum MultipartPart {
+    /// A text field: `{ name, value }`.
+    Text { name: String, value: String },
+    /// A file field read from disk (binary-safe): `{ name, path, filename?, contentType? }`.
+    File {
+        name: String,
+        path: String,
+        filename: Option<String>,
+        content_type: Option<String>,
+    },
+}
+
+/// Extract the `multipart` option — an array of part descriptors — from a `fetch` options object.
+/// Each part is `{ name, value }` (text) or `{ name, path, filename?, contentType? }` (file, read as
+/// bytes so binary uploads work). Returns `None` when there is no usable `multipart` array, so callers
+/// fall back to `body`. A part missing `name`, or with neither `path` nor `value`, is skipped.
+pub(crate) fn extract_multipart(options: Option<&Value>) -> Option<Vec<MultipartPart>> {
+    let field = options.and_then(|v| match v {
+        Value::Object(obj) => obj.borrow().strings.get("multipart").cloned(),
+        _ => None,
+    })?;
+    let items = match field {
+        Value::Array(a) => a.borrow().clone(),
+        _ => return None,
+    };
+    let mut parts = Vec::with_capacity(items.len());
+    for item in items {
+        let obj = match &item {
+            Value::Object(o) => o.borrow(),
+            _ => continue,
+        };
+        let name = match obj.strings.get("name") {
+            Some(v) => v.to_display_string(),
+            None => continue,
+        };
+        let filename = obj.strings.get("filename").map(|v| v.to_display_string());
+        let content_type = obj.strings.get("contentType").map(|v| v.to_display_string());
+        if let Some(path) = obj.strings.get("path").map(|v| v.to_display_string()) {
+            parts.push(MultipartPart::File { name, path, filename, content_type });
+        } else if let Some(value) = obj.strings.get("value").map(|v| v.to_display_string()) {
+            parts.push(MultipartPart::Text { name, value });
+        }
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts)
+    }
+}
+
 pub(crate) fn build_error_response(error: &str) -> Value {
     let mut obj: ObjectMap = ObjectMap::with_capacity(2);
     obj.insert(Arc::from("error"), Value::String(error.into()));

--- a/crates/tish_runtime/src/http_fetch.rs
+++ b/crates/tish_runtime/src/http_fetch.rs
@@ -10,7 +10,10 @@ use futures::Stream;
 use futures::StreamExt;
 use tishlang_core::{NativeFn, ObjectMap, TishOpaque, TishPromise, Value};
 
-use crate::http::{build_error_response, extract_body, extract_headers, extract_method};
+use crate::http::{
+    build_error_response, extract_body, extract_headers, extract_method, extract_multipart,
+    MultipartPart,
+};
 
 // --- Promises (Send payloads only; Value built on awaiting thread) ---
 
@@ -479,6 +482,7 @@ async fn send_request_parts(
     method: String,
     headers: Vec<(String, String)>,
     body: Option<String>,
+    multipart: Option<Vec<MultipartPart>>,
 ) -> Result<reqwest::Response, String> {
     if fetch_block_private() {
         ssrf_preflight(&url).await?;
@@ -496,7 +500,39 @@ async fn send_request_parts(
     for (key, value) in headers {
         req = req.header(key, value);
     }
-    if let Some(body) = body {
+    // A `multipart` option takes precedence over `body` — it builds a multipart/form-data request
+    // (reqwest sets the Content-Type + boundary). File parts are read as bytes, so binary uploads work.
+    if let Some(parts) = multipart {
+        let mut form = reqwest::multipart::Form::new();
+        for part in parts {
+            match part {
+                MultipartPart::Text { name, value } => {
+                    form = form.text(name, value);
+                }
+                MultipartPart::File {
+                    name,
+                    path,
+                    filename,
+                    content_type,
+                } => {
+                    let bytes = std::fs::read(&path)
+                        .map_err(|e| format!("multipart file '{path}': {e}"))?;
+                    let fname = filename.unwrap_or_else(|| {
+                        std::path::Path::new(&path)
+                            .file_name()
+                            .map(|s| s.to_string_lossy().into_owned())
+                            .unwrap_or_else(|| name.clone())
+                    });
+                    let mut p = reqwest::multipart::Part::bytes(bytes).file_name(fname);
+                    if let Some(ct) = content_type {
+                        p = p.mime_str(&ct).map_err(|e| e.to_string())?;
+                    }
+                    form = form.part(name, p);
+                }
+            }
+        }
+        req = req.multipart(form);
+    } else if let Some(body) = body {
         req = req.body(body);
     }
     req.send().await.map_err(|e| e.to_string())
@@ -517,10 +553,11 @@ pub fn fetch_promise_from_args(args: Vec<Value>) -> Value {
     let method = extract_method(args.get(1));
     let headers = extract_headers(args.get(1));
     let body = extract_body(args.get(1));
+    let multipart = extract_multipart(args.get(1));
     let (tx, rx) = tokio::sync::oneshot::channel();
     crate::http::RUNTIME.with(|rt| {
         rt.spawn(async move {
-            let r = send_request_parts(url, method, headers, body).await;
+            let r = send_request_parts(url, method, headers, body, multipart).await;
             let _ = tx.send(r);
         });
     });
@@ -541,7 +578,13 @@ pub fn fetch_all_promise_from_args(args: Vec<Value>) -> Value {
         }
     };
     #[allow(clippy::type_complexity)]
-    let mut parts: Vec<(String, String, Vec<(String, String)>, Option<String>)> = Vec::new();
+    let mut parts: Vec<(
+        String,
+        String,
+        Vec<(String, String)>,
+        Option<String>,
+        Option<Vec<MultipartPart>>,
+    )> = Vec::new();
     for req in requests {
         let (url, opt) = match &req {
             Value::String(s) => (s.to_string(), None),
@@ -576,14 +619,15 @@ pub fn fetch_all_promise_from_args(args: Vec<Value>) -> Value {
         let method = extract_method(opt.as_ref());
         let headers = extract_headers(opt.as_ref());
         let body = extract_body(opt.as_ref());
-        parts.push((url, method, headers, body));
+        let multipart = extract_multipart(opt.as_ref());
+        parts.push((url, method, headers, body, multipart));
     }
     let (tx, rx) = tokio::sync::oneshot::channel();
     crate::http::RUNTIME.with(|rt| {
         rt.spawn(async move {
             let futs: Vec<_> = parts
                 .into_iter()
-                .map(|(url, m, h, b)| send_request_parts(url, m, h, b))
+                .map(|(url, m, h, b, mp)| send_request_parts(url, m, h, b, mp))
                 .collect();
             let results = futures::future::join_all(futs).await;
             let mapped: Vec<Result<reqwest::Response, String>> = results.into_iter().collect();

--- a/tests/modules/http_fetch.tish
+++ b/tests/modules/http_fetch.tish
@@ -18,6 +18,19 @@ if (jsonResponse.ok) {
   }
 }
 
+// Multipart form upload (#482): text fields sent as multipart/form-data; httpbin echoes them under `form`.
+let mpResponse = await fetch("https://httpbin.org/post", {
+  method: "POST",
+  multipart: [
+    { name: "field_a", value: "alpha" },
+    { name: "field_b", value: "beta" }
+  ]
+})
+console.log("Multipart status:", mpResponse.status)
+let mpData = await mpResponse.json()
+console.log("Multipart field_a:", mpData.form.field_a)
+console.log("Multipart is form-data:", String(mpData.headers["Content-Type"]).indexOf("multipart/form-data") === 0)
+
 let req1 = { url: "https://httpbin.org/get" }
 let req2 = { url: "https://httpbin.org/status/200" }
 let req3 = { url: "https://httpbin.org/headers" }


### PR DESCRIPTION
Closes #482.

Native `fetch` could only send a **string** body, so tish programs couldn't POST `multipart/form-data` or binary bodies — file uploads had to shell out to `curl`. (Concretely, Dune's cloud-agent build/deploy to Zectre uploads a gzip tarball to `POST /api/v1/builds`, which is multipart.)

## What changed
- Added a `multipart` option to `fetch`/`fetchAll` — an array of parts:
  - text: `{ name, value }`
  - file: `{ name, path, filename?, contentType? }` (read as **bytes**, so binary uploads work)
- Builds a `reqwest::multipart::Form` and sends via `RequestBuilder::multipart`; reqwest sets `Content-Type: multipart/form-data` + boundary. `multipart` takes precedence over `body`.
- Enabled reqwest's `multipart` feature (reqwest was already a dep).

```tish
await fetch(url, { method: 'POST', multipart: [
  { name: 'metadata', value: metaJson },
  { name: 'project', path: '/tmp/x.tar.gz', filename: 'project.tar.gz', contentType: 'application/gzip' },
]})
```

## Verification
- End-to-end against httpbin: a text field + a **binary** file part round-trip; response `Content-Type` is `multipart/form-data; boundary=…`.
- Added a multipart case to `tests/modules/http_fetch.tish`.
- `cargo build -p tishlang_runtime` clean; runtime lib tests pass (4/4). Applies to both the native target and the VM interpreter (shared runtime).

## Follow-ups (out of scope)
- tish→**JS** target doesn't yet translate `multipart` to `FormData` (JS hosts can use `FormData` directly).
- A general raw **binary body** (`body` as bytes/`Uint8Array`) — the file-part `path` covers the upload need for now.