### PR TITLE
fix(native): borrow the source in Value→struct coercion — fixes E0382 use-after-move (#486)

### DIFF
--- a/crates/tish_compile/src/types.rs
+++ b/crates/tish_compile/src/types.rs
@@ -390,13 +390,18 @@ impl RustType {
                 let field_assigns = fields
                     .iter()
                     .map(|(k, ty)| {
-                        let fetch = format!("tishlang_runtime::get_prop(&_src, {:?})", k.as_ref());
+                        let fetch = format!("tishlang_runtime::get_prop(_src, {:?})", k.as_ref());
                         format!("{}: {}", field_ident(k), ty.from_value_expr(&fetch))
                     })
                     .collect::<Vec<_>>()
                     .join(", ");
+                // Bind `_src` as a BORROW (not a move) of the source Value: field fetches only need
+                // `&Value` (get_prop borrows), and moving would use-after-move a caller-owned temp —
+                // e.g. an assignment-as-expression `{ let _v = obj; lhs = <coerce _v>; _v }` reuses
+                // `_v` for its value (tishlang/tish#486). `&(expr)` evaluates the source once and
+                // (for a temporary) lifetime-extends it to this block, so it's still single-eval.
                 format!(
-                    "{{ let _src = {}; {} {{ {} }} }}",
+                    "{{ let _src = &({}); {} {{ {} }} }}",
                     value_expr,
                     named_struct_ident(name),
                     field_assigns

--- a/crates/tish_compile/tests/regr_e0382_typed_struct.rs
+++ b/crates/tish_compile/tests/regr_e0382_typed_struct.rs
@@ -1,0 +1,26 @@
+//! tishlang/tish#486 — a typed nullable-struct local reassigned to a struct literal in a conditional
+//! must not emit a Value→struct coercion that MOVES the source temp, because the assignment-as-
+//! expression wrapper (`{ let _v = obj; lhs = <coerce _v>; _v }`) reuses that temp for its value —
+//! moving it produced `error[E0382]: use of moved value`. The coercion must borrow the source.
+use std::path::PathBuf;
+use tishlang_compile::compile_project_full;
+
+fn compile(rel: &str) -> String {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = manifest.join("../..").join(rel).canonicalize().unwrap();
+    compile_project_full(&path, path.parent(), &[], true).unwrap().0
+}
+
+#[test]
+fn typed_struct_coercion_borrows_source() {
+    let rust = compile("tests/regression/typed_struct_cond_assign.tish");
+    // The Value→struct coercion must bind `_src` by BORROW, never by moving a bare temp.
+    assert!(
+        rust.contains("let _src = &("),
+        "expected the struct coercion to borrow its source (`let _src = &(...)`)"
+    );
+    assert!(
+        !rust.contains("let _src = _v;"),
+        "tishlang/tish#486: struct coercion must not MOVE the wrapper temp `_v` (use-after-move / E0382)"
+    );
+}

--- a/tests/regression/typed_struct_cond_assign.tish
+++ b/tests/regression/typed_struct_cond_assign.tish
@@ -1,0 +1,8 @@
+interface Repo { url: string, ref: string? }
+fn build(cond: boolean, u: string): Repo? {
+  let repo: Repo? = null
+  if (cond) { repo = { url: u, ref: null } }
+  return repo
+}
+let r = build(true, "x")
+console.log("ok: " + String(r))


### PR DESCRIPTION
Fixes #486.

### Problem
A typed nullable-struct local reassigned to a struct object literal inside a conditional fails to compile with `error[E0382]: use of moved value`:
```tish
interface Repo { url: string, ref: string? }
fn build(cond: boolean, u: string): Repo? {
  let repo: Repo? = null
  if (cond) { repo = { url: u, ref: null } }   // <-- E0382
  return repo
}
```

### Root cause
`from_value_expr`'s `Named` (struct) case emits `{ let _src = <source>; TishStruct { ... get_prop(&_src, "k") ... } }`, binding the source **by move** even though the fields are read via `get_prop`, which only **borrows**. The assignment-as-expression wrapper is `{ let _v = <obj>; lhs = <coerce _v>; _v }` — it reuses `_v` for the assignment's value, so moving `_v` into `_src` turns the trailing `_v` into a use-after-move.

### Fix
Bind `_src` by borrow — `let _src = &(<source>)` — and fetch fields with `get_prop(_src, …)`. `&(expr)` evaluates the source once and (for a temporary) lifetime-extends it to the block, so the single-eval property the `_src` binding exists for is preserved; the source Value is no longer consumed. No clone added.

### Tests
- `tests/regression/typed_struct_cond_assign.tish` + `crates/tish_compile/tests/regr_e0382_typed_struct.rs` — assert the coercion borrows (`let _src = &(`) and never bare-moves the wrapper temp.
- Full `tish_compile` suite green (`from_value_expr` is core codegen — JSON/PG/params/returns all exercise it).
- End-to-end: the repro (previously a hard `rustc` E0382) now compiles + runs.
