### PR TITLE
feat(http): HTTP→WebSocket upgrade on serve() — single-port WS

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1702,6 +1702,7 @@ impl Codegen {
                     "Server" => Some("Value::native(|args: &[Value]| tish_ws_server_construct(args))"),
                     "wsSend" => Some("Value::native(|args: &[Value]| Value::Bool(tishlang_runtime::ws_send_native(args.first().unwrap_or(&Value::Null), &args.get(1).map(|v| v.to_display_string()).unwrap_or_default())))"),
                     "wsBroadcast" => Some("Value::native(|args: &[Value]| tishlang_runtime::ws_broadcast_native(args))"),
+                    "wsAccept" => Some("Value::native(|args: &[Value]| tishlang_runtime::ws_serve_accept(args))"),
                     _ => None,
                 },
             "tish:tty" if self.has_feature("tty") => match export_name {
@@ -2268,6 +2269,10 @@ impl Codegen {
             self.write("use tishlang_runtime::register_static_route as tish_register_static_route;\n");
             if self.is_async {
                 self.write("use tishlang_runtime::{fetch_promise as tish_fetch_promise, fetch_all_promise as tish_fetch_all_promise, http_serve as tish_http_serve, promise_object as tish_promise_object, await_promise as tish_await_promise, await_promise_throw as tish_await_promise_throw};\n");
+            } else if self.has_feature("ws") {
+                // ws programs get `Promise.spawn` (send-values OS-thread spawn) even when not async,
+                // so a server can run a background accept/pump loop alongside the blocking `serve()`.
+                self.write("use tishlang_runtime::{fetch_promise as tish_fetch_promise, fetch_all_promise as tish_fetch_all_promise, http_serve as tish_http_serve, promise_object as tish_promise_object};\n");
             } else {
                 self.write("use tishlang_runtime::{fetch_promise as tish_fetch_promise, fetch_all_promise as tish_fetch_all_promise, http_serve as tish_http_serve};\n");
             }
@@ -2693,7 +2698,7 @@ impl Codegen {
                 "let fetch = Value::native(|args: &[Value]| tish_fetch_promise(args.to_vec()));",
             );
             self.writeln("let fetchAll = Value::native(|args: &[Value]| tish_fetch_all_promise(args.to_vec()));");
-            if self.is_async {
+            if self.is_async || self.has_feature("ws") {
                 self.writeln("let Promise = tish_promise_object();");
             }
             // `serve` supports two shapes:

--- a/crates/tish_runtime/src/http_hyper.rs
+++ b/crates/tish_runtime/src/http_hyper.rs
@@ -289,6 +289,9 @@ fn worker_thread(
                     // headers slower than this instead of pinning the worker task.
                     .header_read_timeout(std::time::Duration::from_secs(30))
                     .serve_connection(io, svc)
+                    // Required for `hyper::upgrade::on` to hand off the socket after a 101 — without
+                    // this, a WebSocket upgrade sends the 101 but the upgrade future never resolves.
+                    .with_upgrades()
                     .await
                 {
                     // Chatty connection errors (resets, client timeouts) are
@@ -312,6 +315,13 @@ async fn handle_request(
     let uri_path_str = req.uri().path();
     if let Some(route) = lookup_static_route_pub(uri_path_str) {
         return Ok(static_route_response(route));
+    }
+
+    // WebSocket upgrade: complete the handshake here and hand the socket to `ws.rs` — the VM handler
+    // never sees it. The program picks the connection up via `wsAccept`. (Single-port WS, issue #495.)
+    #[cfg(feature = "ws")]
+    if is_ws_upgrade(&req) {
+        return Ok(handle_ws_upgrade(req));
     }
 
     // Slow path: cross the mpsc to the VM thread.
@@ -453,6 +463,66 @@ fn simple_error_response(status: StatusCode, msg: &str) -> Response<Full<Bytes>>
         .header("server", "Tish")
         .body(Full::new(Bytes::copy_from_slice(msg.as_bytes())))
         .unwrap()
+}
+
+/// A well-formed WebSocket upgrade handshake request (RFC 6455): `Upgrade: websocket`,
+/// `Connection: Upgrade`, and a `Sec-WebSocket-Key`.
+#[cfg(feature = "ws")]
+fn is_ws_upgrade(req: &Request<hyper::body::Incoming>) -> bool {
+    let h = req.headers();
+    let upgrade_ws = h
+        .get(hyper::header::UPGRADE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.eq_ignore_ascii_case("websocket"))
+        .unwrap_or(false);
+    let conn_upgrade = h
+        .get(hyper::header::CONNECTION)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_ascii_lowercase().split(',').any(|p| p.trim() == "upgrade"))
+        .unwrap_or(false);
+    upgrade_ws && conn_upgrade && h.contains_key(hyper::header::SEC_WEBSOCKET_KEY)
+}
+
+/// Complete a WebSocket handshake on the HTTP port: reply `101` with the derived accept key, then
+/// (after the response flushes) take over the connection, wrap it as a server-role WebSocket, and
+/// register it with `ws.rs` so the program can pick it up via `wsAccept`.
+#[cfg(feature = "ws")]
+fn handle_ws_upgrade(mut req: Request<hyper::body::Incoming>) -> Response<Full<Bytes>> {
+    use tokio_tungstenite::tungstenite::handshake::derive_accept_key;
+    use tokio_tungstenite::tungstenite::protocol::Role;
+
+    let accept = match req.headers().get(hyper::header::SEC_WEBSOCKET_KEY) {
+        Some(k) => derive_accept_key(k.as_bytes()),
+        None => return simple_error_response(StatusCode::BAD_REQUEST, "missing Sec-WebSocket-Key"),
+    };
+
+    let on_upgrade = hyper::upgrade::on(&mut req);
+    tokio::spawn(async move {
+        match on_upgrade.await {
+            Ok(upgraded) => {
+                let io = TokioIo::new(upgraded);
+                let ws = tokio_tungstenite::WebSocketStream::from_raw_socket(io, Role::Server, None)
+                    .await;
+                let id = crate::ws::register_ws_stream(ws);
+                crate::ws::enqueue_upgraded_conn(id);
+            }
+            Err(e) => {
+                if std::env::var_os("TISH_HTTP_DEBUG").is_some() {
+                    eprintln!("[tish http/hyper] ws upgrade failed: {}", e);
+                }
+            }
+        }
+    });
+
+    Response::builder()
+        .status(StatusCode::SWITCHING_PROTOCOLS)
+        .header(hyper::header::UPGRADE, "websocket")
+        .header(hyper::header::CONNECTION, "Upgrade")
+        .header(hyper::header::SEC_WEBSOCKET_ACCEPT, accept)
+        .body(Full::new(Bytes::new()))
+        .unwrap_or_else(|_| {
+            simple_error_response(StatusCode::INTERNAL_SERVER_ERROR, "ws upgrade build failed")
+        })
 }
 
 /// Marker used by external callers (like the bench) to gate the backend

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -1735,7 +1735,7 @@ pub use pty::{pty_kill, pty_pid, pty_read, pty_resize, pty_spawn, pty_write};
 #[cfg(feature = "ws")]
 pub use ws::{
     web_socket_client, web_socket_server_accept, web_socket_server_construct,
-    web_socket_server_listen, ws_broadcast_native, ws_send_native,
+    web_socket_server_listen, ws_broadcast_native, ws_send_native, ws_serve_accept,
 };
 
 #[cfg(feature = "http")]

--- a/crates/tish_runtime/src/ws.rs
+++ b/crates/tish_runtime/src/ws.rs
@@ -82,6 +82,83 @@ fn unregister(id: u32) {
     CONNS.lock().unwrap().remove(&id);
 }
 
+/// Bridge an already-handshaked WebSocket stream into the `CONNS` registry — spawning the read and
+/// write pump tasks — and return its connection id. Shared by the `tish:ws` server-accept loop and
+/// the `serve()` HTTP→WS upgrade path (see `http_hyper.rs`). Must be called inside a tokio runtime.
+pub(crate) fn register_ws_stream<S>(ws_stream: tokio_tungstenite::WebSocketStream<S>) -> u32
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    let (send_tx, mut send_rx) = tokio_mpsc::unbounded_channel::<String>();
+    let (recv_tx, recv_rx) = mpsc::sync_channel::<String>(64);
+    let id = register(send_tx, recv_rx);
+    let recv_tx_task = Arc::new(recv_tx);
+    let (mut write, mut read) = ws_stream.split();
+    tokio::spawn(async move {
+        while let Some(Ok(msg)) = read.next().await {
+            if let tokio_tungstenite::tungstenite::Message::Text(t) = msg {
+                let _ = recv_tx_task.send(t.to_string());
+            }
+        }
+        unregister(id);
+    });
+    tokio::spawn(async move {
+        while let Some(text) = send_rx.recv().await {
+            let _ = write
+                .send(tokio_tungstenite::tungstenite::Message::Text(text.into()))
+                .await;
+        }
+    });
+    id
+}
+
+lazy_static! {
+    /// Connections upgraded from HTTP by `serve()` (http_hyper), waiting for the program to pick them
+    /// up via `wsAccept`. Per-process: an upgraded socket stays in whatever SO_REUSEPORT worker
+    /// accepted it, so each worker drains its own queue and there's no cross-process routing problem.
+    static ref UPGRADE_QUEUE: (Mutex<std::collections::VecDeque<u32>>, std::sync::Condvar) =
+        (Mutex::new(std::collections::VecDeque::new()), std::sync::Condvar::new());
+}
+
+/// Enqueue a `serve()`-upgraded connection id for `wsAccept` to hand to the program.
+pub(crate) fn enqueue_upgraded_conn(id: u32) {
+    let (m, cv) = &*UPGRADE_QUEUE;
+    if let Ok(mut q) = m.lock() {
+        q.push_back(id);
+    }
+    cv.notify_all();
+}
+
+/// `wsAccept(timeoutMs?)` — return the next connection upgraded on the HTTP server's port (see the
+/// `serve()` HTTP→WS upgrade path) as a normal `tish:ws` connection object, or `Null` if none arrives
+/// within the timeout (default 0 = non-blocking).
+pub fn ws_serve_accept(args: &[Value]) -> Value {
+    let timeout_ms = match args.first() {
+        Some(Value::Number(n)) if n.is_finite() && *n >= 0.0 => (*n as u64).min(3_600_000),
+        _ => 0,
+    };
+    let (m, cv) = &*UPGRADE_QUEUE;
+    let mut q = match m.lock() {
+        Ok(q) => q,
+        Err(_) => return Value::Null,
+    };
+    if q.is_empty() && timeout_ms > 0 {
+        let res = cv.wait_timeout_while(
+            q,
+            std::time::Duration::from_millis(timeout_ms),
+            |q| q.is_empty(),
+        );
+        q = match res {
+            Ok((g, _)) => g,
+            Err(e) => e.into_inner().0,
+        };
+    }
+    match q.pop_front() {
+        Some(id) => conn_object(id),
+        None => Value::Null,
+    }
+}
+
 /// Max simultaneous WebSocket connections. Each accepted conn registers in `CONNS` and
 /// spawns tasks + channels, freed only on close — unbounded accepts exhaust tasks/memory.
 /// Override with `TISH_WS_MAX_CONNS`; default 10000.
@@ -399,27 +476,7 @@ pub fn web_socket_server_listen(args: &[Value]) -> Value {
                         continue;
                     }
                 };
-                let (send_tx, mut send_rx) = tokio_mpsc::unbounded_channel::<String>();
-                let (recv_tx, recv_rx) = mpsc::sync_channel::<String>(64);
-                let id = register(send_tx, recv_rx);
-                let recv_tx = Arc::new(recv_tx);
-                let recv_tx_task = Arc::clone(&recv_tx);
-                let (mut write, mut read) = ws_stream.split();
-                tokio::spawn(async move {
-                    while let Some(Ok(msg)) = read.next().await {
-                        if let tokio_tungstenite::tungstenite::Message::Text(t) = msg {
-                            let _ = recv_tx_task.send(t.to_string());
-                        }
-                    }
-                    unregister(id);
-                });
-                tokio::spawn(async move {
-                    while let Some(text) = send_rx.recv().await {
-                        let _ = write
-                            .send(tokio_tungstenite::tungstenite::Message::Text(text.into()))
-                            .await;
-                    }
-                });
+                let id = register_ws_stream(ws_stream);
                 if conn_tx.send(id).is_err() {
                     break;
                 }
@@ -577,6 +634,22 @@ mod tests {
     use super::*;
     use std::thread;
     use std::time::Duration;
+
+    /// The serve() HTTP→WS upgrade queue: `wsAccept` hands out enqueued conns FIFO and returns Null
+    /// when empty. (End-to-end upgrade over a live hyper port is covered by the native smoke test.)
+    #[test]
+    fn upgrade_queue_drains_then_empty() {
+        assert!(matches!(ws_serve_accept(&[Value::Number(0.0)]), Value::Null));
+        enqueue_upgraded_conn(4242);
+        match ws_serve_accept(&[Value::Number(0.0)]) {
+            Value::Object(o) => {
+                let b = o.borrow();
+                assert!(matches!(b.strings.get("_id"), Some(Value::Number(n)) if *n == 4242.0));
+            }
+            other => panic!("expected a conn object, got {:?}", other),
+        }
+        assert!(matches!(ws_serve_accept(&[Value::Number(0.0)]), Value::Null));
+    }
 
     #[test]
     fn ws_echo_roundtrip() {


### PR DESCRIPTION
Closes #495.

`serve()` (hyper backend) can now complete a WebSocket handshake on the **same port** it serves HTTP, so one server does `/rpc` + static assets **and** a WebSocket endpoint (e.g. `/pty`). Previously the only WS path was `tish:ws`'s standalone `Server`, which binds its own port — forcing two ports.

### API
```
import { wsAccept } from 'tish:ws'

serve(8787, (req) => routeHttp(req))          // HTTP as usual

Promise.spawn(() => {                          // background: drain upgraded sockets
  while (true) {
    const conn = wsAccept(50)                  // tish:ws conn object, or null
    if (conn) handle(conn)                     // conn.send / receiveTimeout / close
  }
})
```
Any `Upgrade: websocket` request is completed by the runtime (101 + `Sec-WebSocket-Accept`) and enqueued; `wsAccept(timeoutMs)` hands it back as a normal `tish:ws` connection. Auth stays the program's job (first-message token), same as `tish:ws` servers.

### Implementation
- **`http_hyper.rs`** — detect the upgrade in the per-request path, derive the accept key (`tungstenite::handshake::derive_accept_key`), reply `101`, then `hyper::upgrade::on(&mut req)` → `WebSocketStream::from_raw_socket(TokioIo::new(upgraded), Role::Server)` → hand to `ws.rs`. **`serve_connection(...).with_upgrades()`** is required — without it hyper sends the 101 but the upgrade future never resolves (this was the one non-obvious bug).
- **`ws.rs`** — extract the socket→`CONNS` bridge (the read/write pump tasks, previously inline in the server-accept loop) into a reusable `register_ws_stream(stream) -> id`; add a per-process upgrade queue + `ws_serve_accept` (`wsAccept`) draining it with a `Condvar` timeout.
- **Prefork-safe** — the queue is per-process, so an upgraded conn stays in whichever `SO_REUSEPORT` worker accepted it; the program runs one pump per worker. No single-process requirement.
- **codegen** — expose `wsAccept` under `tish:ws`; also inject the `Promise` global (+ `promise_object` import) for `ws` programs even when not async, so a server can `Promise.spawn` a background loop alongside the blocking `serve()`.
- Gated `#[cfg(all(feature = "http-hyper", feature = "ws"))]`.

### Verification
- `cargo test -p tishlang_runtime --features http-hyper,ws` — upgrade-queue unit test + existing ws server/client roundtrips (proves the bridge refactor is behavior-preserving).
- Plain non-ws `http` builds unchanged; `tishlang_compile` suite green.
- **End-to-end** (native, `--feature http,http-hyper,ws`, `TISH_HTTP_BACKEND=hyper`): one port serves
  ```
  curl :9099/x            → http-ok
  ws client → :9099/pty   → CLIENT GOT: echo:hello-single-port
  ```
  HTTP and a same-port WebSocket upgrade both work.

### Why (downstream)
Lets `dune-server` (native tish) serve workspace RPC **and** an interactive terminal (xterm ↔ PTY via `tish:pty`, #493/#494) on a single port + auth + TLS — the VS Code Remote shape.