### PR TITLE
fix(native): box a typed Option by reference in to_value_expr — fixes E0382 in FnMut/serve closures (#491)

### DIFF
--- a/crates/tish_compile/src/types.rs
+++ b/crates/tish_compile/src/types.rs
@@ -453,9 +453,13 @@ impl RustType {
                 )
             }
             RustType::Option(inner) => {
-                let inner_to_value = inner.to_value_expr("v");
+                // Box by REFERENCE so the source Option is NOT moved — it may be a local captured by
+                // an FnMut closure (a `serve()` handler, called per request) or used again after this
+                // conversion. Mirrors the Vec arm's `.iter()` (which likewise avoids moving). `(*v)`
+                // derefs the `&inner` the ref-match binds, so the inner's own clone/copy still applies.
+                let inner_to_value = inner.to_value_expr("(*v)");
                 format!(
-                    "match {} {{ Some(v) => {}, None => Value::Null }}",
+                    "match &({}) {{ Some(v) => {}, None => Value::Null }}",
                     native_expr, inner_to_value
                 )
             }

--- a/crates/tish_compile/tests/regr_serve_closure.rs
+++ b/crates/tish_compile/tests/regr_serve_closure.rs
@@ -1,0 +1,22 @@
+//! tishlang/tish — a typed Option (`string?`) captured by a long-lived FnMut closure (a `serve()`
+//! handler, called per request) must not be MOVED when boxed to a Value for a `=== null` comparison.
+//! `to_value_expr(Option)` must match by REFERENCE (`match &(…)`), like the Vec arm's `.iter()`.
+use std::path::PathBuf;
+use tishlang_compile::compile_project_full;
+fn compile(rel: &str) -> String {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let path = manifest.join("../..").join(rel).canonicalize().unwrap();
+    compile_project_full(&path, path.parent(), &[], true).unwrap().0
+}
+#[test]
+fn option_boxing_borrows_not_moves() {
+    let rust = compile("tests/regression/serve_closure_captures_typed.tish");
+    assert!(
+        rust.contains("match &(sToken)"),
+        "Option→Value boxing must match by reference so the source isn't moved"
+    );
+    assert!(
+        !rust.contains("match sToken { Some(v)"),
+        "Option→Value boxing must not match by value (moves the closure-captured Option)"
+    );
+}

--- a/tests/regression/serve_closure_captures_typed.tish
+++ b/tests/regression/serve_closure_captures_typed.tish
@@ -1,0 +1,19 @@
+fn handle(root: string, webRoot: string?, token: string?) {
+  let sRoot = root
+  let sWebRoot = webRoot
+  let sToken = token
+  console.log("auth: " + (sToken === null ? "open" : "token required"))
+  serve(8080, fn(req) {
+    if (sToken !== null) {
+      let auth = "x"
+      if (auth !== ("Bearer " + sToken)) {
+        return { status: 401, headers: {}, body: "no" }
+      }
+    }
+    if (sWebRoot !== null) {
+      return { status: 200, headers: {}, body: sWebRoot }
+    }
+    return { status: 200, headers: {}, body: sRoot }
+  })
+}
+handle("/root", null, "secret")


### PR DESCRIPTION
Fixes #491.

### Problem
`RustType::Option::to_value_expr` boxes a typed `Option<T>` → `Value` by matching **by value** (`match sToken { Some(v) => … }`), which **moves** the source. When that source is a local captured by a long-lived `FnMut` closure (a `serve()` handler, called per request) and boxed for a `=== null` check, it fails with `error[E0382]: borrow of partially moved value`.

### Fix
Match by **reference** and deref the bound `&inner`:
```rust
let inner_to_value = inner.to_value_expr("(*v)");
format!("match &({}) {{ Some(v) => {}, None => Value::Null }}", native_expr, inner_to_value)
```
`(*v)` works for every inner (`String` clones, `f64`/`bool` copy, `Named` field-accesses through the deref). This mirrors the `Vec` arm directly above, which already uses `.iter()` to avoid moving the source. Never moves — strictly safer at every boxing site.

### Tests
- `tests/regression/serve_closure_captures_typed.tish` + `regr_serve_closure.rs` assert the Option boxing matches by reference.
- The repro (a real `serve()` handler with a `token: string?` param) compiles instead of E0382.
- Full `tish_compile` suite green (18 suites).

Found typing Dune's `serveWorkspace()`; once released this lets a `serve()` host type its `root`/`webRoot`/`token` params instead of leaving them boxed.
