### PR TITLE
feat(parser): async function expressions — async function(){}

### DIFF
--- a/crates/tish_parser/src/lib.rs
+++ b/crates/tish_parser/src/lib.rs
@@ -101,6 +101,34 @@ mod tests {
         assert!(parse("let x = async 5").is_err());
     }
 
+    /// #428 (function-expression half): `async function (…) {…}` / named `async function f(…) {…}`
+    /// in expression position parse as async ArrowFunctions — anonymous, named, object-property,
+    /// and IIFE-operand forms. Non-async function expressions keep `async_: false` (#464).
+    #[test]
+    fn async_function_expressions_parse() {
+        use tishlang_ast::Expr;
+        let fn_expr_async = |src: &str| -> bool {
+            let p = parse(src).expect("parse");
+            let Some(Statement::VarDecl { init: Some(e), .. }) = p.statements.first() else {
+                panic!("expected `let x = <fn expr>`");
+            };
+            match e {
+                Expr::ArrowFunction { async_, .. } => *async_,
+                other => panic!("expected ArrowFunction, got {other:?}"),
+            }
+        };
+        assert!(fn_expr_async("let f = async function() { return 1 }"), "anonymous");
+        assert!(fn_expr_async("let f = async function named(n) { return n }"), "named");
+        assert!(!fn_expr_async("let f = function() { return 1 }"), "plain fn expr is not async");
+        // Object-property and IIFE-operand positions.
+        assert!(parse("let o = { m: async function() { return 1 } }").is_ok());
+        assert!(parse("let p = (async function() { return 1 })()").is_ok());
+        assert!(parse("let q = (async () => { return 1 })()").is_ok());
+        // `async fn => …` stays a single-param arrow with param `fn` (#55 ident-compat) —
+        // the function-expression branch requires `(` or an identifier after `function`.
+        assert!(parse("let r = async fn => fn").is_ok());
+    }
+
     #[test]
     fn test_async_fn_parse() {
         let program = parse("async fn foo() { }").expect("parse async fn");

--- a/crates/tish_parser/src/parser.rs
+++ b/crates/tish_parser/src/parser.rs
@@ -197,6 +197,11 @@ impl<'a> Parser<'a> {
         self.peek().map(|t| t.kind)
     }
 
+    /// Kind of the token `n` positions past the current one (`peek_ahead_kind(0)` == `peek_kind`).
+    fn peek_ahead_kind(&self, n: usize) -> Option<TokenKind> {
+        self.tokens.get(self.pos + n).map(|t| t.kind)
+    }
+
     fn advance(&mut self) -> Option<&Token> {
         let t = self.tokens.get(self.pos);
         if t.is_some() {
@@ -2465,9 +2470,11 @@ impl<'a> Parser<'a> {
                 value: Literal::Null,
                 span,
             }),
-            // `async` in expression position (#428): an async arrow — `async () => …` or
-            // `async x => …`. The body runs in async context (`await` allowed). Async function
-            // expressions / method shorthand need function-expression support, which tish lacks.
+            // `async` in expression position (#428): an async arrow — `async () => …` /
+            // `async x => …` — or an async function EXPRESSION — `async function (…) {…}` /
+            // named `async function f(…) {…}` (desugars to an async ArrowFunction exactly like
+            // the non-async `function` expression form, #464). The body runs in async context
+            // (`await` allowed).
             TokenKind::Async => {
                 if matches!(self.peek_kind(), Some(TokenKind::LParen)) {
                     self.advance(); // consume `(`
@@ -2475,6 +2482,19 @@ impl<'a> Parser<'a> {
                         return Ok(arrow);
                     }
                     return Err("Expected an arrow function after `async (`".to_string());
+                }
+                // `async function (…) {…}` / `async function f(…) {…}`: `function` (`Fn`)
+                // followed by `(` or an identifier is a function expression, mirroring the
+                // non-async arm below. Checked BEFORE the single-param-arrow branch, which
+                // would otherwise consume `function` as a parameter name and demand `=>`.
+                if matches!(self.peek_kind(), Some(TokenKind::Fn))
+                    && matches!(
+                        self.peek_ahead_kind(1),
+                        Some(TokenKind::LParen | TokenKind::Ident)
+                    )
+                {
+                    self.advance(); // consume `function`
+                    return self.parse_function_expr_tail(&span, true);
                 }
                 if matches!(
                     self.peek_kind(),

--- a/tests/core/parity_async_expression_forms.js
+++ b/tests/core/parity_async_expression_forms.js
@@ -1,0 +1,21 @@
+// #428: `async` in EXPRESSION positions parses on every backend — async arrows (paren and
+// single-param, #436) and async function EXPRESSIONS (anonymous, named, object-property, IIFE
+// operand — this PR). Assertions are typeof-only: tish's concurrency model resolves an async
+// call synchronously (no microtask queue) while node returns a Promise, so consuming a call
+// RESULT here would diverge; the await-consumption path is exercised by vm/native alongside
+// node in the PR validation, and the interp's user-async await gap is tracked separately.
+
+let add = async function(a, b) { return a + b }
+console.log(typeof add)
+
+let named = async function fx(n) { return n * 2 }
+console.log(typeof named)
+
+let o = { m: async function() { return 3 } }
+console.log(typeof o.m)
+
+console.log(typeof (async function() { return 9 }))
+
+let ar = async () => 1
+let ar1 = async x => x
+console.log(typeof ar, typeof ar1)

--- a/tests/core/parity_async_expression_forms.tish
+++ b/tests/core/parity_async_expression_forms.tish
@@ -1,0 +1,21 @@
+// #428: `async` in EXPRESSION positions parses on every backend — async arrows (paren and
+// single-param, #436) and async function EXPRESSIONS (anonymous, named, object-property, IIFE
+// operand — this PR). Assertions are typeof-only: tish's concurrency model resolves an async
+// call synchronously (no microtask queue) while node returns a Promise, so consuming a call
+// RESULT here would diverge; the await-consumption path is exercised by vm/native alongside
+// node in the PR validation, and the interp's user-async await gap is tracked separately.
+
+let add = async function(a, b) { return a + b }
+console.log(typeof add)
+
+let named = async function fx(n) { return n * 2 }
+console.log(typeof named)
+
+let o = { m: async function() { return 3 } }
+console.log(typeof o.m)
+
+console.log(typeof (async function() { return 9 }))
+
+let ar = async () => 1
+let ar1 = async x => x
+console.log(typeof ar, typeof ar1)

--- a/tests/core/parity_async_expression_forms.tish.expected
+++ b/tests/core/parity_async_expression_forms.tish.expected
@@ -1,0 +1,5 @@
+function
+function
+function
+function
+function function

--- a/tests/main.js
+++ b/tests/main.js
@@ -3286,6 +3286,30 @@ console.log("sat-oob", s.at(99))
 }
 
 {
+// #428: `async` in EXPRESSION positions parses on every backend — async arrows (paren and
+// single-param, #436) and async function EXPRESSIONS (anonymous, named, object-property, IIFE
+// operand — this PR). Assertions are typeof-only: tish's concurrency model resolves an async
+// call synchronously (no microtask queue) while node returns a Promise, so consuming a call
+// RESULT here would diverge; the await-consumption path is exercised by vm/native alongside
+// node in the PR validation, and the interp's user-async await gap is tracked separately.
+
+let add = async function(a, b) { return a + b }
+console.log(typeof add)
+
+let named = async function fx(n) { return n * 2 }
+console.log(typeof named)
+
+let o = { m: async function() { return 3 } }
+console.log(typeof o.m)
+
+console.log(typeof (async function() { return 9 }))
+
+let ar = async () => 1
+let ar1 = async x => x
+console.log(typeof ar, typeof ar1)
+}
+
+{
 // Int-domain bitwise lowering (#174): the native typed backend lowers a chain of bitwise/shift
 // ops in the integer domain, erasing the intermediate `ToInt32`/`ToUint32`↔f64 round-trips. This
 // must stay bit-identical to the interpreter, VM, cranelift, wasi and node. The key invariants:

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3337,6 +3337,31 @@ console.log("sat-oob", s.at(99))
 }
 __perf_run_core_parity_array_methods()
 
+fn __perf_run_core_parity_async_expression_forms() {
+// #428: `async` in EXPRESSION positions parses on every backend — async arrows (paren and
+// single-param, #436) and async function EXPRESSIONS (anonymous, named, object-property, IIFE
+// operand — this PR). Assertions are typeof-only: tish's concurrency model resolves an async
+// call synchronously (no microtask queue) while node returns a Promise, so consuming a call
+// RESULT here would diverge; the await-consumption path is exercised by vm/native alongside
+// node in the PR validation, and the interp's user-async await gap is tracked separately.
+
+let add = async function(a, b) { return a + b }
+console.log(typeof add)
+
+let named = async function fx(n) { return n * 2 }
+console.log(typeof named)
+
+let o = { m: async function() { return 3 } }
+console.log(typeof o.m)
+
+console.log(typeof (async function() { return 9 }))
+
+let ar = async () => 1
+let ar1 = async x => x
+console.log(typeof ar, typeof ar1)
+}
+__perf_run_core_parity_async_expression_forms()
+
 fn __perf_run_core_parity_bitwise_int_domain() {
 // Int-domain bitwise lowering (#174): the native typed backend lowers a chain of bitwise/shift
 // ops in the integer domain, erasing the intermediate `ToInt32`/`ToUint32`↔f64 round-trips. This


### PR DESCRIPTION
## Summary

Fixes #428 — completes the async-expression-position surface. #436 landed the async-**arrow** half; `async function (…) {…}` in expression position still failed:

```tish
let o = { m: async function() { return 1 } }
// Parse error: Expected Arrow, got LParen
```

The `Async` arm's single-param-arrow branch consumed `function` as a parameter name and demanded `=>`.

## Fix

One dispatch in the parser's `Async` arm: `function` followed by `(` or an identifier routes to the existing `parse_function_expr_tail` (which already takes `async_` and desugars to an `ArrowFunction`, the same treatment non-async function expressions got in #464), checked before the single-param-arrow branch. Covers anonymous, named (`async function fx(n) {…}`), object-property (`{ m: async function() {} }`), and IIFE-operand (`(async function(){})()`) forms. `async fn => …` keeps its #55 ident-compat meaning (single-param arrow named `fn`).

No downstream changes needed: #436 already threads `ArrowFunction.async_` through the JS emitter, `js_to_tish`, and `opt` — verified the JS target emits `async (…) => …` for the new forms and node runs the output with real Promise semantics.

## Scope notes (why this closes the issue)

- Async **arrows** — landed in #436.
- Async **function expressions** — this PR.
- Async **method shorthand** — N/A: `{ m() {} }` is not tish syntax at all, async or not (tish objects are explicit `key: value`; `{ m: async function() {} }` is the tish spelling and now works). Classes don't exist. Same scoping call #434 made for `export class`.

## Validation

- New `tests/core/parity_async_expression_forms.{tish,js,tish.expected}` — all forms, byte-identical across **interp / vm / native / node**. Assertions are typeof-only by design: tish resolves an async call synchronously (documented no-microtask model) where node returns a Promise, so call *results* aren't parity-comparable; the await-consumption path was verified identical on vm / native / node (`sum 5` / `dbl 8` / `iife ok`), with the interp's pre-existing user-async-await gap unchanged and tracked separately.
- Parser unit tests: new `async_function_expressions_parse` (anonymous/named/property/IIFE/negative/`async fn =>` compat) — `cargo test -p tishlang_parser` 23/23.
- `scripts/run_parity_compare.sh --reference interp --runtimes interp,vm,node`: **99 passed, 0 failed**.
- Integration battery: interpreter, interp==vm parity, JS oracle, **native AOT batch** — all pass; bundle regenerated and its strict native build runs exit 0.