### PR TITLE
fix(native): fused-reduce NumberArray arm — packed Float64Array.reduce returned init

### DIFF
--- a/.github/workflows/packed-arrays.yml
+++ b/.github/workflows/packed-arrays.yml
@@ -26,6 +26,8 @@ on:
       - "crates/tish_core/**"
       - "crates/tish_vm/**"
       - "crates/tish_builtins/**"
+      # #508 lived in codegen's fused-HOF emission — native codegen is in the flag's blast radius.
+      - "crates/tish_compile/**"
       - "scripts/packed_arrays_parity_check.sh"
       - ".github/workflows/packed-arrays.yml"
   pull_request:
@@ -33,6 +35,8 @@ on:
       - "crates/tish_core/**"
       - "crates/tish_vm/**"
       - "crates/tish_builtins/**"
+      # #508 lived in codegen's fused-HOF emission — native codegen is in the flag's blast radius.
+      - "crates/tish_compile/**"
       - "scripts/packed_arrays_parity_check.sh"
       - ".github/workflows/packed-arrays.yml"
   workflow_dispatch:

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -22293,16 +22293,25 @@ impl Codegen {
             None
         };
         if let Some(nat_op) = nat_op {
+            // #508: a packed `Value::NumberArray` receiver (e.g. `new Float64Array([…])` under
+            // TISH_PACKED_ARRAYS=1) must fold too — the old `if let Value::Array … else init`
+            // silently returned the INIT for it. Its elements are raw f64 by construction, so the
+            // packed arm is the pure-f64 fold with zero boxing; a non-Number init falls back to
+            // the boxed fold over `Value::Number` elements (identical semantics).
             return Ok(Some(format!(
                 "{{ let _init0 = {init}; let _arr = ({obj}).clone(); \
-                 if let Value::Array(ref _a) = _arr {{ let _b = _a.borrow(); \
+                 match _arr {{ Value::Array(ref _a) => {{ let _b = _a.borrow(); \
                  let mut _accn: f64 = 0.0; let mut _ok = false; \
                  if let Value::Number(_i0) = &_init0 {{ _accn = *_i0; _ok = true; }} \
                  if _ok {{ for _el in _b.iter() {{ \
                  if let Value::Number(_n) = _el {{ _accn {nat_op} *_n; }} else {{ _ok = false; break; }} }} }} \
                  if _ok {{ Value::Number(_accn) }} \
                  else {{ let mut _acc = _init0; for _el in _b.iter() {{ let _x = _el.clone(); _acc = {body}; }} _acc }} \
-                 }} else {{ _init0 }} }}",
+                 }}, Value::NumberArray(ref _a) => {{ let _b = _a.borrow(); \
+                 if let Value::Number(_i0) = &_init0 {{ let mut _accn: f64 = *_i0; \
+                 for _n in _b.iter() {{ _accn {nat_op} *_n; }} Value::Number(_accn) }} \
+                 else {{ let mut _acc = _init0; for _n in _b.iter() {{ let _x = Value::Number(*_n); _acc = {body}; }} _acc }} \
+                 }}, _ => _init0 }} }}",
                 init = initial,
                 obj = obj_expr,
                 nat_op = nat_op,
@@ -22310,10 +22319,13 @@ impl Codegen {
             )));
         }
 
+        // #508: same NumberArray arm for the general (non-arithmetic-op) fold.
         Ok(Some(format!(
             "{{ let mut _acc = {init}; let _arr = ({obj}).clone(); \
-             if let Value::Array(ref _a) = _arr {{ for _el in _a.borrow().iter() {{ \
-             let _x = _el.clone(); _acc = {body}; }} }} _acc }}",
+             match _arr {{ Value::Array(ref _a) => {{ for _el in _a.borrow().iter() {{ \
+             let _x = _el.clone(); _acc = {body}; }} }} \
+             Value::NumberArray(ref _a) => {{ for _n in _a.borrow().iter() {{ \
+             let _x = Value::Number(*_n); _acc = {body}; }} }} _ => {{}} }} _acc }}",
             init = initial,
             obj = obj_expr,
             body = body_code

--- a/scripts/packed_arrays_parity_check.sh
+++ b/scripts/packed_arrays_parity_check.sh
@@ -56,9 +56,10 @@ object_stress objects_perf string_methods_perf recursion_stress jit_probe jit_re
 # reported and counted separately, not failed — but the default flip stays blocked until this
 # list is empty (see #199). Filed 2026-07-17 by the first full sweep:
 #   #502 fill no-op · #503 for..in empty · #504 delete leaves value · #505 unshift corruption
-#   #506 splice removed-values wrong · #507 flat misses packed inners · #508 native F64A.reduce
+#   #506 splice removed-values wrong · #507 flat misses packed inners
+#   (#508 native F64A.reduce — FIXED: fused-reduce NumberArray arm)
 KNOWN_DIVERGENCES="array_fill:#502 parity_builtins:#503 delete_operator:#504 \
-array_methods:#505 array_sort_splice:#506 higher_order_methods:#507 typed_arrays:#508"
+array_methods:#505 array_sort_splice:#506 higher_order_methods:#507"
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT


### PR DESCRIPTION
## Summary

Fixes #508 — on the native target with `TISH_PACKED_ARRAYS=1`, `new Float64Array([1,2,3,4]).reduce((a,b)=>a+b, 0)` returned `0` (the init) instead of `10`.

## Root cause

Both `try_fused_reduce` templates (the default-on native fold for `arr.reduce((acc,x) => acc OP x, init)`) guarded the receiver with `if let Value::Array(…) { fold } else { init }`. A packed **`Value::NumberArray`** receiver — exactly what the flag-on `Float64Array` constructor builds (`float64_array_with`) — fell into the `else` and silently produced the init.

Why the blast radius was so narrow (triage probes): the shared `builtins::reduce` has a packed fast path (**VM fine**); the general HOF chain fusion materializes via `array_snapshot_values` (**`.map().reduce()` fine**); `Int32Array` stays boxed-`Array`-backed (**fine**). Only the direct fused-reduce on a `NumberArray`, natively, hit the hole.

## Fix

Both templates become a `match` with a `NumberArray` arm:
- the arithmetic-op template folds the **raw `Vec<f64>` directly** for a `Number` init — zero boxing, actually faster than the boxed arm — and falls back to the boxed fold over `Value::Number` elements for a non-Number init (identical semantics);
- the general template threads `Value::Number(x)` through the inlined body.
- Non-array receivers keep the existing return-init behavior (pre-existing, unchanged, noted for a possible future TypeError alignment).

## Bookkeeping

- `typed_arrays` removed from the packed sweep's `KNOWN_DIVERGENCES` — full sweep now **156/162 corpus + 6 known + 0 new**, perf checksums **30/30** (fresh local run).
- `crates/tish_compile/**` added to the packed-arrays workflow's path filter: this bug proves native codegen's fused emission is inside the flag's blast radius, so codegen PRs now trigger the sweep.

## Validation

- Repro binary flag-on == flag-off (`10 / 4 / 5 6 / 12 / 6`).
- All `tishlang_compile` test suites green, including the fused-emission `perf_codegen` assertions.
- Interpreter, interp==vm stdout parity, and native AOT batch suites green.

1 down, 6 to go on the #199 KNOWN list (#502–#507 are all VM-side packed method gaps).