### PR TITLE
regression: dune-server native suite (guards Dune's mission-critical primitives)

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -12,3 +12,4 @@ exclude_paths:
   - '**/*.spec.js'          # *.spec.js
   - '**/*.spec.ts'          # *.spec.ts
   - '**/*.tish.expected'    # expected-output fixtures
+  - 'regression/**'         # regression harnesses/drivers (examples, downstream, dune-server) — CI tooling, not shipped code

--- a/.github/workflows/dune-server-regression.yml
+++ b/.github/workflows/dune-server-regression.yml
@@ -1,0 +1,53 @@
+name: dune-server regression
+
+# Native build + end-to-end drive of a distilled dune-server, guarding the tish primitives Dune's
+# headless backend depends on (hyper serve(), HTTP→WS upgrade + wsAccept, tish:pty, fs stat/readDir,
+# process, Promise.spawn). These are largely native-only and unexercised by the rest of the suite.
+# Manifest + driver: regression/dune-server/.
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - "crates/tish_runtime/**"
+      - "crates/tish_compile/**"
+      - "regression/dune-server/**"
+  push:
+    branches: [main]
+    paths:
+      - "crates/tish_runtime/**"
+      - "crates/tish_compile/**"
+      - "regression/dune-server/**"
+
+permissions:
+  contents: read
+
+jobs:
+  dune-server:
+    name: distilled dune-server vs tish HEAD
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: dune-server-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+
+      - name: Build tish CLI
+        run: cargo build --release --features full
+
+      - name: Run dune-server regression
+        run: bash regression/dune-server/run.sh

--- a/.github/workflows/dune-server-regression.yml
+++ b/.github/workflows/dune-server-regression.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install Node
         uses: actions/setup-node@v4

--- a/crates/tish_vm/src/jit.rs
+++ b/crates/tish_vm/src/jit.rs
@@ -194,6 +194,26 @@ pub fn jit_bool_slots_enabled() -> bool {
     })
 }
 
+/// #168 int-typed slots. **Default ON**; `TISH_JIT_INT_SLOTS=0` disables (falls back to f64
+/// slots — the pre-#168 behavior, byte-identical results).
+///
+/// A local whose every store is a bitwise/shift result (or an integral constant) lives in an
+/// `i64` Variable holding the EXACT JS number ([`Repr::I64Num`]), so an integer hash/PRNG
+/// accumulator (`h = ((h << 13) | (h >>> 19)) >>> 0; h = h ^ …`) stays in integer registers
+/// ACROSS statements instead of paying an f64 materialize at every store plus a `ToInt32`
+/// re-derivation at every load. A syntactic pre-pass ([`classify_int_slots`]) tags the slots;
+/// the StoreLocal translator bails compilation on any store the pre-pass mis-tagged (a
+/// non-integer value reaching an int slot), so a wrong tag can never miscompile — it just
+/// runs the VM.
+pub fn jit_int_slots_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("TISH_JIT_INT_SLOTS")
+            .map(|v| v != "0")
+            .unwrap_or(true)
+    })
+}
+
 /// The self-recursion stack guard (#381). **Default ON**; `TISH_JIT_RECUR_GUARD=0` disables it.
 ///
 /// A JIT'd self-recursive numeric function recurses on the native stack (SelfCall lowers to a native
@@ -1352,6 +1372,13 @@ enum Repr {
     Bool,
     I32,
     U32,
+    /// #168 int-typed slots: an i64 holding an EXACT integral JS number in [-2^31, 2^32).
+    /// Signedness is encoded in the value itself (an I32 store sign-extends, a U32 store
+    /// zero-extends, an integral constant loads exactly), so a slot whose stores mix `^`
+    /// (ToInt32 domain) and `>>> 0` (ToUint32 domain) needs no dynamic tag: materializing
+    /// is one exact `fcvt_from_sint`, and re-entering the 32-bit domain is one `ireduce`
+    /// (ToInt32 of an integral value in this range IS its low 32 bits).
+    I64Num,
 }
 
 /// A typed JIT stack value: the Cranelift SSA value plus its current [`Repr`].
@@ -1386,6 +1413,8 @@ fn jv_f64(bcx: &mut FunctionBuilder, jv: JV) -> ClifValue {
         Repr::F64 | Repr::Bool => jv.v,
         Repr::I32 => bcx.ins().fcvt_from_sint(types::F64, jv.v),
         Repr::U32 => bcx.ins().fcvt_from_uint(types::F64, jv.v),
+        // Exact by construction: an I64Num is integral and |v| < 2^32 << 2^53.
+        Repr::I64Num => bcx.ins().fcvt_from_sint(types::F64, jv.v),
     }
 }
 
@@ -1396,6 +1425,14 @@ fn jv_i32_bits(bcx: &mut FunctionBuilder, jv: JV) -> ClifValue {
     match jv.repr {
         Repr::I32 | Repr::U32 => jv.v,
         Repr::F64 | Repr::Bool => js_to_int32(bcx, jv.v),
+        // ToInt32 of an exact integral in [-2^31, 2^32) is its low 32 bits.
+        Repr::I64Num => bcx.ins().ireduce(types::I32, jv.v),
+    }
+}
+
+impl JV {
+    fn i64num(v: ClifValue) -> Self {
+        Self { v, repr: Repr::I64Num }
     }
 }
 
@@ -2217,6 +2254,82 @@ fn classify_bool_slots(chunk: &Chunk) -> std::collections::HashSet<usize> {
     set
 }
 
+/// #168: slots eligible for i64 int-typed storage ([`Repr::I64Num`]): every `StoreLocal` to the
+/// slot is IMMEDIATELY preceded (linearly — statement boundaries have empty stacks, and the
+/// ternary shape bails out of `build_body_cfg`, so the linear predecessor IS the value producer;
+/// same assumption [`classify_bool_slots`] rests on) by an op that pushes integer bits — a
+/// bitwise/shift `BinOp`, a `~` `UnaryOp`, or a `LoadConst` of an integral Number in
+/// [-2^31, 2^32) (excluding `-0`, whose sign an integer store would erase). Param slots are
+/// excluded (they arrive as arbitrary f64s through the ABI). Like `classify_bool_slots` this is
+/// an OPTIMISTIC tag: a merge point could make the linear predecessor differ from the dynamic
+/// one, so the StoreLocal translator re-checks the actual stored repr and BAILS compilation on
+/// any non-integer store to a tagged slot — misclassification runs the VM, never miscompiles.
+fn classify_int_slots(chunk: &Chunk, arity: usize) -> std::collections::HashSet<usize> {
+    if !jit_int_slots_enabled() {
+        return std::collections::HashSet::new();
+    }
+    let code = &chunk.code;
+    let mut int_stores: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    let mut other_stores: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    let mut ip = 0usize;
+    let mut prev_pushes_int = false;
+    while ip < code.len() {
+        let op = match Opcode::from_u8(code[ip]) {
+            Some(o) => o,
+            None => break,
+        };
+        let size = match op.instruction_size(code, ip) {
+            Some(s) => s,
+            None => break,
+        };
+        if op == Opcode::StoreLocal {
+            if let Some(s) = peek_u16(code, ip + 1) {
+                let slot = s as usize;
+                if prev_pushes_int && slot >= arity {
+                    int_stores.insert(slot);
+                } else {
+                    other_stores.insert(slot);
+                }
+            }
+        }
+        prev_pushes_int = match op {
+            Opcode::BinOp => matches!(
+                peek_u16(code, ip + 1)
+                    .map(|r| r as u8)
+                    .and_then(u8_to_binop),
+                Some(
+                    BinOp::BitAnd
+                        | BinOp::BitOr
+                        | BinOp::BitXor
+                        | BinOp::Shl
+                        | BinOp::Shr
+                        | BinOp::UShr
+                )
+            ),
+            Opcode::UnaryOp => matches!(
+                peek_u16(code, ip + 1)
+                    .map(|r| r as u8)
+                    .and_then(u8_to_unaryop),
+                Some(UnaryOp::BitNot)
+            ),
+            Opcode::LoadConst => matches!(
+                peek_u16(code, ip + 1).and_then(|i| chunk.constants.get(i as usize)),
+                Some(Constant::Number(n))
+                    if n.fract() == 0.0
+                        && *n >= -(2f64.powi(31))
+                        && *n < 2f64.powi(32)
+                        && n.to_bits() != (-0f64).to_bits()
+            ),
+            _ => false,
+        };
+        ip += size;
+    }
+    int_stores
+        .difference(&other_stores)
+        .copied()
+        .collect()
+}
+
 /// on any misuse of a JV ref (it reaching a numeric op, a return, a call arg, a block boundary, …),
 /// so a mis-shaped use never miscompiles — it just falls back to the interpreter.
 fn classify_jv_slots(chunk: &Chunk) -> Option<std::collections::HashSet<usize>> {
@@ -2275,17 +2388,53 @@ fn peek_u16(code: &[u8], off: usize) -> Option<u16> {
 /// `LoadConst(Number)` (→ an f64 const) — for the array read/write peepholes. `None` for any other
 /// opcode / a non-numeric const, which makes the caller bail. #187
 #[cfg(not(target_arch = "wasm32"))]
+/// #168: the exact i64 for a `StoreLocal` into an int slot whose value arrived as a plain F64
+/// push — the classifier-approved case is a linearly-preceding `LoadConst` of an integral
+/// Number in [-2^31, 2^32) (excluding `-0`). `store_ip` points AT the StoreLocal opcode; the
+/// cfg builder's empty-stack-at-block-boundary discipline guarantees the linear predecessor is
+/// the dynamic value producer. Any other shape → `None` → the caller bails the whole compile.
+fn int_const_i64(
+    bcx: &mut FunctionBuilder,
+    chunk: &Chunk,
+    code: &[u8],
+    store_ip: usize,
+) -> Option<ClifValue> {
+    let lc = store_ip.checked_sub(3)?;
+    if Opcode::from_u8(*code.get(lc)?)? != Opcode::LoadConst {
+        return None;
+    }
+    match chunk.constants.get(peek_u16(code, lc + 1)? as usize)? {
+        Constant::Number(n)
+            if n.fract() == 0.0
+                && *n >= -(2f64.powi(31))
+                && *n < 2f64.powi(32)
+                && n.to_bits() != (-0f64).to_bits() =>
+        {
+            Some(bcx.ins().iconst(types::I64, *n as i64))
+        }
+        _ => None,
+    }
+}
+
 fn read_simple_operand(
     bcx: &mut FunctionBuilder,
     code: &[u8],
     at: usize,
     chunk: &Chunk,
     vars: &[Variable],
+    int_slots: &std::collections::HashSet<usize>,
 ) -> Option<ClifValue> {
     match Opcode::from_u8(*code.get(at)?)? {
         Opcode::LoadLocal => {
             let s = peek_u16(code, at + 1)? as usize;
-            Some(bcx.use_var(*vars.get(s)?))
+            let v = bcx.use_var(*vars.get(s)?);
+            // #168: an int slot's Variable is i64 (exact number) — materialize to the f64 this
+            // fast path assumes. Without this, the i64 value would flow into f64 instructions
+            // and trip the cranelift verifier (a crash, not a bail).
+            if int_slots.contains(&s) {
+                return Some(bcx.ins().fcvt_from_sint(types::F64, v));
+            }
+            Some(v)
         }
         Opcode::LoadConst => {
             let ci = peek_u16(code, at + 1)? as usize;
@@ -2342,6 +2491,7 @@ fn build_body_cfg(
     }
     // #187: slots that hold a boolean (represented as `f64` 0/1). A `LoadLocal` of one carries
     // `is_bool` so a diverging `bool === number` compare or a `return bool` bails to the interpreter.
+    let int_slots = classify_int_slots(chunk, arity);
     let bool_slots = if jit_bool_slots_enabled() {
         classify_bool_slots(chunk)
     } else {
@@ -2452,11 +2602,12 @@ fn build_body_cfg(
     };
     let body_start = *blocks.get(&0)?; // `entry` normally; `body_block` when guarded
 
-    // 2. A Variable per slot, all defined at entry so every path defines them. A JV slot (#189) holds
-    //    an arena HANDLE (a `u64`, 0 = null) so its Variable is `i64`, not `f64`.
+    // 2. A Variable per slot, all defined at entry so every path defines them. A JV slot (#189)
+    //    holds an arena HANDLE (a `u64`, 0 = null) so its Variable is `i64`, not `f64`; an int
+    //    slot (#168) holds an exact integral JS number as `i64` ([`Repr::I64Num`]).
     let vars: Vec<Variable> = (0..num_slots)
         .map(|i| {
-            let ty = if jv.is_some_and(|j| j.slots.contains(&i)) {
+            let ty = if jv.is_some_and(|j| j.slots.contains(&i)) || int_slots.contains(&i) {
                 types::I64
             } else {
                 types::F64
@@ -2492,6 +2643,8 @@ fn build_body_cfg(
                     .load(types::F64, MemFlags::new(), numeric_ptr, numeric_i * 8);
                 numeric_i += 1;
                 v
+            } else if int_slots.contains(&slot) {
+                bcx.ins().iconst(types::I64, 0)
             } else {
                 bcx.ins().f64const(0.0)
             };
@@ -2509,6 +2662,8 @@ fn build_body_cfg(
             } else {
                 let init = if i < arity {
                     params[i]
+                } else if int_slots.contains(&i) {
+                    bcx.ins().iconst(types::I64, 0)
                 } else {
                     bcx.ins().f64const(0.0)
                 };
@@ -2603,13 +2758,16 @@ fn build_body_cfg(
                         ip += 3;
                         continue;
                     }
-                    let idx_f64 = read_simple_operand(&mut bcx, code, ip + 3, chunk, &vars)?;
+                    let idx_f64 =
+                        read_simple_operand(&mut bcx, code, ip + 3, chunk, &vars, &int_slots)?;
                     // i = idx as usize (saturating: NaN→0, neg→0 — matches the VM's `n as usize`).
                     let i = bcx.ins().fcvt_to_uint_sat(types::I64, idx_f64);
                     // Read `val` (write only) BEFORE the bounds-check split so its LoadLocal reads the
                     // slot's current SSA value in `cur`, not the fresh `cont` block.
                     let store_val = if is_write {
-                        Some(read_simple_operand(&mut bcx, code, ip + 6, chunk, &vars)?)
+                        Some(read_simple_operand(
+                            &mut bcx, code, ip + 6, chunk, &vars, &int_slots,
+                        )?)
                     } else {
                         None
                     };
@@ -2634,10 +2792,14 @@ fn build_body_cfg(
                 }
                 let v = *vars.get(slot)?;
                 // #187: a bool slot's `f64` 0/1 value carries the Bool repr so downstream
-                // equality/return guards fire; a plain numeric slot pushes F64.
+                // equality/return guards fire; an int slot (#168) pushes its exact-i64 repr
+                // (identity into further int ops, one exact convert at an f64 boundary); a
+                // plain numeric slot pushes F64.
                 let lv = bcx.use_var(v);
                 stack.push(if bool_slots.contains(&slot) {
                     JV::boolean(lv)
+                } else if int_slots.contains(&slot) {
+                    JV::i64num(lv)
                 } else {
                     JV::f64(lv)
                 });
@@ -2661,10 +2823,35 @@ fn build_body_cfg(
                 if jval.is_bool() && !bool_slots.contains(&slot) {
                     return None;
                 }
+                let v = *vars.get(slot)?;
+                if int_slots.contains(&slot) {
+                    // #168: an int slot stores the EXACT number as i64 — sign-extend ToInt32
+                    // results, zero-extend ToUint32 results, integral constants load exactly.
+                    // Anything else reaching here means the optimistic pre-pass mis-tagged the
+                    // slot (e.g. a merge point whose linear predecessor differed) → bail the
+                    // whole compile; the VM keeps semantics.
+                    let iv = match jval.repr {
+                        Repr::I32 => bcx.ins().sextend(types::I64, jval.v),
+                        Repr::U32 => bcx.ins().uextend(types::I64, jval.v),
+                        Repr::I64Num => jval.v,
+                        Repr::F64 => {
+                            // The classifier only tags int-op/const-preceded stores, but a
+                            // constant reaches here as an F64 push — re-derive its exact i64
+                            // when it is one of the classifier-approved integral constants.
+                            match int_const_i64(&mut bcx, chunk, code, ip) {
+                                Some(iv) => iv,
+                                None => return None,
+                            }
+                        }
+                        Repr::Bool => return None,
+                    };
+                    bcx.def_var(v, iv);
+                    ip += 3;
+                    continue;
+                }
                 // Slots are f64 Variables — materialize an int repr once, at the store (an
                 // `h = ((h<<13)|(h>>>19))>>>0` chain pays exactly ONE convert here, not per op).
                 let val = jv_f64(&mut bcx, jval);
-                let v = *vars.get(slot)?;
                 bcx.def_var(v, val);
                 ip += 3;
             }

--- a/regression/downstream/repos.tsv
+++ b/regression/downstream/repos.tsv
@@ -54,5 +54,10 @@ tish-playground	git:https://github.com/spacedevin/tish-playground.git@main	.	tis
 # resolve to the workspace lattish.
 tish-midi	git:https://github.com/spacedevin/deckard.git@main	.	tish	rc=0; while IFS= read -r f; do tish build --target js "$f" -o /tmp/_m.js >/tmp/_m.err 2>&1 || { echo "FAIL: $f"; head -2 /tmp/_m.err; rc=1; }; done < <(find src -name "*.tish" -not -path "*/node_modules/*"); exit $rc	pass
 tish-tailwind	local:~/Projects/tish-audio/tish-tailwind	.	tish	bash -c 'f=$(find . -name "*.tish" -not -path "*/node_modules/*" | head -1); [ -z "$f" ] || tish build --target js "$f" -o /tmp/_tw.js'	pass
+# The REAL dune-server (dune-ide headless backend) built NATIVELY against tish HEAD with its exact
+# feature set — a build-regression guard for the actual server. cmd is a direct `tish build` (NOT npm),
+# so the runner skips the heavy monorepo npm install. Private repo → local-only (skipped in CI). The
+# always-on CI guard for the SAME primitives is the self-contained regression/dune-server suite.
+dune-server	local:~/Projects/dune/dune-ide	.	tish	TISH_HTTP_BACKEND=hyper tish build --target native --feature http,http-hyper,fs,process,ws,pty -o /tmp/_dune_server apps/dune-server/dune-server.tish	pass
 spider3-tish	git:https://github.com/schlopai/spider-gwen-webgpu.git@main	.	tish	bash -c 'rc=0; while IFS= read -r f; do tish build --target js "$f" -o /tmp/_s.js >/tmp/_s.err 2>&1 || { echo "FAIL: $f"; head -2 /tmp/_s.err; rc=1; }; done < <(find . -name "*.tish" -not -path "*/node_modules/*" -not -path "*/vendor/*" -not -path "*/dist/*"); exit $rc'	pass
 spacekinematics	git:https://github.com/spacedevin/solar-system-webgpu.git@main	.	tish	bash -c 'rc=0; while IFS= read -r f; do tish build --target js "$f" -o /tmp/_s.js >/tmp/_s.err 2>&1 || { echo "FAIL: $f"; head -2 /tmp/_s.err; rc=1; }; done < <(find . -name "*.tish" -not -path "*/node_modules/*" -not -path "*/vendor/*" -not -path "*/sgp4-wasm/*"); exit $rc'	pass

--- a/regression/dune-server/README.md
+++ b/regression/dune-server/README.md
@@ -1,0 +1,51 @@
+# dune-server regression
+
+Guards the tish primitives that **Dune's headless backend** (`apps/dune-server` in the
+[dune-ide](https://github.com/duneyou/dune-ide) repo) depends on, so a tish release can't silently
+break the mission-critical surface. Unlike `regression/examples` (which runs the JS interpreter),
+this **builds natively** and drives the real native-only primitives — `tish:pty`, the HTTP→WS
+upgrade + `tish:ws` `wsAccept`, and the hyper `serve()` backend — end-to-end.
+
+Why it exists: Dune connects to a remote `dune-server` for files, git, an interactive terminal, and
+live change-push. That server is one native tish binary built with
+`--feature http,http-hyper,fs,process,ws,pty` and `TISH_HTTP_BACKEND=hyper`. Several of those
+primitives (`wsAccept`, the HTTP→WS upgrade, `tish:pty`, `Promise.spawn`) are **native-target only**
+and were added *for* Dune (tish #493/#494 pty, #495/#496 upgrade), so nothing else in the suite
+exercises them. A break there would only surface when someone updates Dune's tish pin — weeks later.
+
+## What it checks
+
+`server.tish` is a **distilled dune-server** — self-contained (no dune-ide imports), reproducing the
+exact usage pattern. `drive.mjs` (Node ≥ 21, global `WebSocket`) asserts, over a freshly-built native
+binary:
+
+| # | Surface | tish primitive |
+|---|---|---|
+| 1 | `GET /health` → `{"ok":true}` | `tish:http` `serve()` (hyper) |
+| 2 | `POST /rpc` `ping` → `"pong"` | HTTP RPC dispatch |
+| 3 | `workspace_signature` **changes** after a file edit | `tish:fs` `stat` + `readDir` + `isDir` |
+| 4 | `git_head` → the branch name | `process.execFileCapture` |
+| 5 | `/pty` WS spawns a shell + **echoes** a command | `tish:pty` over the HTTP→WS upgrade + `wsAccept` |
+| 6 | `/watch` WS **pushes** a changed signature on edit | `Promise.spawn` pump + upgrade dispatch by first frame |
+
+A red on any of these is a real regression in a primitive Dune ships on.
+
+## Run it
+
+```bash
+regression/dune-server/run.sh              # build native + drive + assert (exit 0 = pass)
+regression/dune-server/run.sh --tish DIR   # build with a different tish checkout's CLI
+regression/dune-server/run.sh --keep       # keep the scratch workspace + binary
+```
+
+It resolves a `tish` CLI (the checkout's `target/{release,debug}/tish`, else one on `PATH`, else
+builds release), makes a temp git workspace, native-builds `server.tish` with dune-server's exact
+flags, starts it, waits for the port, then runs the driver. CI: `.github/workflows/dune-server-regression.yml`
+(triggered on changes to `crates/tish_runtime/**` and this dir).
+
+## Keeping it faithful
+
+`server.tish` mirrors `apps/dune-server` in dune-ide (`serveWorkspace.tish` + `servePtyWs.tish`). If
+Dune's server changes which primitives it leans on, update `server.tish` here to match — this test is
+only as good as its fidelity to the real thing. The real dune-server itself can be built against tish
+HEAD on a dev machine via the `local:` entry in `regression/downstream/repos.tsv`.

--- a/regression/dune-server/README.md
+++ b/regression/dune-server/README.md
@@ -47,5 +47,13 @@ flags, starts it, waits for the port, then runs the driver. CI: `.github/workflo
 
 `server.tish` mirrors `apps/dune-server` in dune-ide (`serveWorkspace.tish` + `servePtyWs.tish`). If
 Dune's server changes which primitives it leans on, update `server.tish` here to match — this test is
-only as good as its fidelity to the real thing. The real dune-server itself can be built against tish
-HEAD on a dev machine via the `local:` entry in `regression/downstream/repos.tsv`.
+only as good as its fidelity to the real thing.
+
+## Related: isolated per-primitive smoke tests
+
+This end-to-end suite is complemented by **isolated** native tests for the individual primitives, wired
+into `scripts/test_native_smoke.sh` (CI: `native-smoke.yml`) so each has its own standing guard:
+`tests/native_smoke/pty_app.tish` (`tish:pty`), `ws_app.tish` (HTTP→WS upgrade + `wsAccept`), and
+`stat_app.tish` (`tish:fs` `stat`/`readDir`). The real dune-server can also be built against tish HEAD
+on a dev machine by adding a `local:` entry to `regression/downstream/repos.tsv` (a direct `tish build`
+cmd, so the runner skips the monorepo npm install).

--- a/regression/dune-server/drive.mjs
+++ b/regression/dune-server/drive.mjs
@@ -1,0 +1,115 @@
+// Drives the distilled dune-server (server.tish) and asserts the mission-critical surface end-to-end:
+//   1. HTTP  /health                       → {"ok":true}
+//   2. HTTP  /rpc ping                     → "pong"
+//   3. HTTP  /rpc workspace_signature      → a string that CHANGES after a file edit (fs stat/readDir)
+//   4. HTTP  /rpc git_head                 → the branch name (process.execFileCapture)
+//   5. WS    /pty  {t:"start"} then {t:"in"} echo cmd → the shell echoes it back (tish:pty over the upgrade)
+//   6. WS    /watch {t:"watch"} → baseline sig, then a PUSHED changed sig after a file edit
+//
+// Usage: node drive.mjs <baseUrl> <workspaceDir>   (e.g. node drive.mjs http://127.0.0.1:8799 /tmp/ws)
+// Exit 0 = all pass, 1 = a failure. Requires Node >= 21 (global WebSocket).
+
+import { writeFileSync } from "node:fs";
+
+const BASE = process.argv[2];
+const WS = "ws://" + BASE.replace(/^https?:\/\//, "");
+const WORKSPACE = process.argv[3];
+
+let failures = 0;
+function check(name, ok, detail) {
+  console.log((ok ? "PASS " : "FAIL ") + name + (detail ? "  " + detail : ""));
+  if (!ok) failures++;
+}
+
+async function rpc(method) {
+  const r = await fetch(BASE + "/rpc", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ method }),
+  });
+  return r.json();
+}
+
+function wsOnce(path, onOpen, onMessage, timeoutMs) {
+  return new Promise((resolve) => {
+    const sock = new WebSocket(WS + path);
+    sock.binaryType = "arraybuffer";
+    let done = false;
+    const finish = (v) => { if (!done) { done = true; try { sock.close(); } catch {} resolve(v); } };
+    sock.onopen = () => onOpen(sock);
+    sock.onmessage = (e) => {
+      const data = typeof e.data === "string" ? e.data : Buffer.from(e.data).toString("utf8");
+      const r = onMessage(data, sock, finish);
+      if (r !== undefined) finish(r);
+    };
+    sock.onerror = (e) => finish({ error: String(e && e.message ? e.message : e) });
+    setTimeout(() => finish({ timeout: true }), timeoutMs);
+  });
+}
+
+async function main() {
+  // 1. health
+  const health = await fetch(BASE + "/health").then((r) => r.text()).catch((e) => "ERR:" + e);
+  check("http /health", health.includes("\"ok\":true"), health);
+
+  // 2. ping
+  const ping = await rpc("ping");
+  check("rpc ping", ping && ping.ok === true && ping.result === "pong", JSON.stringify(ping));
+
+  // 3. workspace_signature changes on a file edit (fs stat/readDir walk)
+  const sig1 = await rpc("workspace_signature");
+  writeFileSync(WORKSPACE + "/edited.txt", "changed-" + Math.random().toString(36).slice(2));
+  const sig2 = await rpc("workspace_signature");
+  check(
+    "rpc workspace_signature (fs stat/readDir) changes on edit",
+    sig1 && sig2 && typeof sig1.result === "string" && sig1.result !== sig2.result,
+    (sig1 && sig1.result) + " -> " + (sig2 && sig2.result)
+  );
+
+  // 4. git_head (process.execFileCapture)
+  const gh = await rpc("git_head");
+  check(
+    "rpc git_head (process.execFileCapture)",
+    gh && gh.ok === true && gh.result && typeof gh.result.stdout === "string" && gh.result.stdout.trim().length > 0,
+    gh && gh.result && JSON.stringify(gh.result.stdout)
+  );
+
+  // 5. /pty WS: spawn a shell, echo a marker, expect it back (tish:pty over the HTTP→WS upgrade)
+  const MARKER = "DUNE_PTY_OK_" + Math.floor(Math.random() * 1e6);
+  const ptyRes = await wsOnce(
+    "/pty",
+    (sock) => sock.send(JSON.stringify({ t: "start", cols: 80, rows: 24 })),
+    (data, sock, finish) => {
+      if (!sock.__sent && data.length > 0) {
+        sock.__sent = true;
+        sock.send(JSON.stringify({ t: "in", d: "echo " + MARKER + "\n" }));
+      }
+      sock.__buf = (sock.__buf || "") + data;
+      if (sock.__buf.includes(MARKER + "\r") || sock.__buf.split(MARKER).length > 2) return { ok: true };
+    },
+    5000
+  );
+  check("ws /pty terminal echoes a command (tish:pty + wsAccept upgrade)", ptyRes && ptyRes.ok === true, JSON.stringify(ptyRes).slice(0, 120));
+
+  // 6. /watch WS: baseline sig, then a PUSHED changed sig after an edit (Promise.spawn pump)
+  const watchRes = await wsOnce(
+    "/watch",
+    (sock) => sock.send(JSON.stringify({ t: "watch" })),
+    (data, sock, finish) => {
+      const m = JSON.parse(data);
+      sock.__sigs = sock.__sigs || [];
+      sock.__sigs.push(m.sig);
+      if (sock.__sigs.length === 1) {
+        setTimeout(() => writeFileSync(WORKSPACE + "/watched.txt", "w-" + Math.random().toString(36).slice(2)), 150);
+      }
+      if (sock.__sigs.length === 2) return { ok: sock.__sigs[0] !== sock.__sigs[1], sigs: sock.__sigs };
+    },
+    6000
+  );
+  check("ws /watch pushes a changed signature on edit (Promise.spawn pump)", watchRes && watchRes.ok === true, JSON.stringify(watchRes).slice(0, 120));
+
+  console.log("\n" + (failures === 0 ? "ALL PASS" : failures + " FAILURE(S)"));
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((e) => { console.error("driver error", e); process.exit(1); });

--- a/regression/dune-server/run.sh
+++ b/regression/dune-server/run.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# dune-server regression — build a DISTILLED dune-server (server.tish) NATIVELY,
+# exactly as Dune's headless backend does, then drive it end-to-end and assert the
+# mission-critical primitives still work: tish:http serve() on the hyper backend,
+# the HTTP→WS upgrade + tish:ws wsAccept, tish:pty, tish:fs stat/readDir, process,
+# and Promise.spawn.
+#
+# The built-in example/downstream suites run the JS interpreter (`tish run`), which
+# CAN'T exercise these native-only primitives — hence this dedicated native build+drive.
+#
+# Usage: regression/dune-server/run.sh [--tish DIR] [--keep]
+#   --tish DIR   tish checkout to build with (default: this repo). Its `tish` CLI is used.
+#   --keep       keep the scratch workspace + binary for inspection.
+# Env: TISH_DIR overrides --tish.
+# Exit 0 = all mission-critical checks pass; 1 = a regression.
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+TISH="${TISH_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+KEEP=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tish) TISH=$(cd "$2" && pwd); shift 2 ;;
+    --keep) KEEP=1; shift ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Resolve a `tish` CLI: prefer the checkout's built binary, else one on PATH.
+TISH_BIN=""
+for cand in "$TISH/target/release/tish" "$TISH/target/debug/tish" "$(command -v tish 2>/dev/null || true)"; do
+  [[ -n "$cand" && -x "$cand" ]] && { TISH_BIN="$cand"; break; }
+done
+if [[ -z "$TISH_BIN" ]]; then
+  echo "building tish CLI (release, --features full) from $TISH ..."
+  ( cd "$TISH" && cargo build --release --features full ) || { echo "ERROR: could not build tish CLI"; exit 2; }
+  TISH_BIN="$TISH/target/release/tish"
+fi
+command -v node >/dev/null 2>&1 || { echo "ERROR: node is required (the WS driver uses global WebSocket, Node >= 21)"; exit 2; }
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/dune-server-reg.XXXXXX")
+WS="$WORK/ws"; mkdir -p "$WS"
+BIN="$WORK/dune-server-parity"
+SRV_PID=""
+cleanup() {
+  if [[ -n "$SRV_PID" ]]; then
+    kill "$SRV_PID" 2>/dev/null
+    wait "$SRV_PID" 2>/dev/null || true   # absorb the shell's "Terminated" job-control notice
+  fi
+  [[ $KEEP -eq 1 ]] || rm -rf "$WORK"
+  [[ $KEEP -eq 1 ]] && echo "kept: $WORK"
+}
+trap cleanup EXIT
+
+echo "tish:      $TISH_BIN ($(git -C "$TISH" rev-parse --short HEAD 2>/dev/null || echo '?'))"
+echo "workspace: $WS"
+
+# Seed the workspace (git repo so git_head has a branch; a couple files for the fs walk).
+( cd "$WS" && git init -q && git config user.email t@t.co && git config user.name t \
+    && printf 'hello\n' > a.txt && printf 'world\n' > sub_b.txt && git add -A && git commit -qm init ) \
+  || { echo "ERROR: could not seed git workspace"; exit 2; }
+
+# Build NATIVELY with the EXACT feature set + hyper backend dune-server uses.
+echo "building server.tish → native (--feature http,http-hyper,fs,process,ws,pty) ..."
+if ! TISH_HTTP_BACKEND=hyper "$TISH_BIN" build --target native \
+      --feature http,http-hyper,fs,process,ws,pty \
+      -o "$BIN" "$SCRIPT_DIR/server.tish" > "$WORK/build.log" 2>&1; then
+  echo "FAIL: native build of the distilled dune-server did not compile"
+  tail -30 "$WORK/build.log"
+  exit 1
+fi
+echo "build OK"
+
+# Pick a free-ish high port.
+PORT=$(( 8800 + RANDOM % 800 ))
+
+TISH_HTTP_BACKEND=hyper "$BIN" --workspace "$WS" --port "$PORT" > "$WORK/server.log" 2>&1 &
+SRV_PID=$!
+
+# Wait for the HTTP port to accept (up to ~5s).
+up=0
+for _ in $(seq 1 50); do
+  if ! kill -0 "$SRV_PID" 2>/dev/null; then echo "FAIL: server exited early"; tail -20 "$WORK/server.log"; exit 1; fi
+  if curl -s -m 1 "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then up=1; break; fi
+  sleep 0.1
+done
+[[ $up -eq 1 ]] || { echo "FAIL: server never came up on $PORT"; tail -20 "$WORK/server.log"; exit 1; }
+
+echo "server up on $PORT — driving …"
+echo "---------------------------------------------"
+if node "$SCRIPT_DIR/drive.mjs" "http://127.0.0.1:$PORT" "$WS"; then
+  echo "---------------------------------------------"
+  echo "dune-server regression: PASS"
+  exit 0
+else
+  echo "---------------------------------------------"
+  echo "dune-server regression: FAIL"
+  echo "--- server.log tail ---"; tail -20 "$WORK/server.log"
+  exit 1
+fi

--- a/regression/dune-server/server.tish
+++ b/regression/dune-server/server.tish
@@ -1,0 +1,169 @@
+// regression/dune-server — a DISTILLED dune-server that exercises the tish primitives Dune's headless
+// backend (apps/dune-server in the dune-ide repo) depends on, so a tish release can't silently break the
+// mission-critical surface. Self-contained: NO imports from dune-ide, so it always builds+runs in CI.
+//
+// Mission-critical surface mirrored here (each maps to a real dune-server dependency):
+//   • tish:http serve() on the HYPER backend (TISH_HTTP_BACKEND=hyper)  — single-port HTTP RPC (/rpc)
+//   • HTTP→WS upgrade on that SAME port + tish:ws wsAccept               — /pty and /watch ride it
+//   • tish:pty spawn/read/write/kill                                    — the interactive terminal
+//   • tish:fs stat + readDir (+ isDir global)                           — the workspace-change signature
+//   • process.execFileCapture                                          — git
+//   • Promise.spawn                                                    — the WS pump beside serve()
+//
+// Build EXACTLY as dune-server does:
+//   TISH_HTTP_BACKEND=hyper tish build --target native \
+//     --feature http,http-hyper,fs,process,ws,pty -o dune-server-parity server.tish
+//   ./dune-server-parity --workspace <dir> --port <port>
+//
+// The driver (drive.mjs) asserts: HTTP /health + /rpc ping + workspace_signature + git_head, a /pty WS
+// that spawns a shell and echoes a command, and a /watch WS that pushes a changed signature on a file
+// edit. See run.sh + README.md.
+
+import { stat } from "tish:fs"
+import { wsAccept } from "tish:ws"
+import { spawn as ptySpawn, read as ptyRead, write as ptyWrite, kill as ptyKill } from "tish:pty"
+
+fn argValue(flag: string): string? {
+  let a = process.argv
+  let i = 0
+  while (i < a.length) {
+    if (a[i] === flag && i + 1 < a.length) { return a[i + 1] }
+    i = i + 1
+  }
+  return null
+}
+
+// Manual base-10 parse (avoid leaning on parseInt/Number availability in the native target).
+fn toInt(s: string): number {
+  let n = 0
+  let i = 0
+  while (i < s.length) {
+    let c = s[i]
+    if (c >= "0" && c <= "9") { n = n * 10 + (c.charCodeAt(0) - 48) }
+    i = i + 1
+  }
+  return n
+}
+
+// The workspace-change fingerprint dune-server pushes: file count + summed mtime(sec) + summed size over
+// the tree (heavy dirs skipped). mtime floored to SECONDS so stat's fractional mtimeMs can't jitter it.
+fn walkSig(dir: string, st: any): any {
+  let names = readDir(dir)
+  if (!Array.isArray(names)) { return st }
+  let i = 0
+  while (i < names.length) {
+    let name = names[i]
+    i = i + 1
+    if (name === ".git" || name === "node_modules" || name === "target") { continue }
+    let full = dir + "/" + name
+    if (isDir(full)) {
+      st = walkSig(full, st)
+    } else {
+      let s = stat(full)
+      if (s !== null && typeof s.mtimeMs === "number" && typeof s.size === "number") {
+        st.count = st.count + 1
+        st.mtimeSum = st.mtimeSum + Math.floor(s.mtimeMs / 1000)
+        st.sizeSum = st.sizeSum + s.size
+      }
+    }
+  }
+  return st
+}
+
+fn workspaceSignature(root: string): string {
+  let st = walkSig(root, { count: 0, mtimeSum: 0, sizeSum: 0 })
+  return String(st.count) + ":" + String(st.mtimeSum) + ":" + String(st.sizeSum)
+}
+
+fn rpcDispatch(root: string, method: string): any {
+  if (method === "ping") { return { ok: true, result: "pong" } }
+  if (method === "workspace_signature") { return { ok: true, result: workspaceSignature(root) } }
+  if (method === "git_head") {
+    let r = process.execFileCapture("git", ["-C", root, "rev-parse", "--abbrev-ref", "HEAD"])
+    return { ok: true, result: { code: r.code, stdout: r.stdout } }
+  }
+  return { ok: false, error: "unknown method: " + method }
+}
+
+// One WS pump for BOTH endpoints — wsAccept doesn't carry the path, so dispatch by the FIRST client
+// frame: {t:"start"} = a PTY terminal, {t:"watch"} = a change-push subscription (exactly like dune-server).
+fn handleWsMsg(c, data, root) {
+  let msg = JSON.parse(data)
+  let t = msg.t
+  if (t === "start") {
+    c.mode = "pty"
+    c.id = ptySpawn({ program: null, cwd: root, cols: 80, rows: 24 })
+    return "ok"
+  }
+  if (t === "watch") {
+    c.mode = "watch"
+    c.lastSig = workspaceSignature(root)
+    c.tick = 0
+    c.ws.send(JSON.stringify({ sig: c.lastSig }))
+    return "ok"
+  }
+  if (c.mode === "pty" && c.id !== 0 && t === "in") {
+    ptyWrite(c.id, msg.d)
+  }
+  return "ok"
+}
+
+fn wsPump(root) {
+  let conns = []
+  while (true) {
+    let ws = wsAccept(8)
+    if (ws !== null) { conns.push({ ws: ws, id: 0, mode: null, lastSig: "", tick: 0 }) }
+    let alive = []
+    let i = 0
+    while (i < conns.length) {
+      let c = conns[i]
+      let dead = false
+      let ev = c.ws.receiveTimeout(0)
+      while (ev !== null && dead === false) {
+        handleWsMsg(c, ev.data, root)
+        ev = c.ws.receiveTimeout(0)
+      }
+      if (c.mode === "pty" && c.id !== 0) {
+        let out = ptyRead(c.id, 0)
+        if (out === null) { c.ws.close(); dead = true }
+        else if (out !== "") { if (c.ws.send(out) === false) { dead = true } }
+      }
+      if (c.mode === "watch") {
+        c.tick = c.tick + 1
+        if (c.tick >= 60) {
+          c.tick = 0
+          let sig = workspaceSignature(root)
+          if (sig !== c.lastSig) {
+            c.lastSig = sig
+            if (c.ws.send(JSON.stringify({ sig: sig })) === false) { dead = true }
+          }
+        }
+      }
+      if (dead === true) { if (c.id !== 0) { ptyKill(c.id) } } else { alive.push(c) }
+      i = i + 1
+    }
+    conns = alive
+  }
+}
+
+fn main() {
+  let root = argValue("--workspace")
+  if (root === null) { root = "." }
+  let portStr = argValue("--port")
+  let port = portStr === null ? 8799 : toInt(portStr)
+  console.log("dune-server-parity: http+ws on port " + String(port) + " workspace=" + root)
+  // The WS pump runs on its own OS thread beside the blocking serve() loop (like dune-server).
+  Promise.spawn(fn() { wsPump(root) })
+  serve(port, fn(req) {
+    if (req.path === "/health") {
+      return { status: 200, headers: { "Content-Type": "application/json" }, body: "{\"ok\":true}" }
+    }
+    if (req.path === "/rpc" && req.method === "POST") {
+      let msg = JSON.parse(req.body)
+      return { status: 200, headers: { "Content-Type": "application/json" }, body: JSON.stringify(rpcDispatch(root, msg.method)) }
+    }
+    return { status: 404, headers: { "Content-Type": "text/plain" }, body: "not found" }
+  })
+}
+
+main()

--- a/scripts/test_native_smoke.sh
+++ b/scripts/test_native_smoke.sh
@@ -64,7 +64,41 @@ fs-join: alpha-beta-gamma" \
 --feature fs --feature process
 rm -f "$FSTMP"
 
-# 3. HTTP serve — both backends (delegates to the serve smoke).
+# 3. pty app — tish:pty (Dune's remote terminal). Spawn a shell, run a command, read its OUTPUT back.
+build_run "pty" "tests/native_smoke/pty_app.tish" "" \
+"pty: ok" \
+--feature pty
+
+# 4. fs stat/readDir app — the workspace-change signature walk. Deterministic count + total size.
+STATDIR="target/native_smoke_stat_$$"
+rm -rf "$STATDIR"
+build_run "stat" "tests/native_smoke/stat_app.tish" "SMOKE_DIR=$STATDIR" \
+"stat: count=2 size=15 isdir=true" \
+--feature fs --feature process
+rm -rf "$STATDIR"
+
+# 5. HTTP→WS upgrade + wsAccept (issue #495/#496) — the transport Dune's /pty + /watch ride. Built with
+# the hyper backend; a serve()+wsAccept echo run on Promise.spawn threads while the main thread connects
+# as a WS client and asserts the echo. Its own inline check: the server logs a startup line, so this is a
+# CONTAINS check ("ws: ok" present, "ws: FAIL" absent), and TISH_HTTP_PREFORK=0 keeps it single-process so
+# the in-process client isn't forked.
+echo "──────── ws-upgrade (tests/native_smoke/ws_app.tish) ────────"
+WSBIN="target/native_smoke_ws"
+if ! TISH_HTTP_BACKEND=hyper "$TISH" build tests/native_smoke/ws_app.tish -o "$WSBIN" \
+      --target native --native-backend rust --feature http --feature http-hyper --feature ws \
+      >"$WSBIN.build.log" 2>&1; then
+  echo "  ✗ BUILD FAILED"; tail -30 "$WSBIN.build.log"; FAIL=1
+else
+  WSOUT=$(TISH_HTTP_BACKEND=hyper TISH_HTTP_PREFORK=0 "$WSBIN" 2>/dev/null)
+  if echo "$WSOUT" | grep -q "ws: ok" && ! echo "$WSOUT" | grep -q "ws: FAIL"; then
+    echo "  ✓ ws upgrade round-trip (client → serve upgrade → wsAccept echo → client)"
+  else
+    echo "  ✗ ws upgrade FAILED"; echo "$WSOUT"; FAIL=1
+  fi
+fi
+rm -f "$WSBIN" "$WSBIN.build.log"
+
+# 6. HTTP serve — both backends (delegates to the serve smoke).
 echo "──────── http serve (both backends) ────────"
 if TISH="$TISH" bash scripts/test_serve_smoke.sh; then
   echo "  ✓ serve smoke passed"
@@ -74,7 +108,7 @@ fi
 
 echo "════════════════════════════════"
 if [[ "$FAIL" == 0 ]]; then
-  echo "ALL NATIVE SMOKE TESTS PASSED (cli + fs + http×2)"
+  echo "ALL NATIVE SMOKE TESTS PASSED (cli + fs + pty + stat + ws + http×2)"
 else
   echo "NATIVE SMOKE FAILURES — see above"
 fi

--- a/tests/native_smoke/pty_app.tish
+++ b/tests/native_smoke/pty_app.tish
@@ -1,0 +1,34 @@
+// Native smoke — tish:pty (issue #493/#494). Dune's remote terminal rides this. Proves the
+// native-compiled path (codegen exports + runtime) works end to end: spawn a shell in a real
+// pseudoterminal, drive a command through it, and read the command's OUTPUT back.
+//
+// The marker is split with '' so the shell CONCATENATES it to PTYMARK_OK in the OUTPUT, while the
+// cooked-mode ECHO of the typed line keeps the quotes (PTY''MARK_OK) — so finding "PTYMARK_OK"
+// proves the shell EXECUTED, not merely echoed input.
+//
+// Build: tish build --target native --feature pty ... ; expected stdout: "pty: ok"
+
+import { spawn as ptySpawn, read as ptyRead, write as ptyWrite, kill as ptyKill } from "tish:pty"
+
+fn main() {
+  let id = ptySpawn({ program: null, cwd: ".", cols: 80, rows: 24 })
+  if (id === null || id === 0) {
+    console.log("pty: FAIL spawn")
+    return
+  }
+  ptyWrite(id, "printf 'PTY''MARK_OK\\n'\n")
+  let buf = ""
+  let i = 0
+  let seen = false
+  while (i < 400 && !seen) {
+    let out = ptyRead(id, 25) // up to 25ms per poll
+    if (out === null) { break } // process exited
+    if (out !== "") { buf = buf + out }
+    if (buf.indexOf("PTYMARK_OK") >= 0) { seen = true }
+    i = i + 1
+  }
+  ptyKill(id)
+  console.log(seen ? "pty: ok" : "pty: FAIL")
+}
+
+main()

--- a/tests/native_smoke/stat_app.tish
+++ b/tests/native_smoke/stat_app.tish
@@ -1,0 +1,30 @@
+// Native smoke — tish:fs stat + readDir + isDir. Dune's workspace-change signature walks the tree
+// with exactly these. Proves the native-compiled path: create a dir with two known-size files, list
+// it, stat each, and report count + total size (deterministic → asserted by the smoke harness).
+//
+// SMOKE_DIR must point at a FRESH empty dir (the harness makes + cleans it).
+// Build: tish build --target native --feature fs,process ... ; expected stdout: "stat: count=2 size=15 isdir=true"
+
+// stat/statSync are NOT auto-injected globals (unlike readFile/writeFile/isDir/readDir/mkdir) — import it.
+import { stat } from "tish:fs"
+
+fn main() {
+  let dir = process.env.SMOKE_DIR
+  if (typeof dir !== "string" || dir === "") { dir = "target/native_smoke_stat" }
+  mkdir(dir)
+  writeFile(dir + "/a.txt", "hello")        // 5 bytes
+  writeFile(dir + "/bb.txt", "worldworld")  // 10 bytes
+  let names = readDir(dir)
+  if (!Array.isArray(names)) { console.log("stat: FAIL readDir"); return }
+  names.sort()
+  let sizeSum = 0
+  let i = 0
+  while (i < names.length) {
+    let s = stat(dir + "/" + names[i])
+    if (s !== null && typeof s.size === "number") { sizeSum = sizeSum + s.size }
+    i = i + 1
+  }
+  console.log("stat: count=" + String(names.length) + " size=" + String(sizeSum) + " isdir=" + String(isDir(dir)))
+}
+
+main()

--- a/tests/native_smoke/ws_app.tish
+++ b/tests/native_smoke/ws_app.tish
@@ -1,0 +1,62 @@
+// Native smoke — the HTTP→WS upgrade (issue #495/#496) + tish:ws wsAccept, on the SAME port serve()
+// binds. Dune's remote terminal (/pty) and change-push (/watch) both ride this exact path. Self-contained:
+// a serve() + wsAccept echo pump run on Promise.spawn threads (as dune-server does), while the main
+// thread connects as a WebSocket client, sends a frame, and asserts the echo.
+//
+// Build: TISH_HTTP_BACKEND=hyper tish build --target native --feature http,http-hyper,ws ...
+// Run   with TISH_HTTP_BACKEND=hyper. Expected stdout: "ws: ok"
+
+import { WebSocket, wsAccept } from "tish:ws"
+
+// serve() is called from a NAMED fn (not directly inside the Promise.spawn closure): calling a captured
+// builtin inside a spawn closure that also captures a local trips a native codegen move error (E0507) —
+// tracked upstream as tishlang/tish#513. dune-server dodges it the same way (Promise.spawn calls
+// servePtyPump, never a builtin directly).
+fn runServer(port) {
+  serve(port, fn(req) {
+    return { status: 404, headers: { "Content-Type": "text/plain" }, body: "not found" }
+  })
+}
+
+fn wsEchoPump() {
+  let conns = []
+  while (true) {
+    let ws = wsAccept(20)
+    if (ws !== null) { conns.push(ws) }
+    let i = 0
+    while (i < conns.length) {
+      let c = conns[i]
+      let ev = c.receiveTimeout(0)
+      while (ev !== null) {
+        c.send(ev.data) // echo it straight back
+        ev = c.receiveTimeout(0)
+      }
+      i = i + 1
+    }
+  }
+}
+
+fn main() {
+  let port = 8790
+  // serve() blocks forever → its own thread; it auto-completes the WS handshake and queues the socket
+  // to wsAccept (drained by the echo pump on a second thread). Exactly the dune-server shape.
+  Promise.spawn(fn() { runServer(port) })
+  Promise.spawn(fn() { wsEchoPump() })
+
+  // Retry the connect until the server has bound (WebSocket() returns null on connection-refused).
+  let client = null
+  let tries = 0
+  while (client === null && tries < 400) {
+    client = WebSocket("ws://127.0.0.1:" + String(port) + "/pty")
+    tries = tries + 1
+  }
+  if (client === null) {
+    console.log("ws: FAIL connect")
+    return
+  }
+  client.send("PINGPONG")
+  let reply = client.receiveTimeout(3000) // bounded so a lost echo can't hang CI
+  console.log(reply !== null && reply.data === "PINGPONG" ? "ws: ok" : "ws: FAIL echo")
+}
+
+main()


### PR DESCRIPTION
Splitting this out of #511 (it was committed while the JIT branch was checked out) so the dune-server suite and its new CI workflow land as their own reviewable unit with their own checks.

From the commit message: Dune's headless backend (dune-ide apps/dune-server) is one native tish binary built `--feature http,http-hyper,fs,process,ws,pty` with `TISH_HTTP_BACKEND=hyper`. Several primitives it rides — the HTTP→WS upgrade + `tish:ws` wsAccept, `tish:pty`, `Promise.spawn` beside a blocking `serve()` — are native-target only. The suite builds and drives a representative server (`regression/dune-server/`): a signature that moves on a file edit (fs stat/readDir), `git_head` (`process.execFileCapture`), a `/pty` WS echoing a command over the upgrade, and a `/watch` WS pushing a changed signature (`Promise.spawn` pump). `run.sh` builds + drives + asserts; the CI workflow triggers on `tish_runtime`/`tish_compile` changes. Also adds the real dune-server as a local-only downstream build guard (`repos.tsv`). Verified locally: 6/6 pass.