### PR TITLE
fix(native): clone-hoist serve/Boolean in arrow closures — E0507 in spawn closures

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -9960,7 +9960,14 @@ impl Codegen {
             }
         }
         // Only clone builtins that are actually referenced (clone so outer scope can still use, e.g. process for PORT)
+        // #513: every name on the BUILTINS skip-list below MUST also be clone-hoisted here (or
+        // lower as a constant, like Infinity/NaN). A name skipped by the implicit env-capture
+        // fallback but NOT hoisted is referenced raw inside the `move` closure — which MOVES it
+        // out of the enclosing `Fn` closure's capture (E0507: `serve`/`Boolean` in any nested
+        // value-closure that also captures a local, e.g. a `Promise.spawn(fn() { serve(port, …) })`).
         for builtin in &[
+            "Boolean",
+            "serve",
             "console",
             "Math",
             "JSON",

--- a/tests/core/parity_closure_builtin_capture.js
+++ b/tests/core/parity_closure_builtin_capture.js
@@ -1,0 +1,22 @@
+// #513: a nested value-closure that captures a LOCAL and also references a clone-hoisted
+// BUILTIN must compile natively. The arrow emitter's implicit-capture skip-list (BUILTINS)
+// contained names its clone-hoist list lacked (`Boolean`, `serve`) — those were referenced raw
+// inside the `move` closure, MOVING them out of the enclosing `Fn` closure (E0507) whenever a
+// captured local forced real capture context. Boolean is the default-features member of that
+// set, so this fixture locks the class corpus-wide; the `serve` shape is covered by the serve
+// smoke suite. Identical output across interp/vm/native + node.
+
+function main() {
+  let x = 1
+  let flag = function() { return Boolean(x) }
+  console.log(flag())
+
+  // two levels + both a local and a builtin at each level
+  let outer = function() {
+    let y = 0
+    let inner = function() { return Boolean(y) }
+    return Boolean(x) && !inner()
+  }
+  console.log(outer())
+}
+main()

--- a/tests/core/parity_closure_builtin_capture.tish
+++ b/tests/core/parity_closure_builtin_capture.tish
@@ -1,0 +1,22 @@
+// #513: a nested value-closure that captures a LOCAL and also references a clone-hoisted
+// BUILTIN must compile natively. The arrow emitter's implicit-capture skip-list (BUILTINS)
+// contained names its clone-hoist list lacked (`Boolean`, `serve`) — those were referenced raw
+// inside the `move` closure, MOVING them out of the enclosing `Fn` closure (E0507) whenever a
+// captured local forced real capture context. Boolean is the default-features member of that
+// set, so this fixture locks the class corpus-wide; the `serve` shape is covered by the serve
+// smoke suite. Identical output across interp/vm/native + node.
+
+fn main() {
+  let x = 1
+  let flag = fn() { return Boolean(x) }
+  console.log(flag())
+
+  // two levels + both a local and a builtin at each level
+  let outer = fn() {
+    let y = 0
+    let inner = fn() { return Boolean(y) }
+    return Boolean(x) && !inner()
+  }
+  console.log(outer())
+}
+main()

--- a/tests/core/parity_closure_builtin_capture.tish.expected
+++ b/tests/core/parity_closure_builtin_capture.tish.expected
@@ -1,0 +1,2 @@
+true
+true

--- a/tests/main.js
+++ b/tests/main.js
@@ -3690,6 +3690,31 @@ console.log("method-call", o.greet())
 }
 
 {
+// #513: a nested value-closure that captures a LOCAL and also references a clone-hoisted
+// BUILTIN must compile natively. The arrow emitter's implicit-capture skip-list (BUILTINS)
+// contained names its clone-hoist list lacked (`Boolean`, `serve`) — those were referenced raw
+// inside the `move` closure, MOVING them out of the enclosing `Fn` closure (E0507) whenever a
+// captured local forced real capture context. Boolean is the default-features member of that
+// set, so this fixture locks the class corpus-wide; the `serve` shape is covered by the serve
+// smoke suite. Identical output across interp/vm/native + node.
+
+function main() {
+  let x = 1
+  let flag = function() { return Boolean(x) }
+  console.log(flag())
+
+  // two levels + both a local and a builtin at each level
+  let outer = function() {
+    let y = 0
+    let inner = function() { return Boolean(y) }
+    return Boolean(x) && !inner()
+  }
+  console.log(outer())
+}
+main()
+}
+
+{
 // Cross-backend parity probe for the classic divergence sources between compilation targets:
 // typeof, value-to-string coercion, nullish/absent reads, numeric formatting, and equality edges.
 // Every backend (interp/vm/native/cranelift/llvm/wasi) and node must agree. Valid in tish and node.

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3746,6 +3746,32 @@ console.log("method-call", o.greet())
 }
 __perf_run_core_parity_call_non_function_catchable()
 
+fn __perf_run_core_parity_closure_builtin_capture() {
+// #513: a nested value-closure that captures a LOCAL and also references a clone-hoisted
+// BUILTIN must compile natively. The arrow emitter's implicit-capture skip-list (BUILTINS)
+// contained names its clone-hoist list lacked (`Boolean`, `serve`) — those were referenced raw
+// inside the `move` closure, MOVING them out of the enclosing `Fn` closure (E0507) whenever a
+// captured local forced real capture context. Boolean is the default-features member of that
+// set, so this fixture locks the class corpus-wide; the `serve` shape is covered by the serve
+// smoke suite. Identical output across interp/vm/native + node.
+
+fn main() {
+  let x = 1
+  let flag = fn() { return Boolean(x) }
+  console.log(flag())
+
+  // two levels + both a local and a builtin at each level
+  let outer = fn() {
+    let y = 0
+    let inner = fn() { return Boolean(y) }
+    return Boolean(x) && !inner()
+  }
+  console.log(outer())
+}
+main()
+}
+__perf_run_core_parity_closure_builtin_capture()
+
 fn __perf_run_core_parity_coercion() {
 // Cross-backend parity probe for the classic divergence sources between compilation targets:
 // typeof, value-to-string coercion, nullish/absent reads, numeric formatting, and equality edges.


### PR DESCRIPTION
## Summary

Fixes #513 — on the native target, `Promise.spawn(fn() { serve(port, …) })` with a captured local failed with `E0507: cannot move out of 'serve', a captured variable in an 'Fn' closure`.

## Root cause

The arrow/value-closure emitter keeps two builtin lists that must agree:
- the **`BUILTINS` skip-list** — names the implicit env-capture fallback must not `_ref`-capture, and
- the **clone-hoist list** — names re-bound via `let X = X.clone();` inside the closure block before `Value::native(move …)`.

`serve` and `Boolean` were on the skip-list but **missing from the hoist list**, so a nested closure referencing them got *neither* treatment: the raw identifier inside the `move` closure moved the builtin out of the enclosing `Fn` closure's capture. The FunDecl emitter's hoist list already had `serve` — which is exactly why only the nested/arrow shape (the `Promise.spawn` closure Dune hits) broke — and `fetch` was immune because it's on *neither* list and rides the borrow-based implicit `_ref` path.

## Triage findings folded in

- **`Boolean` reproduces identically** (default features, no http needed).
- **`Promise.spawn` is irrelevant** — any nested value-closure with a captured local triggers it (`let g = fn() { serve(port, …) }` inside a fn).
- Scope is exactly the skip-list∖hoist-list set: `{serve, Boolean}` (the other skip-only names, `Infinity`/`NaN`, lower as constants and never reference the ident).

## Fix

Add the two fall-through names to the arrow emitter's clone-hoist list, with a comment stating the invariant (every skip-list name must be hoisted or constant-lowered).

## Validation

- The issue's exact repro, the `Boolean` variant, and the plain-nested variant all **build**, and the spawned `serve` actually serves (`curl` → handler's "ok").
- New default-features `tests/core/parity_closure_builtin_capture` fixture locks the bug class corpus-wide via its `Boolean` member — byte-identical across interp/vm/native/node — so the native AOT batch gates it on every PR; the `serve` shape is additionally covered by the serve smoke and (once merged) the #512 dune-server suite.
- Full battery: compile lib 67/67; interpreter, interp==vm, JS-oracle, native-AOT-batch suites green; parity gate **101/0**; bundle regenerated, strict native build runs exit 0.