### PR TITLE
ci(packed): trim KNOWN list to the #506 rep boundary (6 of 7 fixed)

### DIFF
--- a/.github/workflows/packed-arrays.yml
+++ b/.github/workflows/packed-arrays.yml
@@ -8,12 +8,13 @@
 #     divergences may be allowlisted in the script's KNOWN_DIVERGENCES).
 #   * nextest — the tishlang + tishlang_vm unit/integration suites with TISH_PACKED_ARRAYS=1 in
 #     the env, so the packed representation is exercised by the whole test corpus, not only the
-#     builtins/VM unit tests. workflow_dispatch-ONLY until the divergences the first sweep filed
-#     (#502-#508) are fixed: the interp==vm corpus parity test fails on exactly those fixtures
-#     with the flag on (verified 2026-07-17; the vm + builtins UNIT suites pass), and the sweep
-#     job already reports them as KNOWN. Flip this job onto pull_request when the known list in
-#     scripts/packed_arrays_parity_check.sh empties — it then becomes the #199 acceptance gate
-#     "nextest passes with TISH_PACKED_ARRAYS=1".
+#     builtins/VM unit tests. workflow_dispatch-ONLY: six of the first sweep's seven divergences
+#     are fixed (#502/#503/#504/#505/#507 via #517/#518, #508 via #516), but the interp==vm corpus
+#     parity test still fails on the ONE remaining KNOWN — #506, splice() with non-numeric inserts,
+#     which is the packed-array REPRESENTATION boundary (a NumberArray can't go heterogeneous
+#     without a receiver-deopt protocol), not a fixable method bug. Flip this job onto pull_request
+#     when the KNOWN list in scripts/packed_arrays_parity_check.sh empties (i.e. #506 is resolved) —
+#     it then becomes the #199 acceptance gate "nextest passes with TISH_PACKED_ARRAYS=1".
 #
 # Path-filtered to the crates that own the packed representation (+ this tooling): the sweep
 # builds every fixture natively, which is too heavy for every PR.

--- a/scripts/packed_arrays_parity_check.sh
+++ b/scripts/packed_arrays_parity_check.sh
@@ -54,12 +54,15 @@ object_stress objects_perf string_methods_perf recursion_stress jit_probe jit_re
 
 # Fixtures with a KNOWN, FILED flag-on divergence (format: "name:#issue"). A known fixture is
 # reported and counted separately, not failed — but the default flip stays blocked until this
-# list is empty (see #199). Filed 2026-07-17 by the first full sweep:
-#   #502 fill no-op · #503 for..in empty · #504 delete leaves value · #505 unshift corruption
-#   #506 splice removed-values wrong · #507 flat misses packed inners
-#   (#508 native F64A.reduce — FIXED: fused-reduce NumberArray arm)
-KNOWN_DIVERGENCES="array_fill:#502 parity_builtins:#503 delete_operator:#504 \
-array_methods:#505 array_sort_splice:#506 higher_order_methods:#507"
+# list is empty (see #199). The first full sweep (2026-07-17) filed 7; six were clean builtins /
+# VM gaps and are fixed (#502 fill, #503 for..in/Object.keys, #504 delete, #505 concat, #507 flat
+# — #517/#518; #508 native fused-reduce — #516). The one that remains is the packed-array
+# REPRESENTATION boundary, not a method bug:
+#   #506 — splice() with non-numeric inserts (`arr.splice(1,3,"a","b")`) must make the array
+#          heterogeneous, but a NumberArray (VmRef<Vec<f64>>) can't hold strings and no method can
+#          rebind its receiver's slot to a boxed Array. Blocks the default flip until a
+#          receiver-deopt protocol lands or the semantics are decided.
+KNOWN_DIVERGENCES="array_sort_splice:#506"
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT


### PR DESCRIPTION
## Summary

Follow-up to the packed-array divergence drawdown. The first #199 sweep filed 7 divergences; **6 are now merged as fixed**, leaving only the representation boundary:

| issue | fix |
|---|---|
| #508 native `Float64Array.reduce` | #516 |
| #503 `for..in` / `Object.keys` on packed | #517 |
| #505 packed `concat` arg not spread | #517 |
| #507 packed inner not `flat`-tened | #517 |
| #502 packed `fill` silent no-op | #518 |
| #504 packed `delete` no-op | #518 |
| **#506 splice w/ non-numeric inserts** | — (rep boundary, [analysis](https://github.com/tishlang/tish/issues/506#issuecomment-5007478090)) |

## Changes

- `scripts/packed_arrays_parity_check.sh`: `KNOWN_DIVERGENCES` trimmed from 7 entries to just `array_sort_splice:#506`, with the comment rewritten to record where each fix landed and why #506 is the one that remains.
- `.github/workflows/packed-arrays.yml`: the nextest-with-flag job's comment now names #506 as the single blocker keeping it `workflow_dispatch`-only (the flag-on interp==vm corpus parity test still fails on #506; the job flips to a PR gate when #506 is resolved).

## Validation

Fresh local sweep: **corpus 161/162 flag-on == flag-off, 1 known (#506), 0 new; perf checksums 30/30 flag-on == flag-off == node.** shellcheck clean, YAML valid.

The packed default flip stays correctly blocked on #506.