### PR TITLE
fix(native): cover S-0 object-field-value params in the numeric-arg whitelist (#484)

### DIFF
--- a/crates/tish_compile/src/infer.rs
+++ b/crates/tish_compile/src/infer.rs
@@ -338,9 +338,44 @@ fn param_is_body_numeric_candidate(body: &Statement, base_nums: &HashSet<String>
         && copy_descendants.iter().all(|x| lns_stmt(body, x.as_str(), &nums))
 }
 
-/// Per fn (top-level and nested), the parameter POSITIONS that are numeric candidates — i.e. the
-/// body would M4-promote them to f64. The call-arg whitelist (#485/#477/#484) checks ONLY these
-/// positions, so array/object params (e.g. native-vec devirt) never disqualify a fn.
+/// analyze_aggregate's S-0 numeric-param set for one fn: the optimistic `pus_stmt` fixpoint (a param
+/// used only as an object-field VALUE / numeric operand is numeric). Shared with the call-arg
+/// whitelist so its candidate set covers what S-0 (via `stamp_numeric_params`) actually promotes.
+fn s0_numeric_candidates(params: &[FunParam], body: &Statement) -> HashSet<String> {
+    let mut nums = HashSet::new();
+    collect_numeric_locals_fixpoint(body, &mut nums);
+    let mut numeric_params: HashSet<String> = params
+        .iter()
+        .filter_map(|p| match p {
+            FunParam::Simple(tp) if tp.type_ann.is_none() && tp.default.is_none() => {
+                Some(tp.name.to_string())
+            }
+            _ => None,
+        })
+        .collect();
+    loop {
+        let mut local_nums = nums.clone();
+        for n in &numeric_params {
+            local_nums.insert(n.clone());
+        }
+        let drop: Vec<String> = numeric_params
+            .iter()
+            .filter(|n| !pus_stmt(body, n.as_str(), &local_nums))
+            .cloned()
+            .collect();
+        if drop.is_empty() {
+            break;
+        }
+        for n in drop {
+            numeric_params.remove(&n);
+        }
+    }
+    numeric_params
+}
+
+/// Per fn (top-level and nested), the parameter POSITIONS that are numeric candidates — i.e. either
+/// promotion path would M4-promote them to f64. The call-arg whitelist (#485/#477/#484) checks ONLY
+/// these positions, so array/object params (e.g. native-vec devirt) never disqualify a fn.
 pub(crate) fn numeric_candidate_positions(
     statements: &[Statement],
 ) -> std::collections::HashMap<String, Vec<(usize, String)>> {
@@ -359,12 +394,18 @@ fn ncp_stmt(s: &Statement, out: &mut std::collections::HashMap<String, Vec<(usiz
         FunDecl { name, params, body, .. } => {
             let mut base_nums = HashSet::new();
             collect_numeric_locals_fixpoint(body, &mut base_nums);
+            // A position is a candidate if EITHER promotion path would take it: pi_stmt (nus_stmt) OR
+            // analyze_aggregate's S-0 (pus_stmt — which also accepts a param used as an object-field
+            // VALUE, e.g. `{ v: s }`). The whitelist must cover BOTH or a param S-0 promotes but
+            // pi_stmt doesn't (tishlang/tish#484) gets an f64 unbox with no call-arg check.
+            let s0 = s0_numeric_candidates(params, body);
             let mut positions: Vec<(usize, String)> = Vec::new();
             for (i, p) in params.iter().enumerate() {
                 if let FunParam::Simple(tp) = p {
                     if tp.type_ann.is_none()
                         && tp.default.is_none()
-                        && param_is_body_numeric_candidate(body, &base_nums, tp.name.as_ref())
+                        && (param_is_body_numeric_candidate(body, &base_nums, tp.name.as_ref())
+                            || s0.contains(tp.name.as_ref()))
                     {
                         positions.push((i, tp.name.to_string()));
                     }
@@ -706,9 +747,17 @@ pub(crate) fn fns_with_unsafe_numeric_arg(statements: &[Statement]) -> HashSet<S
     for s in statements {
         cfm_stmt(s, &mut all_params, &mut fn_locals);
     }
+    // Top-level numeric locals — run a fixpoint ACROSS statements so a chain propagates
+    // (`let PI = …; let SOLAR_MASS = 4 * PI * PI` ⇒ both numeric, so `body(…, SOLAR_MASS)` is safe).
     let mut top_nums = HashSet::new();
-    for s in statements {
-        collect_numeric_locals_fixpoint(s, &mut top_nums);
+    loop {
+        let before = top_nums.len();
+        for s in statements {
+            collect_numeric_locals_fixpoint(s, &mut top_nums);
+        }
+        if top_nums.len() == before {
+            break;
+        }
     }
     let mut calls = Vec::new();
     for s in statements {
@@ -731,7 +780,10 @@ pub(crate) fn fns_with_unsafe_numeric_arg(statements: &[Statement]) -> HashSet<S
             let ctx: HashSet<String> = match &cs.caller {
                 None => top_nums.clone(),
                 Some(c) => {
-                    let mut ctx = fn_locals.get(c).cloned().unwrap_or_default();
+                    // Top-level numeric globals (`SOLAR_MASS`, `PI`, …) are numeric inside every fn,
+                    // plus this fn's numeric locals + its still-numeric params.
+                    let mut ctx = top_nums.clone();
+                    ctx.extend(fn_locals.get(c).cloned().unwrap_or_default());
                     if let (Some(ps), Some(np)) = (all_params.get(c), numeric_pos.get(c)) {
                         for &pos in np {
                             if let Some(n) = ps.get(pos) {

--- a/crates/tish_compile/tests/regr_484_obj_field_param.rs
+++ b/crates/tish_compile/tests/regr_484_obj_field_param.rs
@@ -1,0 +1,18 @@
+//! tishlang/tish#484 — a string param used only as an object-field VALUE (`{ v: s }`) must not be
+//! native-promoted to f64. analyze_aggregate's S-0 (`pus_stmt`) treats a field-value param as
+//! numeric; the call-arg whitelist must cover S-0's candidate set, so `f("hello")` disqualifies f.
+use std::path::PathBuf;
+use tishlang_compile::compile_project_full;
+fn compile(rel: &str) -> String {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = manifest.join("../..").join(rel).canonicalize().unwrap();
+    compile_project_full(&path, path.parent(), &[], true).unwrap().0
+}
+#[test]
+fn obj_field_string_param_stays_boxed() {
+    for f in ["tests/regression/obj_field_string_param.tish", "tests/regression/async_param_across_await.tish"] {
+        let rust = compile(f);
+        let bad: Vec<&str> = rust.lines().filter(|l| l.contains("expected number")).collect();
+        assert!(bad.is_empty(), "{f}: string field-value param must not f64-unbox:\n{}", bad.join("\n"));
+    }
+}

--- a/tests/regression/async_param_across_await.tish
+++ b/tests/regression/async_param_across_await.tish
@@ -1,0 +1,7 @@
+fn f(s) {
+  let o = { v: s }
+  await Promise.resolve(1)
+  return JSON.stringify(o)
+}
+let r = await f("hello")
+console.log("R=" + r)

--- a/tests/regression/obj_field_string_param.tish
+++ b/tests/regression/obj_field_string_param.tish
@@ -1,0 +1,2 @@
+fn f(s) { let o = { v: s }; return JSON.stringify(o) }
+console.log("R=" + f("hello"))


### PR DESCRIPTION
Fixes #484.

### Problem
A string param used only as an object-field **value** — `fn f(s) { let o = { v: s }; return JSON.stringify(o) }` — gets native-promoted to `f64` and unboxed, so `f("hello")` aborts with `expected number` (both sync and async; the issue's "sync OK" turned out to be version-specific — both abort on current `main`).

### Why #489 missed it
There are **two** numeric-param promotion paths and they disagree on what's a candidate:
- `pi_stmt` uses `nus_stmt` — an object store bails (`s` is *not* a candidate).
- `analyze_aggregate`'s **S-0** uses `pus_stmt`, which treats a param used as an object-field value as numeric (so `{ key: n }` can fold into a native struct).

#489's whitelist built its candidate set only from `pi_stmt`'s predicate, so an **S-0-only** candidate was promoted with no call-arg check.

### Fix
`numeric_candidate_positions` now **unions in S-0's candidate set** (`s0_numeric_candidates`, the `pus_stmt` fixpoint extracted from `analyze_aggregate`). The whitelist then checks those positions and disqualifies `f` when a non-number reaches one — while a genuinely-numeric field-value param (`mk(5)` → `{ key: 5 }`) still passes and keeps the S-0 native-struct optimization.

Broadening the candidate set surfaced two latent soundness holes in the whitelist's numeric context, fixed here so there's **no perf regression**:
1. top-level numeric **globals** (`let SOLAR_MASS = 4*PI*PI`) are now seeded into every fn's caller context, so `body(…, SOLAR_MASS)` inside a fn is provably numeric;
2. the top-level numeric-locals set uses a fixpoint **across** statements so `let PI=…; let SOLAR_MASS = 4*PI*PI` propagates.

### Verification
- sync + async #484 repros now run: `R={"v":"hello"}` (were exit 134).
- **Whole perf gauntlet** compiles + produces correct values: `mandelbrot 247703 · fasta 216928169 · nbody -169083713 · fannkuch 7319600038 · queens 42600 · fnv_hash 87326928 · spectral_norm 1274224148`.
- Full `tish_compile` suite green (17 suites).
- TDD: `tests/regression/{obj_field_string_param,async_param_across_await}.tish` + `regr_484_obj_field_param.rs` assert no f64 unbox.

`infer.rs`-only. With #488/#489 already merged, this closes out the whole `expected number` / f64-unbox family (#477/#479/#484/#485/#486).
