### PR TITLE
ci: TISH_PACKED_ARRAYS=1 parity sweep — the packed default-flip gate

### DIFF
--- a/.github/workflows/packed-arrays.yml
+++ b/.github/workflows/packed-arrays.yml
@@ -104,7 +104,7 @@ jobs:
           node-version: "22"
 
       - name: Install nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@ed67fa35ac944f3a9b33f12c4dd43b6f31a47e20 # v2
         with:
           tool: nextest
 

--- a/.github/workflows/packed-arrays.yml
+++ b/.github/workflows/packed-arrays.yml
@@ -1,0 +1,115 @@
+# TISH_PACKED_ARRAYS=1 parity gate (#199) — the precondition for ever flipping packed f64
+# arrays default-on. Two jobs:
+#
+#   * sweep — scripts/packed_arrays_parity_check.sh: every tests/core fixture runs flag-off and
+#     flag-on across interp/vm/native (flag is runtime-read via OnceLock, so one native build per
+#     fixture, run twice), plus tests/perf GAUNTLET checksums flag-on == flag-off == node on the
+#     VM. Any NEW divergence fails the job (file it as a bug and link it in #199; only filed
+#     divergences may be allowlisted in the script's KNOWN_DIVERGENCES).
+#   * nextest — the tishlang + tishlang_vm unit/integration suites with TISH_PACKED_ARRAYS=1 in
+#     the env, so the packed representation is exercised by the whole test corpus, not only the
+#     builtins/VM unit tests. workflow_dispatch-ONLY until the divergences the first sweep filed
+#     (#502-#508) are fixed: the interp==vm corpus parity test fails on exactly those fixtures
+#     with the flag on (verified 2026-07-17; the vm + builtins UNIT suites pass), and the sweep
+#     job already reports them as KNOWN. Flip this job onto pull_request when the known list in
+#     scripts/packed_arrays_parity_check.sh empties — it then becomes the #199 acceptance gate
+#     "nextest passes with TISH_PACKED_ARRAYS=1".
+#
+# Path-filtered to the crates that own the packed representation (+ this tooling): the sweep
+# builds every fixture natively, which is too heavy for every PR.
+name: Packed arrays
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "crates/tish_core/**"
+      - "crates/tish_vm/**"
+      - "crates/tish_builtins/**"
+      - "scripts/packed_arrays_parity_check.sh"
+      - ".github/workflows/packed-arrays.yml"
+  pull_request:
+    paths:
+      - "crates/tish_core/**"
+      - "crates/tish_vm/**"
+      - "crates/tish_builtins/**"
+      - "scripts/packed_arrays_parity_check.sh"
+      - ".github/workflows/packed-arrays.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: packed-arrays-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sweep:
+    name: Packed-arrays parity sweep
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      # Fleet-safe target-cpu (#223): avoids the SIGILL the default `native` causes on the
+      # virtualized fleet.
+      RUSTFLAGS: "-C target-cpu=x86-64-v3"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@d651010b8da762cde178750d8eda7b5febfe147a # v0.0.9
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build tish (release)
+        run: cargo build --release -p tishlang --bin tish
+
+      - name: Packed-arrays parity sweep (corpus + perf checksums)
+        run: scripts/packed_arrays_parity_check.sh
+
+  nextest:
+    name: Unit/integration suites with TISH_PACKED_ARRAYS=1
+    # See header — manual until #502-#508 are fixed and the sweep's KNOWN list is empty.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTFLAGS: "-C target-cpu=x86-64-v3"
+      TISH_PACKED_ARRAYS: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@d651010b8da762cde178750d8eda7b5febfe147a # v0.0.9
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      - name: Build tish (debug — integration tests run target/debug/tish)
+        run: cargo build -p tishlang --bin tish
+
+      - name: nextest with TISH_PACKED_ARRAYS=1
+        run: cargo nextest run -p tishlang -p tishlang_vm --features full

--- a/justfile
+++ b/justfile
@@ -234,6 +234,15 @@ parity-verbose filter="":
 parity-limit N:
     ./scripts/run_parity_compare.sh --limit {{N}}
 
+# TISH_PACKED_ARRAYS=1 parity sweep (#199) — the gate for flipping packed f64 arrays default-on.
+# Corpus flag-on == flag-off on interp/vm/native, plus tests/perf GAUNTLET checksums vs node.
+#
+#   just packed-parity             # full sweep (builds every fixture natively — slow)
+#   just packed-parity --no-native # interp + vm + perf checksums only (fast)
+
+packed-parity *args:
+    ./scripts/packed_arrays_parity_check.sh {{args}}
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # UTILITIES
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/scripts/packed_arrays_parity_check.sh
+++ b/scripts/packed_arrays_parity_check.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# TISH_PACKED_ARRAYS=1 parity sweep (#199) — the gate for ever flipping packed f64 arrays
+# default-on. Two parts:
+#
+#   1. CORPUS: every tests/core/*.tish with a committed .expected runs FLAG-OFF and FLAG-ON on
+#      the interpreter, the bytecode VM, and (unless --no-native) a native build — and the two
+#      outputs must be identical per backend. The flag is read once per process via a OnceLock
+#      (#239/#166), so a single native binary is built per fixture and run twice with the env
+#      var toggled; no double build. Inherent nondeterminism (`<N>ms` timings) is normalized
+#      before diffing, mirroring scripts/flags_on_corpus_check.sh; fixtures whose stdout is
+#      nondeterministic BY DESIGN are skipped, mirroring the parity_skip list in
+#      scripts/run_parity_compare.sh / TIMING_NONDETERMINISTIC in integration_test.rs.
+#
+#   2. PERF CHECKSUMS: every tests/perf/*.tish prints `GAUNTLET <name> <ms> <check>`; the
+#      <check> column must be identical for VM flag-off, VM flag-on, and node (the fixtures are
+#      valid in both languages; a `<name>.js` sibling overrides the node source). This is the
+#      differential the packed VM fast paths (NewArray, HOFs, sort) must preserve.
+#
+# Any divergence is a release blocker for the default flip: file it as a bug, link it in #199,
+# and (only if it must not block unrelated CI) add the fixture to KNOWN_DIVERGENCES below with
+# the issue number.
+#
+# Usage: scripts/packed_arrays_parity_check.sh [--no-native] [--corpus-only|--perf-only]
+# Env:   TISH_BIN (default target/release/tish)
+set -u
+cd "$(dirname "$0")/.." || exit 1
+TISH="${TISH_BIN:-target/release/tish}"
+
+RUN_NATIVE=1
+RUN_CORPUS=1
+RUN_PERF=1
+for arg in "$@"; do
+  case "$arg" in
+    --no-native) RUN_NATIVE=0 ;;
+    --corpus-only) RUN_PERF=0 ;;
+    --perf-only) RUN_CORPUS=0 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [ ! -x "$TISH" ]; then
+  echo "tish binary not found at $TISH — build with: cargo build --release -p tishlang --bin tish" >&2
+  exit 2
+fi
+
+# Fixtures whose stdout is nondeterministic or backend-specific BY DESIGN (timings, stress
+# diagnostics). Mirrors run_parity_compare.sh's parity_skip / integration_test.rs's
+# TIMING_NONDETERMINISTIC.
+SKIP=" array_stress array_stress_01_large_array_creation array_stress_02_iteration \
+array_stress_03_map_filter_reduce array_stress_04_chained array_stress_05_sorting \
+array_stress_06_search array_stress_07_splice_slice array_stress_08_concat_spread \
+array_stress_09_flat array_stress_10_objects basic_types benchmark_granular new_features_perf \
+object_stress objects_perf string_methods_perf recursion_stress jit_probe jit_regression "
+
+# Fixtures with a KNOWN, FILED flag-on divergence (format: "name:#issue"). A known fixture is
+# reported and counted separately, not failed — but the default flip stays blocked until this
+# list is empty (see #199). Filed 2026-07-17 by the first full sweep:
+#   #502 fill no-op · #503 for..in empty · #504 delete leaves value · #505 unshift corruption
+#   #506 splice removed-values wrong · #507 flat misses packed inners · #508 native F64A.reduce
+KNOWN_DIVERGENCES="array_fill:#502 parity_builtins:#503 delete_operator:#504 \
+array_methods:#505 array_sort_splice:#506 higher_order_methods:#507 typed_arrays:#508"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+norm() { sed -E 's/[0-9]+(\.[0-9]+)?ms/Nms/g'; }
+
+known_issue_for() { # name -> issue ref or empty
+  local entry
+  for entry in $KNOWN_DIVERGENCES; do
+    if [ "${entry%%:*}" = "$1" ]; then echo "${entry#*:}"; return; fi
+  done
+}
+
+fail=0; known=0
+
+if [ "$RUN_CORPUS" = 1 ]; then
+  n=0; pass=0
+  for src in tests/core/*.tish; do
+    [ -f "${src}.expected" ] || continue
+    base=$(basename "${src%.tish}")
+    [[ "$SKIP" == *" $base "* ]] && continue
+    n=$((n+1))
+    diverged=""
+    for backend in interp vm; do
+      off=$(env -u TISH_PACKED_ARRAYS "$TISH" run --backend "$backend" "$src" 2>/dev/null | norm)
+      on=$(env TISH_PACKED_ARRAYS=1 "$TISH" run --backend "$backend" "$src" 2>/dev/null | norm)
+      if [ "$on" != "$off" ]; then
+        diverged="$diverged $backend"
+        printf 'DIFF  %-45s [%s]\n' "$base" "$backend"
+        diff <(printf '%s' "$off") <(printf '%s' "$on") | head -6 | sed 's/^/    /'
+      fi
+    done
+    if [ "$RUN_NATIVE" = 1 ]; then
+      bin="$tmp/$base"
+      if env TISH_FAST_NATIVE_BUILD=1 "$TISH" build "$src" -o "$bin" >/dev/null 2>"$tmp/err"; then
+        off=$(env -u TISH_PACKED_ARRAYS "$bin" 2>/dev/null | norm)
+        on=$(env TISH_PACKED_ARRAYS=1 "$bin" 2>/dev/null | norm)
+        if [ "$on" != "$off" ]; then
+          diverged="$diverged native"
+          printf 'DIFF  %-45s [native]\n' "$base"
+          diff <(printf '%s' "$off") <(printf '%s' "$on") | head -6 | sed 's/^/    /'
+        fi
+        rm -f "$bin"
+      else
+        printf 'BUILD-FAIL  %-39s [native]\n' "$base"
+        sed 's/^/    /' "$tmp/err" | head -4
+        diverged="$diverged native-build"
+      fi
+    fi
+    if [ -z "$diverged" ]; then
+      pass=$((pass+1))
+    else
+      issue=$(known_issue_for "$base")
+      if [ -n "$issue" ]; then
+        echo "KNOWN ($issue): $base —$diverged"
+        known=$((known+1))
+      else
+        fail=$((fail+1))
+      fi
+    fi
+  done
+  echo "corpus: $pass/$n flag-on == flag-off, $known known (filed), $((n - pass - known)) new divergence(s)"
+fi
+
+if [ "$RUN_PERF" = 1 ]; then
+  pn=0; ppass=0
+  for src in tests/perf/*.tish; do
+    base=$(basename "${src%.tish}")
+    pn=$((pn+1))
+    line_off=$(env -u TISH_PACKED_ARRAYS "$TISH" run --backend vm "$src" 2>/dev/null | grep "^GAUNTLET " | tail -1)
+    line_on=$(env TISH_PACKED_ARRAYS=1 "$TISH" run --backend vm "$src" 2>/dev/null | grep "^GAUNTLET " | tail -1)
+    js="$src"
+    [ -f "tests/perf/${base}.js" ] && js="tests/perf/${base}.js"
+    line_node=$(node "$js" 2>/dev/null | grep "^GAUNTLET " | tail -1)
+    c_off=$(echo "$line_off" | awk '{print $4}')
+    c_on=$(echo "$line_on" | awk '{print $4}')
+    c_node=$(echo "$line_node" | awk '{print $4}')
+    if [ -n "$c_off" ] && [ "$c_off" = "$c_on" ] && [ "$c_off" = "$c_node" ]; then
+      ppass=$((ppass+1))
+    else
+      issue=$(known_issue_for "$base")
+      if [ -n "$issue" ]; then
+        echo "KNOWN ($issue): perf $base checksum off=$c_off on=$c_on node=$c_node"
+        known=$((known+1))
+      else
+        echo "CHECKSUM-DIFF  $base: off=${c_off:-MISSING} on=${c_on:-MISSING} node=${c_node:-MISSING}"
+        fail=$((fail+1))
+      fi
+    fi
+  done
+  echo "perf checksums: $ppass/$pn flag-on == flag-off == node"
+fi
+
+echo "packed-arrays parity: ${fail} new divergence(s), ${known} known (filed)"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Implements #199 — the full-corpus flag-on parity sweep that is the stated precondition for ever flipping packed f64 arrays default-on. And it immediately earned its keep: **the first run found 7 real divergences**, exactly the sharp-edge classes the issue predicted.

## What's in it

- **`scripts/packed_arrays_parity_check.sh`** (shellcheck-clean):
  - **Corpus**: every `tests/core/*.tish` with a committed `.expected` runs flag-off and flag-on across **interp, vm, and a native build**, diffing per backend (ms-normalized). The flag is runtime-read via a OnceLock (#239), so native needs **one build per fixture run twice** — no double build. Skip list mirrors `run_parity_compare.sh` / `TIMING_NONDETERMINISTIC`.
  - **Perf checksums**: every `tests/perf/*.tish`'s `GAUNTLET <name> <ms> <check>` column compared **vm-flag-off == vm-flag-on == node**.
  - Any **new** divergence fails. A **filed** divergence may be allowlisted in `KNOWN_DIVERGENCES` (issue ref required) — reported, counted, not failed — and the default flip stays blocked until that list is empty.
- **`just packed-parity`** (`--no-native` for the fast variant).
- **`.github/workflows/packed-arrays.yml`** — path-filtered to `crates/tish_core|tish_vm|tish_builtins` + the tooling: the sweep job (PR/push gate), plus a `cargo nextest -p tishlang -p tishlang_vm --features full` job with `TISH_PACKED_ARRAYS=1` that is **workflow_dispatch-only for now** (see below).

## What the first sweep found (all filed, all allowlisted as KNOWN)

| Issue | Divergence | Backend |
|---|---|---|
| #502 | `fill` is a silent no-op on a packed array | vm |
| #503 | `for..in` over a packed array yields no keys | vm |
| #504 | `delete a[i]` leaves the element value in place | vm |
| #505 | `unshift` corrupts a packed receiver | vm |
| #506 | `splice` returns wrong removed elements | vm |
| #507 | `flat()` does not flatten packed inner arrays | vm |
| #508 | `Float64Array(from array literal).reduce` returns the init value | native |

Each has a minimal repro in its issue; results are also summarized on #199.

## Current standing (local, release build)

- Corpus: **152/159 flag-on == flag-off, 7 known (filed), 0 new** — exit 0.
- Perf checksums: **30/30** flag-on == flag-off == node.
- Unit suites with the flag on: `tishlang_vm` 20/20, `tishlang_builtins` 61/61.
- The corpus-level interp==vm parity integration test **fails with the flag on**, on exactly the filed fixtures — which is why the workflow's nextest job is dispatch-only until #502–#508 are fixed; flip it onto `pull_request` when the KNOWN list empties, at which point it becomes #199's "nextest passes flag-on" acceptance gate.

## Acceptance criteria from #199

- [x] Script sweeps all of tests/core with `TISH_PACKED_ARRAYS=1` across interp, VM, and native, diffing vs flag-off
- [x] tests/perf checksum columns equal flag-on vs flag-off vs node
- [x] Justfile recipe + CI job (sweep job green; nextest job gated as documented)
- [x] Divergences filed as bugs and listed on the issue (#502–#508)
- [ ] Default-flip PR — separate, explicitly blocked until the KNOWN list is empty

Refs #199 (leaving it open as the tracker until the knowns are fixed and the flip lands, per its own definition of done).