### PR TITLE
feat(pty): native `tish:pty` module — pseudoterminal spawn/read/write/resize/kill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -909,6 +915,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dragonbox_ecma"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,6 +998,17 @@ dependencies = [
  "cfg-if",
  "rustix 1.1.4",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -1789,13 +1812,25 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -2271,6 +2306,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,7 +2413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -2398,7 +2454,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2 0.6.3",
@@ -2755,7 +2811,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.30.1",
  "radix_trie",
  "unicode-segmentation",
  "unicode-width",
@@ -2902,6 +2958,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2922,6 +2989,22 @@ dependencies = [
  "cpufeatures 0.3.0",
  "digest 0.11.3",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -3521,6 +3604,7 @@ dependencies = [
  "hyper-util",
  "lazy_static",
  "libc",
+ "portable-pty",
  "rand 0.10.1",
  "reqwest",
  "socket2 0.5.10",
@@ -4543,6 +4627,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1714,6 +1714,15 @@ impl Codegen {
                     "readLine" => Some("Value::native(|args: &[Value]| tishlang_runtime::tty_read_line(args))"),
                     _ => None,
                 },
+            "tish:pty" if self.has_feature("pty") => match export_name {
+                    "spawn" => Some("Value::native(|args: &[Value]| tishlang_runtime::pty_spawn(args))"),
+                    "read" => Some("Value::native(|args: &[Value]| tishlang_runtime::pty_read(args))"),
+                    "write" => Some("Value::native(|args: &[Value]| tishlang_runtime::pty_write(args))"),
+                    "resize" => Some("Value::native(|args: &[Value]| tishlang_runtime::pty_resize(args))"),
+                    "kill" => Some("Value::native(|args: &[Value]| tishlang_runtime::pty_kill(args))"),
+                    "pid" => Some("Value::native(|args: &[Value]| tishlang_runtime::pty_pid(args))"),
+                    _ => None,
+                },
             _ => return None,
         };
         init.map(String::from)
@@ -1723,7 +1732,7 @@ impl Codegen {
         if self.features.contains("full") {
             matches!(
                 name,
-                "http" | "timers" | "fs" | "process" | "regex" | "ws" | "tty"
+                "http" | "timers" | "fs" | "process" | "regex" | "ws" | "tty" | "pty"
             )
         } else {
             self.features.contains(name)

--- a/crates/tish_compile/src/resolve.rs
+++ b/crates/tish_compile/src/resolve.rs
@@ -59,6 +59,7 @@ const BUILTIN_ALIASES: &[(&str, &str)] = &[
     ("process", "tish:process"),
     ("ws", "tish:ws"),
     ("tty", "tish:tty"),
+    ("pty", "tish:pty"),
 ];
 
 /// Normalize built-in spec to canonical form. Handles the Node `node:` prefix
@@ -87,9 +88,10 @@ pub fn is_builtin_native_spec(spec: &str) -> bool {
             | "tish:process"
             | "tish:ws"
             | "tish:tty"
+            | "tish:pty"
     ) || matches!(
         spec,
-        "fs" | "fs/promises" | "http" | "timers" | "process" | "ws" | "tty"
+        "fs" | "fs/promises" | "http" | "timers" | "process" | "ws" | "tty" | "pty"
     )
 }
 

--- a/crates/tish_native/src/build.rs
+++ b/crates/tish_native/src/build.rs
@@ -17,6 +17,7 @@ const RUNTIME_CARGO_FEATURES: &[&str] = &[
     "regex",
     "ws",
     "tty",
+    "pty",
 ];
 
 /// Map CLI/compile features to flags passed to `tishlang_runtime` in the temp crate's Cargo.toml.

--- a/crates/tish_runtime/Cargo.toml
+++ b/crates/tish_runtime/Cargo.toml
@@ -58,6 +58,9 @@ fs = ["promise", "dep:rand"]
 process = []
 # Interactive terminal I/O (issue #101): raw mode, key/resize events, size, alt screen.
 tty = ["dep:crossterm"]
+# Pseudoterminal hosting (issue #493): spawn a shell/program on a real PTY, read/write/resize/kill —
+# so an interactive terminal emulator on the other end of a socket behaves like a real TTY.
+pty = ["dep:portable-pty", "dep:lazy_static"]
 regex = ["tishlang_core/regex"]
 # WebSocket (JS-like API). Modular: import { WebSocket, Server } from 'tish:ws'.
 # Requires `send-values` because the WS server keeps an `Arc<dyn Fn + Send +
@@ -90,6 +93,8 @@ libc = { version = "0.2", optional = true }
 arc-swap = { version = "1", optional = true }
 # Interactive terminal I/O (feature = tty): cross-platform raw mode, key/resize events, size.
 crossterm = { version = "0.28", optional = true }
+# Pseudoterminal hosting (feature = pty): cross-platform openpty + shell spawn (same crate Dune uses).
+portable-pty = { version = "0.9", optional = true }
 # hyper backend (feature = http-hyper)
 hyper = { version = "1", default-features = false, features = ["server", "http1", "http2"], optional = true }
 hyper-util = { version = "0.1", features = ["server", "tokio"], optional = true }

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -1727,6 +1727,11 @@ pub use tty::{
     tty_enter_alt_screen, tty_is_tty, tty_leave_alt_screen, tty_read, tty_read_line, tty_set_raw_mode, tty_size,
 };
 
+#[cfg(feature = "pty")]
+pub mod pty;
+#[cfg(feature = "pty")]
+pub use pty::{pty_kill, pty_pid, pty_read, pty_resize, pty_spawn, pty_write};
+
 #[cfg(feature = "ws")]
 pub use ws::{
     web_socket_client, web_socket_server_accept, web_socket_server_construct,

--- a/crates/tish_runtime/src/pty.rs
+++ b/crates/tish_runtime/src/pty.rs
@@ -1,0 +1,451 @@
+//! Pseudoterminal (PTY) module for Tish (`tish:pty`), behind the `pty` feature.
+//!
+//! Spawns a real OS pseudoterminal with a live shell/program attached — so an interactive
+//! terminal emulator (xterm.js) on the other end of a socket behaves like a real TTY:
+//! `isatty()` passes, so line-editing and curses apps (vim, top, ssh, tab-completion, and
+//! `SIGWINCH` resize) all work. This is what `tish:process` (run-to-completion capture) and
+//! `tish:tty` (this process's OWN controlling terminal) cannot do. Imported as
+//! `import { spawn, read, write, resize, kill } from 'tish:pty'`.
+//!
+//! Polling model (transport-agnostic — pairs with a `tish:ws` pump or an HTTP long-poll):
+//!   - `spawn({ program?, cwd?, cols?, rows?, env? }) -> id | null`
+//!   - `read(id, timeoutMs?) -> string | null`   (`""` = live but no output yet; `null` = EOF/unknown)
+//!   - `write(id, data) -> bool`
+//!   - `resize(id, cols, rows) -> bool`
+//!   - `kill(id) -> bool`
+//!   - `pid(id) -> number | null`
+//!
+//! A per-session reader thread fills a byte buffer that `read` drains at a UTF-8 boundary
+//! (incomplete trailing multibyte sequences are held for the next read — no mojibake). A global
+//! `Mutex<HashMap<id, PtySession>>` registry mirrors `ws.rs`'s `CONNS`. Errors surface as
+//! `null`/`false` rather than panicking.
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
+
+use lazy_static::lazy_static;
+use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
+use tishlang_core::Value;
+
+/// Output accumulated by the reader thread, drained by `read`.
+struct PtyBuf {
+    data: Vec<u8>,
+    eof: bool,
+}
+
+struct PtySession {
+    child: Mutex<Box<dyn Child + Send + Sync>>,
+    master: Mutex<Box<dyn MasterPty + Send>>,
+    writer: Mutex<Box<dyn Write + Send>>,
+    buf: Arc<(Mutex<PtyBuf>, Condvar)>,
+    pid: Option<u32>,
+}
+
+lazy_static! {
+    static ref SESSIONS: Mutex<HashMap<u64, PtySession>> = Mutex::new(HashMap::new());
+}
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+// --- Value helpers (mirror the ws.rs idioms) ---
+
+fn arg_u64(args: &[Value], i: usize) -> Option<u64> {
+    match args.get(i) {
+        Some(Value::Number(n)) if n.is_finite() && *n >= 0.0 => Some(*n as u64),
+        _ => None,
+    }
+}
+
+fn arg_u16(args: &[Value], i: usize) -> Option<u16> {
+    match args.get(i) {
+        Some(Value::Number(n)) if n.is_finite() && *n >= 0.0 => Some(*n as u16),
+        _ => None,
+    }
+}
+
+/// Clone a field out of an options object (`{ key: value }`), or `None` if the arg isn't an object.
+fn obj_field(o: &Value, key: &str) -> Option<Value> {
+    if let Value::Object(m) = o {
+        return m.borrow().strings.get(key).cloned();
+    }
+    None
+}
+
+fn obj_str(o: &Value, key: &str) -> Option<String> {
+    match obj_field(o, key) {
+        Some(Value::String(s)) => Some(s.to_string()),
+        Some(Value::Null) | None => None,
+        Some(v) => Some(v.to_display_string()),
+    }
+}
+
+fn obj_num(o: &Value, key: &str) -> Option<f64> {
+    match obj_field(o, key) {
+        Some(Value::Number(n)) if n.is_finite() => Some(n),
+        _ => None,
+    }
+}
+
+/// `spawn({ program?, cwd?, cols?, rows?, env? })` → a stable id for read/write/resize/kill,
+/// or `null` on failure.
+pub fn pty_spawn(args: &[Value]) -> Value {
+    let null = Value::Null;
+    let opts = args.first().unwrap_or(&null);
+
+    let cols = obj_num(opts, "cols").filter(|n| *n > 0.0).unwrap_or(80.0) as u16;
+    let rows = obj_num(opts, "rows").filter(|n| *n > 0.0).unwrap_or(24.0) as u16;
+
+    let pty_system = native_pty_system();
+    let pair = match pty_system.openpty(PtySize {
+        rows,
+        cols,
+        pixel_width: 0,
+        pixel_height: 0,
+    }) {
+        Ok(p) => p,
+        Err(_) => return Value::Null,
+    };
+
+    let mut cmd = if let Some(prog) = obj_str(opts, "program") {
+        CommandBuilder::new(prog)
+    } else if cfg!(windows) {
+        CommandBuilder::new("powershell.exe")
+    } else {
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
+        CommandBuilder::new(shell)
+    };
+
+    if let Some(cwd) = obj_str(opts, "cwd") {
+        cmd.cwd(cwd);
+    }
+
+    // Caller-supplied env overrides inherit the parent environment (portable_pty default); we
+    // only add. Ensure TERM is set so curses apps negotiate correctly unless overridden.
+    let mut has_term = false;
+    if let Some(Value::Object(em)) = obj_field(opts, "env") {
+        for (k, v) in em.borrow().strings.iter() {
+            if k.as_ref() == "TERM" {
+                has_term = true;
+            }
+            cmd.env(k.as_ref(), v.to_display_string());
+        }
+    }
+    if !has_term {
+        cmd.env("TERM", "xterm-256color");
+    }
+
+    let child = match pair.slave.spawn_command(cmd) {
+        Ok(c) => c,
+        Err(_) => return Value::Null,
+    };
+    let reader = match pair.master.try_clone_reader() {
+        Ok(r) => r,
+        Err(_) => return Value::Null,
+    };
+    let writer = match pair.master.take_writer() {
+        Ok(w) => w,
+        Err(_) => return Value::Null,
+    };
+    let pid = child.process_id();
+
+    let buf = Arc::new((
+        Mutex::new(PtyBuf {
+            data: Vec::new(),
+            eof: false,
+        }),
+        Condvar::new(),
+    ));
+
+    // Reader thread: block on the master, append bytes, wake any waiting `read`. On EOF/error,
+    // mark eof so `read` can return null once the buffer drains.
+    {
+        let buf = buf.clone();
+        let mut reader = reader;
+        std::thread::spawn(move || {
+            let mut tmp = [0u8; 8192];
+            loop {
+                match reader.read(&mut tmp) {
+                    Ok(0) => {
+                        let (lock, cv) = &*buf;
+                        if let Ok(mut b) = lock.lock() {
+                            b.eof = true;
+                        }
+                        cv.notify_all();
+                        break;
+                    }
+                    Ok(n) => {
+                        let (lock, cv) = &*buf;
+                        if let Ok(mut b) = lock.lock() {
+                            b.data.extend_from_slice(&tmp[..n]);
+                        }
+                        cv.notify_all();
+                    }
+                    Err(_) => {
+                        let (lock, cv) = &*buf;
+                        if let Ok(mut b) = lock.lock() {
+                            b.eof = true;
+                        }
+                        cv.notify_all();
+                        break;
+                    }
+                }
+            }
+        });
+    }
+
+    let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+    let session = PtySession {
+        child: Mutex::new(child),
+        master: Mutex::new(pair.master),
+        writer: Mutex::new(writer),
+        buf,
+        pid,
+    };
+    match SESSIONS.lock() {
+        Ok(mut g) => {
+            g.insert(id, session);
+        }
+        Err(_) => return Value::Null,
+    }
+    Value::Number(id as f64)
+}
+
+/// `read(id, timeoutMs?)` → available output as a string (possibly `""` if none arrived within the
+/// timeout), or `null` at EOF / for an unknown id. Drains only a valid UTF-8 prefix, holding any
+/// incomplete trailing multibyte bytes for the next call.
+pub fn pty_read(args: &[Value]) -> Value {
+    let id = match arg_u64(args, 0) {
+        Some(x) => x,
+        None => return Value::Null,
+    };
+    let timeout_ms = match args.get(1) {
+        Some(Value::Number(n)) if n.is_finite() && *n >= 0.0 => *n as u64,
+        _ => 0,
+    };
+
+    let buf = {
+        let g = match SESSIONS.lock() {
+            Ok(g) => g,
+            Err(_) => return Value::Null,
+        };
+        match g.get(&id) {
+            Some(s) => s.buf.clone(),
+            None => return Value::Null,
+        }
+    };
+
+    let (lock, cv) = &*buf;
+    let mut b = match lock.lock() {
+        Ok(b) => b,
+        Err(_) => return Value::Null,
+    };
+    if b.data.is_empty() && !b.eof && timeout_ms > 0 {
+        let res = cv.wait_timeout_while(b, Duration::from_millis(timeout_ms), |b| {
+            b.data.is_empty() && !b.eof
+        });
+        b = match res {
+            Ok((g, _)) => g,
+            Err(e) => e.into_inner().0,
+        };
+    }
+
+    if b.data.is_empty() {
+        if b.eof {
+            return Value::Null;
+        }
+        return Value::String("".into());
+    }
+
+    // Drain up to the last complete UTF-8 code point; keep the incomplete tail for next time.
+    let valid = match std::str::from_utf8(&b.data) {
+        Ok(_) => b.data.len(),
+        Err(e) => e.valid_up_to(),
+    };
+    if valid == 0 {
+        // A leading incomplete multibyte sequence. If the stream is done, flush it lossily so
+        // nothing is stranded; otherwise wait for the rest.
+        if b.eof {
+            let s = String::from_utf8_lossy(&b.data).into_owned();
+            b.data.clear();
+            return Value::String(s.into());
+        }
+        return Value::String("".into());
+    }
+    let out: Vec<u8> = b.data.drain(..valid).collect();
+    let s = String::from_utf8(out).unwrap_or_default();
+    Value::String(s.into())
+}
+
+/// `write(id, data)` → feed input bytes to the PTY. Returns whether the write succeeded.
+pub fn pty_write(args: &[Value]) -> Value {
+    let id = match arg_u64(args, 0) {
+        Some(x) => x,
+        None => return Value::Bool(false),
+    };
+    let data = match args.get(1) {
+        Some(Value::String(s)) => s.to_string(),
+        Some(v) => v.to_display_string(),
+        None => return Value::Bool(false),
+    };
+    let g = match SESSIONS.lock() {
+        Ok(g) => g,
+        Err(_) => return Value::Bool(false),
+    };
+    let s = match g.get(&id) {
+        Some(s) => s,
+        None => return Value::Bool(false),
+    };
+    let mut w = match s.writer.lock() {
+        Ok(w) => w,
+        Err(_) => return Value::Bool(false),
+    };
+    match w.write_all(data.as_bytes()).and_then(|_| w.flush()) {
+        Ok(_) => Value::Bool(true),
+        Err(_) => Value::Bool(false),
+    }
+}
+
+/// `resize(id, cols, rows)` → tell the PTY its new window size (fires `SIGWINCH` in the child).
+pub fn pty_resize(args: &[Value]) -> Value {
+    let id = match arg_u64(args, 0) {
+        Some(x) => x,
+        None => return Value::Bool(false),
+    };
+    let cols = match arg_u16(args, 1) {
+        Some(c) if c > 0 => c,
+        _ => return Value::Bool(false),
+    };
+    let rows = match arg_u16(args, 2) {
+        Some(r) if r > 0 => r,
+        _ => return Value::Bool(false),
+    };
+    let g = match SESSIONS.lock() {
+        Ok(g) => g,
+        Err(_) => return Value::Bool(false),
+    };
+    let s = match g.get(&id) {
+        Some(s) => s,
+        None => return Value::Bool(false),
+    };
+    let m = match s.master.lock() {
+        Ok(m) => m,
+        Err(_) => return Value::Bool(false),
+    };
+    match m.resize(PtySize {
+        rows,
+        cols,
+        pixel_width: 0,
+        pixel_height: 0,
+    }) {
+        Ok(_) => Value::Bool(true),
+        Err(_) => Value::Bool(false),
+    }
+}
+
+/// `kill(id)` → terminate the child and drop the session. Returns whether the id was live.
+pub fn pty_kill(args: &[Value]) -> Value {
+    let id = match arg_u64(args, 0) {
+        Some(x) => x,
+        None => return Value::Bool(false),
+    };
+    let sess = {
+        let mut g = match SESSIONS.lock() {
+            Ok(g) => g,
+            Err(_) => return Value::Bool(false),
+        };
+        g.remove(&id)
+    };
+    match sess {
+        Some(s) => {
+            if let Ok(mut c) = s.child.lock() {
+                let _ = c.kill();
+                let _ = c.wait();
+            }
+            Value::Bool(true)
+        }
+        None => Value::Bool(false),
+    }
+}
+
+/// `pid(id)` → the child process id, or `null` for an unknown id / no pid.
+pub fn pty_pid(args: &[Value]) -> Value {
+    let id = match arg_u64(args, 0) {
+        Some(x) => x,
+        None => return Value::Null,
+    };
+    let g = match SESSIONS.lock() {
+        Ok(g) => g,
+        Err(_) => return Value::Null,
+    };
+    match g.get(&id).and_then(|s| s.pid) {
+        Some(p) => Value::Number(p as f64),
+        None => Value::Null,
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    /// Proves a LIVE interactive PTY (persistent shell on a pseudoterminal), not run-to-completion:
+    /// spawn a shell, write a command, and read its executed output back.
+    #[test]
+    fn spawn_write_read_roundtrip() {
+        let id = match pty_spawn(&[]) {
+            Value::Number(n) => n,
+            other => panic!("spawn failed: {:?}", other),
+        };
+        // Drain the shell's startup banner/prompt.
+        let _ = pty_read(&[Value::Number(id), Value::Number(300.0)]);
+        assert!(matches!(
+            pty_write(&[Value::Number(id), Value::String("echo pty_ok_123\n".into())]),
+            Value::Bool(true)
+        ));
+        let mut acc = String::new();
+        for _ in 0..100 {
+            match pty_read(&[Value::Number(id), Value::Number(50.0)]) {
+                Value::String(s) => acc.push_str(&s),
+                Value::Null => break,
+                _ => {}
+            }
+            if acc.contains("pty_ok_123") {
+                break;
+            }
+        }
+        let _ = pty_kill(&[Value::Number(id)]);
+        assert!(acc.contains("pty_ok_123"), "pty output missing echo: {:?}", acc);
+    }
+
+    #[test]
+    fn resize_live_session_ok() {
+        let id = match pty_spawn(&[]) {
+            Value::Number(n) => n,
+            other => panic!("spawn failed: {:?}", other),
+        };
+        assert!(matches!(
+            pty_resize(&[Value::Number(id), Value::Number(120.0), Value::Number(40.0)]),
+            Value::Bool(true)
+        ));
+        assert!(matches!(pty_pid(&[Value::Number(id)]), Value::Number(_)));
+        assert!(matches!(pty_kill(&[Value::Number(id)]), Value::Bool(true)));
+    }
+
+    #[test]
+    fn unknown_id_surfaces_null_or_false() {
+        let bad = 9_999_999.0;
+        assert!(matches!(pty_read(&[Value::Number(bad)]), Value::Null));
+        assert!(matches!(
+            pty_write(&[Value::Number(bad), Value::String("x".into())]),
+            Value::Bool(false)
+        ));
+        assert!(matches!(
+            pty_resize(&[Value::Number(bad), Value::Number(80.0), Value::Number(24.0)]),
+            Value::Bool(false)
+        ));
+        assert!(matches!(pty_kill(&[Value::Number(bad)]), Value::Bool(false)));
+        assert!(matches!(pty_pid(&[Value::Number(bad)]), Value::Null));
+    }
+}


### PR DESCRIPTION
Closes #493.

Adds a built-in native module **`tish:pty`** for hosting a real OS pseudoterminal, mirroring `tish:ws` / `tish:tty`. This is the one primitive native tish lacked for an **interactive terminal server**: `tish:process` is run-to-completion capture only, and `tish:tty` controls the host's *own* controlling terminal — neither can spawn a live shell on a PTY that an xterm.js front end drives (so `isatty()` passes and line-editing, vim/top/ssh, and `SIGWINCH` resize work).

### API
`import { spawn, read, write, resize, kill, pid } from 'tish:pty'` — a polling model, so it pairs with a `tish:ws` pump or an HTTP long-poll:

| export | signature | returns |
|---|---|---|
| `spawn` | `spawn({ program?, cwd?, cols?, rows?, env? })` | `number` id, or `null` |
| `read` | `read(id, timeoutMs?)` | `string` (`""` = live but idle), or `null` at EOF / unknown id |
| `write` | `write(id, data)` | `boolean` |
| `resize` | `resize(id, cols, rows)` | `boolean` |
| `kill` | `kill(id)` | `boolean` |
| `pid` | `pid(id)` | `number`, or `null` |

### Implementation
- `crates/tish_runtime/src/pty.rs` wraps **`portable-pty`** (`openpty` + `CommandBuilder` — the same crate the Dune desktop terminal uses). A per-session reader thread fills a byte buffer that `read` drains **at a UTF-8 boundary** (incomplete trailing multibyte held for the next read — no mojibake), waking waiters via a `Condvar` timeout; a global `Mutex<HashMap<id, PtySession>>` registry mirrors `ws.rs`'s `CONNS`. Default shell = `$SHELL`/`/bin/bash` (PowerShell on Windows); `TERM=xterm-256color` unless overridden.
- Cargo: `pty = ["dep:portable-pty", "dep:lazy_static"]`; `portable-pty = "0.9"` optional.
- Wiring mirrors `ws`/`tty`: `tish:pty` arm in `codegen.rs`, `"pty"` added to the `full` set + `tish_native`'s `RUNTIME_CARGO_FEATURES`, module + re-exports in `lib.rs`, builtin-spec + alias in `resolve.rs`.

### Verification
- `cargo test -p tishlang_runtime --features pty` — 3/3: `spawn → write "echo …" → read` round-trip proves a **live** PTY (not run-to-completion); `resize`/`pid` on a live session; unknown-id → `null`/`false`.
- Default build (no `pty`) still compiles — feature gating is clean.
- **End-to-end:** `tish build --target native --feature pty` on a smoke program spawns `/bin/sh`, writes `echo hi-from-pty`, and reads the executed output back:
  ```
  spawned pty id=1 pid=50341
  PTY OK — command executed on the pseudoterminal
  ```

### Why (downstream)
Unblocks a Dune "connect to remote server" **interactive terminal**: `dune-server` (native tish) already has the streaming transport (`tish:ws`) but no way to spawn/stream a PTY. With this, the remote server spawns a real shell and pumps bytes to the local xterm — the VS Code Remote shape.