### PR TITLE
fix(packed-arrays): sound in-place deopt for NumberArray backing (#199, #506)

### DIFF
--- a/.github/workflows/packed-arrays.yml
+++ b/.github/workflows/packed-arrays.yml
@@ -8,12 +8,11 @@
 #     divergences may be allowlisted in the script's KNOWN_DIVERGENCES).
 #   * nextest — the tishlang + tishlang_vm unit/integration suites with TISH_PACKED_ARRAYS=1 in
 #     the env, so the packed representation is exercised by the whole test corpus, not only the
-#     builtins/VM unit tests. workflow_dispatch-ONLY until the divergences the first sweep filed
-#     (#502-#508) are fixed: the interp==vm corpus parity test fails on exactly those fixtures
-#     with the flag on (verified 2026-07-17; the vm + builtins UNIT suites pass), and the sweep
-#     job already reports them as KNOWN. Flip this job onto pull_request when the known list in
-#     scripts/packed_arrays_parity_check.sh empties — it then becomes the #199 acceptance gate
-#     "nextest passes with TISH_PACKED_ARRAYS=1".
+#     builtins/VM unit tests. This is the #199 acceptance gate "nextest passes with
+#     TISH_PACKED_ARRAYS=1". It ran workflow_dispatch-ONLY until the divergences the first sweep
+#     filed (#502-#508) were fixed by the sound in-place deopt backing; with the sweep's KNOWN
+#     list now empty (corpus 162/162, perf 30/30 flag-on == flag-off == node) and the full suite
+#     verified green with the flag on (2026-07-17), it now runs on pull_request / push.
 #
 # Path-filtered to the crates that own the packed representation (+ this tooling): the sweep
 # builds every fixture natively, which is too heavy for every PR.
@@ -81,8 +80,8 @@ jobs:
 
   nextest:
     name: Unit/integration suites with TISH_PACKED_ARRAYS=1
-    # See header — manual until #502-#508 are fixed and the sweep's KNOWN list is empty.
-    if: github.event_name == 'workflow_dispatch'
+    # #199 acceptance gate — live on PR/push now that the KNOWN list is empty (#502-#508 fixed by
+    # the sound in-place deopt backing). See header.
     runs-on: blacksmith-4vcpu-ubuntu-2204
     env:
       RUSTC_WRAPPER: sccache

--- a/crates/tish_builtins/src/array.rs
+++ b/crates/tish_builtins/src/array.rs
@@ -18,7 +18,7 @@ pub fn from_vec(v: Vec<Value>) -> Value {
 pub fn snapshot_values(arr: &Value) -> Vec<Value> {
     match arr {
         Value::Array(a) => a.borrow().clone(),
-        Value::NumberArray(a) => a.borrow().iter().map(|&n| Value::Number(n)).collect(),
+        Value::NumberArray(a) => a.borrow().to_values(),
         _ => Vec::new(),
     }
 }
@@ -30,19 +30,24 @@ pub fn snapshot_values(arr: &Value) -> Vec<Value> {
 /// unboxed f64 fast path for it too. The `None` result drives the fused lowering back to its boxed
 /// loop, so any non-numeric element is handled with identical `Value` semantics.
 pub fn as_f64_snapshot(arr: &Value) -> Option<Vec<f64>> {
-    match arr {
-        Value::NumberArray(a) => Some(a.borrow().clone()),
-        Value::Array(a) => {
-            let b = a.borrow();
-            let mut out: Vec<f64> = Vec::with_capacity(b.len());
-            for v in b.iter() {
-                match v {
-                    Value::Number(n) => out.push(*n),
-                    _ => return None,
-                }
+    let extract = |vals: &[Value]| -> Option<Vec<f64>> {
+        let mut out: Vec<f64> = Vec::with_capacity(vals.len());
+        for v in vals {
+            match v {
+                Value::Number(n) => out.push(*n),
+                _ => return None,
             }
-            Some(out)
         }
+        Some(out)
+    };
+    match arr {
+        // Still packed: clone the f64s directly. Deopted: extract from the boxed values (None if
+        // any is non-numeric — the caller then uses the boxed path).
+        Value::NumberArray(a) => match a.borrow().as_packed() {
+            Some(v) => Some(v.clone()),
+            None => extract(a.borrow().as_boxed().map(|v| v.as_slice()).unwrap_or(&[])),
+        },
+        Value::Array(a) => extract(&a.borrow()),
         _ => None,
     }
 }
@@ -81,7 +86,9 @@ fn packed_snapshot<'c>(
     callback: &'c Value,
 ) -> Option<(Vec<f64>, &'c tishlang_core::NativeFn)> {
     match (arr, callback) {
-        (Value::NumberArray(na), Value::Function(cb)) => Some((na.borrow().clone(), cb)),
+        (Value::NumberArray(na), Value::Function(cb)) => {
+            na.borrow().as_packed().map(|v| (v.clone(), cb))
+        }
         _ => None,
     }
 }
@@ -409,9 +416,7 @@ pub fn concat(arr: &Value, args: &[Value]) -> Value {
                 // A packed `NumberArray` arg spreads its numbers, same as a boxed array — under
                 // TISH_PACKED_ARRAYS=1 a numeric literal `[3,4]` is a NumberArray, so
                 // `[1,2].concat([3,4])` must flatten to `[1,2,3,4]`, not push the array whole.
-                Value::NumberArray(other) => {
-                    result.extend(other.borrow().iter().map(|n| Value::Number(*n)))
-                }
+                Value::NumberArray(other) => result.extend(other.borrow().to_values()),
                 _ => result.push(v.clone()),
             }
         }
@@ -435,9 +440,7 @@ pub fn flat(arr: &Value, depth: &Value) -> Value {
                     // flattened elements) — `[[1,2],[3,4]].flat()` where the inners packed must not
                     // leave a `NumberArray` sitting as a scalar element.
                     Value::NumberArray(inner) => {
-                        for n in inner.borrow().iter() {
-                            result.push(Value::Number(*n));
-                        }
+                        result.extend(inner.borrow().to_values());
                         continue;
                     }
                     _ => {}
@@ -978,13 +981,15 @@ pub fn sort_numeric_desc(arr: &Value) -> Value {
 fn sort_numeric_impl(arr: &Value, asc: bool) -> Value {
     // NumberArray fast path: sort the Vec<f64> directly — no unbox pass, no rebox.
     if let Value::NumberArray(a) = arr {
-        let mut g = a.borrow_mut();
-        if asc {
-            g.sort_unstable_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
-        } else {
-            g.sort_unstable_by(|x, y| y.partial_cmp(x).unwrap_or(std::cmp::Ordering::Equal));
+        // Fast path only while still packed; a deopted numeric array sorts via the boxed path below.
+        if let Some(nums) = a.borrow_mut().as_packed_mut() {
+            if asc {
+                nums.sort_unstable_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
+            } else {
+                nums.sort_unstable_by(|x, y| y.partial_cmp(x).unwrap_or(std::cmp::Ordering::Equal));
+            }
+            return Value::NumberArray(a.clone());
         }
-        return Value::NumberArray(a.clone());
     }
     if let Value::Array(a) = arr {
         {
@@ -1142,15 +1147,15 @@ mod packed_hof_tests {
     //! on it. These run with packing semantics directly (the helpers don't read the env flag; a
     //! `NumberArray` value is enough to take the fast path).
     use super::*;
-    use tishlang_core::Value;
+    use tishlang_core::{NumArrayBacking, Value};
 
     fn na(xs: &[f64]) -> Value {
-        Value::NumberArray(VmRef::new(xs.to_vec()))
+        Value::NumberArray(VmRef::new(NumArrayBacking::Packed(xs.to_vec())))
     }
     fn nums(v: &Value) -> Vec<f64> {
         match v {
             Value::Array(a) => a.borrow().iter().map(|e| e.as_number().unwrap_or(f64::NAN)).collect(),
-            Value::NumberArray(a) => a.borrow().clone(),
+            Value::NumberArray(a) => a.borrow().to_values().iter().map(|e| e.as_number().unwrap_or(f64::NAN)).collect(),
             _ => vec![],
         }
     }

--- a/crates/tish_builtins/src/collections.rs
+++ b/crates/tish_builtins/src/collections.rs
@@ -226,7 +226,7 @@ fn same_value_zero(a: &Value, b: &Value) -> bool {
 fn iter_elements(v: &Value) -> Vec<Value> {
     match v {
         Value::Array(a) => a.borrow().iter().cloned().collect(),
-        Value::NumberArray(a) => a.borrow().iter().map(|n| Value::Number(*n)).collect(),
+        Value::NumberArray(a) => a.borrow().to_values(),
         _ => Vec::new(),
     }
 }

--- a/crates/tish_builtins/src/globals.rs
+++ b/crates/tish_builtins/src/globals.rs
@@ -79,7 +79,7 @@ pub fn array_from(args: &[Value]) -> Value {
     let source = args.first().cloned().unwrap_or(Value::Null);
     let items: Vec<Value> = match &source {
         Value::Array(a) => a.borrow().clone(),
-        Value::NumberArray(a) => a.borrow().iter().map(|n| Value::Number(*n)).collect(),
+        Value::NumberArray(a) => a.borrow().to_values(),
         // `drain_iterator` covers String (chars), Set/Map, and any iterator object.
         other => {
             if let Some(d) = tishlang_core::drain_iterator(other) {

--- a/crates/tish_builtins/src/typedarrays.rs
+++ b/crates/tish_builtins/src/typedarrays.rs
@@ -93,7 +93,7 @@ fn bytes_per_element(kind: Kind) -> f64 {
 fn elements(value: &Value) -> Vec<Value> {
     match value {
         Value::Array(a) => a.borrow().clone(),
-        Value::NumberArray(a) => a.borrow().iter().map(|n| Value::Number(*n)).collect(),
+        Value::NumberArray(a) => a.borrow().to_values(),
         _ => Vec::new(),
     }
 }
@@ -291,6 +291,7 @@ mod tests {
         match &packed {
             Value::NumberArray(a) => {
                 let v = a.borrow();
+                let v = v.as_packed().expect("packed backing");
                 assert_eq!(v[0], 1.1);
                 assert_eq!(v[1], 2.2);
                 assert!(v[2].is_nan());

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -742,7 +742,9 @@ pub fn compile_with_native_modules_emit(
     g.has_native_ui_host = native_modules.iter().any(|m| {
         m.package_name == "tish-macos"
             || m.package_name == "tish-ios"
+            || m.crate_name == "tish_macos"
             || m.crate_name == "tishlang_macos"
+            || m.crate_name == "tish_ios"
             || m.crate_name == "tishlang_ios"
     });
     g.emit_program(&program)?;
@@ -5058,10 +5060,10 @@ impl Codegen {
                     // re-boxing each element to `Value::Number` for the loop body.
                     self.writeln("Value::NumberArray(ref _arr) => {");
                     self.indent += 1;
-                    self.writeln("for _v in _arr.borrow().iter() {");
+                    self.writeln("for _v in _arr.borrow().to_values() {");
                     self.indent += 1;
                     self.writeln(&format!(
-                        "let {} = Value::Number(*_v);",
+                        "let {} = _v;",
                         Self::escape_ident(name.as_ref())
                     ));
                     self.emit_statement(body)?;
@@ -5895,7 +5897,7 @@ impl Codegen {
                                 // `arr[oob]`→NaN) is unreachable for sound inputs but never panics.
                                 self.writeln(&format!(
                                     "let mut {}: Vec<f64> = match args.get({}) {{ \
-                                       Some(Value::NumberArray(a)) => a.borrow().clone(), \
+                                       Some(Value::NumberArray(a)) => a.borrow().to_values().iter().map(|v| match v {{ Value::Number(n) => *n, _ => f64::NAN }}).collect(), \
                                        Some(Value::Array(arr)) => arr.borrow().iter().map(|v| match v {{ Value::Number(n) => *n, _ => f64::NAN }}).collect(), \
                                        _ => Vec::new() }};",
                                     Self::escape_ident(tp.name.as_ref()),
@@ -15064,7 +15066,7 @@ impl Codegen {
 
     fn module_const_f64_array_as_value(static_name: &str) -> String {
         format!(
-            "Value::NumberArray(VmRef::new({}.iter().copied().collect::<Vec<f64>>()))",
+            "Value::NumberArray(VmRef::new(tishlang_runtime::NumArrayBacking::Packed({}.iter().copied().collect::<Vec<f64>>())))",
             static_name
         )
     }
@@ -22307,10 +22309,10 @@ impl Codegen {
                  if let Value::Number(_n) = _el {{ _accn {nat_op} *_n; }} else {{ _ok = false; break; }} }} }} \
                  if _ok {{ Value::Number(_accn) }} \
                  else {{ let mut _acc = _init0; for _el in _b.iter() {{ let _x = _el.clone(); _acc = {body}; }} _acc }} \
-                 }}, Value::NumberArray(ref _a) => {{ let _b = _a.borrow(); \
-                 if let Value::Number(_i0) = &_init0 {{ let mut _accn: f64 = *_i0; \
-                 for _n in _b.iter() {{ _accn {nat_op} *_n; }} Value::Number(_accn) }} \
-                 else {{ let mut _acc = _init0; for _n in _b.iter() {{ let _x = Value::Number(*_n); _acc = {body}; }} _acc }} \
+                 }}, Value::NumberArray(ref _a) => {{ let _vals = _a.borrow().to_values(); \
+                 if let (true, Value::Number(_i0)) = (_a.borrow().as_packed().is_some(), &_init0) {{ let mut _accn: f64 = *_i0; \
+                 for _v in &_vals {{ if let Value::Number(_n) = _v {{ _accn {nat_op} *_n; }} }} Value::Number(_accn) }} \
+                 else {{ let mut _acc = _init0; for _x in _vals {{ _acc = {body}; }} _acc }} \
                  }}, _ => _init0 }} }}",
                 init = initial,
                 obj = obj_expr,
@@ -22324,8 +22326,8 @@ impl Codegen {
             "{{ let mut _acc = {init}; let _arr = ({obj}).clone(); \
              match _arr {{ Value::Array(ref _a) => {{ for _el in _a.borrow().iter() {{ \
              let _x = _el.clone(); _acc = {body}; }} }} \
-             Value::NumberArray(ref _a) => {{ for _n in _a.borrow().iter() {{ \
-             let _x = Value::Number(*_n); _acc = {body}; }} }} _ => {{}} }} _acc }}",
+             Value::NumberArray(ref _a) => {{ for _x in _a.borrow().to_values() {{ \
+             _acc = {body}; }} }} _ => {{}} }} _acc }}",
             init = initial,
             obj = obj_expr,
             body = body_code
@@ -22818,7 +22820,7 @@ impl Codegen {
                     "let mut __out: Vec<f64> = Vec::new(); \
                      for &__f0 in __na.iter() {{ let mut __f = __f0; {inner} \
                      let {p}: f64 = __f; __out.push({term}); }} \
-                     Value::NumberArray(VmRef::new(__out))",
+                     Value::NumberArray(VmRef::new(tishlang_runtime::NumArrayBacking::Packed(__out)))",
                     inner = inner, p = pesc, term = term
                 )
             }
@@ -22830,7 +22832,7 @@ impl Codegen {
                     "let mut __out: Vec<f64> = Vec::new(); \
                      for &__f0 in __na.iter() {{ let mut __f = __f0; {inner} \
                      let {p}: f64 = __f; if {pred} {{ __out.push({p}); }} }} \
-                     Value::NumberArray(VmRef::new(__out))",
+                     Value::NumberArray(VmRef::new(tishlang_runtime::NumArrayBacking::Packed(__out)))",
                     inner = inner, p = pesc, pred = pred
                 )
             }

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -5897,7 +5897,9 @@ impl Codegen {
                                 // `arr[oob]`→NaN) is unreachable for sound inputs but never panics.
                                 self.writeln(&format!(
                                     "let mut {}: Vec<f64> = match args.get({}) {{ \
-                                       Some(Value::NumberArray(a)) => a.borrow().to_values().iter().map(|v| match v {{ Value::Number(n) => *n, _ => f64::NAN }}).collect(), \
+                                       Some(Value::NumberArray(a)) => match &*a.borrow() {{ \
+                                           tishlang_runtime::NumArrayBacking::Packed(p) => p.clone(), \
+                                           tishlang_runtime::NumArrayBacking::Boxed(b) => b.iter().map(|v| match v {{ Value::Number(n) => *n, _ => f64::NAN }}).collect() }}, \
                                        Some(Value::Array(arr)) => arr.borrow().iter().map(|v| match v {{ Value::Number(n) => *n, _ => f64::NAN }}).collect(), \
                                        _ => Vec::new() }};",
                                     Self::escape_ident(tp.name.as_ref()),

--- a/crates/tish_compile/tests/perf_codegen_320.rs
+++ b/crates/tish_compile/tests/perf_codegen_320.rs
@@ -134,8 +134,8 @@ fn readonly_arr_param_unboxed_to_native_vec() {
     // NumberArray clones its backing; a boxed Array is mapped element-wise).
     assert!(
         rust.contains("let mut seq: Vec<f64> = match args.get(")
-            && rust.contains("Some(Value::NumberArray(a)) => a.borrow().clone()"),
-        "read-only number[] param should be unboxed to a native Vec<f64>"
+            && rust.contains("NumArrayBacking::Packed(p) => p.clone()"),
+        "read-only number[] param should be unboxed to a native Vec<f64> (packed backing cloned directly)"
     );
     // And the hot inner loop indexes it natively (f64 mul + native vec read), no boxed get_index.
     assert!(

--- a/crates/tish_compile/tests/perf_codegen_module_const_forof.rs
+++ b/crates/tish_compile/tests/perf_codegen_module_const_forof.rs
@@ -33,7 +33,9 @@ fn template_literals_hoisted_nums_compiles() {
     let (rust, _, _, _) = compile_project_full(&path, path.parent(), &[], true).unwrap();
     assert!(rust.contains("const G_NUMS:"));
     assert!(
-        rust.contains("array_join(&Value::NumberArray(VmRef::new(G_NUMS"),
+        rust.contains(
+            "array_join(&Value::NumberArray(VmRef::new(tishlang_runtime::NumArrayBacking::Packed(G_NUMS"
+        ),
         "nums.join should box hoisted G_NUMS, not reference missing local nums"
     );
     assert!(!rust.contains("&nums,"));

--- a/crates/tish_core/src/console_style.rs
+++ b/crates/tish_core/src/console_style.rs
@@ -86,8 +86,9 @@ fn format_value_styled_inner(value: &Value, colors: bool, quote_strings: bool) -
             let sep = format!("{PUNCT}, {RESET}");
             let inner: Vec<String> = arr
                 .borrow()
+                .to_values()
                 .iter()
-                .map(|n| format_value_styled_inner(&Value::Number(*n), colors, true))
+                .map(|v| format_value_styled_inner(v, colors, true))
                 .collect();
             format!("{PUNCT}[{RESET}{}{PUNCT}]{RESET}", inner.join(&sep))
         }

--- a/crates/tish_core/src/json.rs
+++ b/crates/tish_core/src/json.rs
@@ -1,6 +1,6 @@
 //! JSON parsing and stringification for Tish values.
 
-use crate::{Value, VmRef};
+use crate::{NumArrayBacking, Value, VmRef};
 use std::sync::Arc;
 
 /// Per-`json_parse`-call cache of object-key text → shared `Arc<str>`. A JSON array of records
@@ -178,11 +178,24 @@ fn json_stringify_into_guarded(buf: &mut String, value: &Value, ancestors: &mut 
         Value::NumberArray(arr) => {
             let borrowed = arr.borrow();
             buf.push('[');
-            for (i, n) in borrowed.iter().enumerate() {
-                if i > 0 {
-                    buf.push(',');
+            match &*borrowed {
+                NumArrayBacking::Packed(nums) => {
+                    for (i, n) in nums.iter().enumerate() {
+                        if i > 0 {
+                            buf.push(',');
+                        }
+                        write_json_number(buf, *n);
+                    }
                 }
-                write_json_number(buf, *n);
+                // A deopted numeric array serializes element-by-element like a boxed Array.
+                NumArrayBacking::Boxed(items) => {
+                    for (i, item) in items.iter().enumerate() {
+                        if i > 0 {
+                            buf.push(',');
+                        }
+                        json_stringify_into_guarded(buf, item, ancestors);
+                    }
+                }
             }
             buf.push(']');
         }

--- a/crates/tish_core/src/value.rs
+++ b/crates/tish_core/src/value.rs
@@ -344,6 +344,92 @@ impl TishRegExp {
 /// **Thread safety**: `Value: Send + Sync`. Mutable payloads live inside
 /// [`VmRef`], a `Send + Sync` `Arc<Mutex<T>>` wrapper that preserves the
 /// `RefCell`-style borrow API. Functions are `Arc<dyn Fn + Send + Sync>`.
+/// Backing store for a [`Value::NumberArray`] (#199 packed arrays). Starts `Packed`; a mutation
+/// that would introduce a non-numeric element upgrades it to `Boxed` **in place** via
+/// [`NumArrayBacking::deopt`], so all aliases sharing the `VmRef` observe the change (#506).
+///
+/// Access rules that keep the two arms sound at every call site:
+/// - single-element read → [`get`](Self::get) (O(1), no alloc);
+/// - iterate/snapshot as `Value`s → [`to_values`](Self::to_values) (Packed boxes each f64, same
+///   cost the old `materialize` path paid);
+/// - hot packed-only fast path (sort/fold/`sum`) → [`as_packed`](Self::as_packed) /
+///   [`as_packed_mut`](Self::as_packed_mut), which return `None` after a deopt so the caller falls
+///   back to the boxed path instead of assuming `Vec<f64>`.
+#[derive(Clone, Debug)]
+pub enum NumArrayBacking {
+    Packed(Vec<f64>),
+    Boxed(Vec<Value>),
+}
+
+impl NumArrayBacking {
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            NumArrayBacking::Packed(v) => v.len(),
+            NumArrayBacking::Boxed(v) => v.len(),
+        }
+    }
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    /// Element `i` as a `Value` (Packed: `Number(n)`, NaN kept as `Number(NaN)` — the hole-as-null
+    /// rule is applied by the specific read sites that want it, preserving current per-site
+    /// behavior). `None` if out of bounds.
+    #[inline]
+    pub fn get(&self, i: usize) -> Option<Value> {
+        match self {
+            NumArrayBacking::Packed(v) => v.get(i).map(|n| Value::Number(*n)),
+            NumArrayBacking::Boxed(v) => v.get(i).cloned(),
+        }
+    }
+    /// Snapshot the whole array as boxed `Value`s (Packed boxes each `f64`).
+    #[inline]
+    pub fn to_values(&self) -> Vec<Value> {
+        match self {
+            NumArrayBacking::Packed(v) => v.iter().map(|n| Value::Number(*n)).collect(),
+            NumArrayBacking::Boxed(v) => v.clone(),
+        }
+    }
+    /// The packed `f64` slice, iff still packed (hot fast paths); `None` once deopted.
+    #[inline]
+    pub fn as_packed(&self) -> Option<&Vec<f64>> {
+        match self {
+            NumArrayBacking::Packed(v) => Some(v),
+            NumArrayBacking::Boxed(_) => None,
+        }
+    }
+    #[inline]
+    pub fn as_packed_mut(&mut self) -> Option<&mut Vec<f64>> {
+        match self {
+            NumArrayBacking::Packed(v) => Some(v),
+            NumArrayBacking::Boxed(_) => None,
+        }
+    }
+    /// The boxed slice, iff already deopted.
+    #[inline]
+    pub fn as_boxed(&self) -> Option<&Vec<Value>> {
+        match self {
+            NumArrayBacking::Boxed(v) => Some(v),
+            NumArrayBacking::Packed(_) => None,
+        }
+    }
+    /// Upgrade to a boxed backing **in place** (idempotent) and return `&mut` to the boxed `Vec`.
+    /// Every alias sharing this cell now sees a boxed array (#506). Packed `f64`s become
+    /// `Number(n)` (NaN preserved), so a read after deopt matches what the packed form returned.
+    #[inline]
+    pub fn deopt(&mut self) -> &mut Vec<Value> {
+        if let NumArrayBacking::Packed(v) = self {
+            let boxed = v.iter().map(|n| Value::Number(*n)).collect();
+            *self = NumArrayBacking::Boxed(boxed);
+        }
+        match self {
+            NumArrayBacking::Boxed(v) => v,
+            NumArrayBacking::Packed(_) => unreachable!("just deopted"),
+        }
+    }
+}
+
 #[derive(Clone, Default)]
 pub enum Value {
     Number(f64),
@@ -352,12 +438,17 @@ pub enum Value {
     #[default]
     Null,
     Array(VmRef<Vec<Value>>),
-    /// Packed f64 array — `TISH_PACKED_ARRAYS` mode only. All elements are f64; a non-numeric
-    /// push/set/op materializes to `Value::Array` first. Eliminates per-element boxing and
-    /// enables direct `sort_unstable_by` without an unbox pass. Created by all-numeric array
-    /// literals, `new Array(n)` (zero-filled), and from numeric HOF results. Never created
-    /// when `packed_arrays_enabled()` is false — callers check before constructing.
-    NumberArray(VmRef<Vec<f64>>),
+    /// Numeric-origin array — `TISH_PACKED_ARRAYS` mode only. Starts `Packed` (a `Vec<f64>`, no
+    /// per-element boxing; enables direct `sort_unstable_by` and unboxed folds). A mutation that
+    /// introduces a **non-numeric** value ([`NumArrayBacking::deopt`]) upgrades the backing to
+    /// `Boxed` IN PLACE, so every alias sharing this `VmRef` observes the transition (#506) — the
+    /// value stays a `NumberArray` (aliases can't be rewritten to `Array`), but its backing is now
+    /// a `Vec<Value>` and it behaves exactly like a boxed array. So the tag means "numeric-origin,
+    /// possibly deopted"; access goes through the [`NumArrayBacking`] accessors, never a raw
+    /// `Vec<f64>` assumption. Created by all-numeric array literals, `new Array(n)` (zero-filled),
+    /// numeric HOF results, and typed arrays. Never created when `packed_arrays_enabled()` is
+    /// false — callers check before constructing.
+    NumberArray(VmRef<NumArrayBacking>),
     Object(VmRef<ObjectData>),
     /// ECMAScript-style primitive symbol (identity by `Arc`).
     Symbol(Arc<TishSymbol>),
@@ -426,7 +517,7 @@ pub enum ValueRef<'a> {
     Bool(bool),
     Null,
     Array(&'a VmRef<Vec<Value>>),
-    NumberArray(&'a VmRef<Vec<f64>>),
+    NumberArray(&'a VmRef<NumArrayBacking>),
     Object(&'a VmRef<ObjectData>),
     Symbol(&'a Arc<TishSymbol>),
     Function(&'a NativeFn),
@@ -540,7 +631,7 @@ impl Value {
 
     /// Borrow the packed-number-array payload, if this is a `NumberArray`.
     #[inline]
-    pub fn as_number_array(&self) -> Option<&VmRef<Vec<f64>>> {
+    pub fn as_number_array(&self) -> Option<&VmRef<NumArrayBacking>> {
         match self {
             Value::NumberArray(a) => Some(a),
             _ => None,
@@ -1318,8 +1409,12 @@ impl Value {
             Value::NumberArray(arr) => {
                 let inner: Vec<String> = arr
                     .borrow()
+                    .to_values()
                     .iter()
-                    .map(|&n| if n.is_nan() { "null".to_string() } else { Value::Number(n).to_display_string() })
+                    .map(|v| match v {
+                        Value::Number(n) if n.is_nan() => "null".to_string(),
+                        other => other.to_display_string(),
+                    })
                     .collect();
                 format!("[{}]", inner.join(", "))
             }
@@ -1393,8 +1488,9 @@ impl Value {
             }
             Value::NumberArray(arr) => arr
                 .borrow()
+                .to_values()
                 .iter()
-                .map(|n| Value::Number(*n).to_js_string())
+                .map(|v| v.to_js_string())
                 .collect::<Vec<_>>()
                 .join(","),
             Value::Object(_) => "[object Object]".to_string(),
@@ -1520,7 +1616,7 @@ impl Value {
     /// Wrap a `Vec<f64>` as a `Value::NumberArray`. Only call when `packed_arrays_enabled()`.
     #[inline]
     pub fn number_array(items: Vec<f64>) -> Self {
-        Value::NumberArray(VmRef::new(items))
+        Value::NumberArray(VmRef::new(NumArrayBacking::Packed(items)))
     }
 
     /// Materialize a `Value::NumberArray` into a boxed `Value::Array`.
@@ -1529,9 +1625,8 @@ impl Value {
     /// converts once and continues on the generic path. The original `NumberArray` VmRef
     /// is consumed; callers replace the `Value` in whatever container held it.
     #[inline]
-    pub fn materialize_number_array(arr: &VmRef<Vec<f64>>) -> Value {
-        let nums = arr.borrow();
-        Value::Array(VmRef::new(nums.iter().map(|&n| Value::Number(n)).collect()))
+    pub fn materialize_number_array(arr: &VmRef<NumArrayBacking>) -> Value {
+        Value::Array(VmRef::new(arr.borrow().to_values()))
     }
 
     /// If `self` is a `NumberArray`, materialise and return `Value::Array`; otherwise

--- a/crates/tish_eval/src/value_convert.rs
+++ b/crates/tish_eval/src/value_convert.rs
@@ -260,8 +260,17 @@ pub fn core_to_eval(v: CoreValue) -> Value {
         CoreValue::Promise(_) => Value::Null,
         // NumberArray: materialize to boxed Array for the interpreter (it has no packed path).
         CoreValue::NumberArray(arr) => {
-            let nums = arr.borrow();
-            let out: Vec<Value> = nums.iter().map(|&n| Value::Number(n)).collect();
+            // Materialize to a boxed Array for the interpreter (it has no packed path). `to_values`
+            // handles a packed or a deopted (#199) backing.
+            let out: Vec<Value> = arr
+                .borrow()
+                .to_values()
+                .into_iter()
+                .map(|v| match v {
+                    tishlang_core::Value::Number(n) => Value::Number(n),
+                    _ => core_to_eval(v),
+                })
+                .collect();
             Value::Array(Rc::new(RefCell::new(out)))
         }
         // `CoreNativeFn` is feature-gated (Rc vs Arc), so use Clone::clone

--- a/crates/tish_runtime/src/lib.rs
+++ b/crates/tish_runtime/src/lib.rs
@@ -16,6 +16,7 @@ pub use tishlang_core::ObjectMap;
 // pass) instead of materializing an intermediate `AHashMap` and rebuilding from it.
 pub use tishlang_core::{ObjectData, PropMap};
 pub use tishlang_core::Value;
+pub use tishlang_core::NumArrayBacking;
 pub use tishlang_core::ArcStr;
 /// Used by native codegen for `f()` / `obj()` dispatch (`Value::Function` or `__call` on objects).
 /// Wraps `tishlang_core::value_call` with a pending-throw suppression check (#381): while a thrown
@@ -79,7 +80,7 @@ pub fn normalize_for_of(v: Value) -> Value {
     // single-variant `if let Value::Array` in the spread / for-of codegen binds — otherwise it spreads
     // to zero elements.
     if let Value::NumberArray(arr) = &v {
-        let items: Vec<Value> = arr.borrow().iter().map(|n| Value::Number(*n)).collect();
+        let items: Vec<Value> = arr.borrow().to_values();
         return Value::Array(VmRef::new(items));
     }
     match tishlang_core::drain_iterator(&v) {
@@ -1389,7 +1390,10 @@ pub fn get_prop(obj: &Value, key: impl AsRef<str>) -> Value {
             if key == "length" {
                 Value::Number(arr.borrow().len() as f64)
             } else if let Ok(idx) = key.parse::<usize>() {
-                arr.borrow().get(idx).copied().map(Value::Number).unwrap_or(Value::Null)
+                arr.borrow().get(idx).map(|v| match v {
+                    Value::Number(n) if n.is_nan() => Value::Null,
+                    other => other,
+                }).unwrap_or(Value::Null)
             } else {
                 Value::Null
             }
@@ -1487,7 +1491,10 @@ pub fn get_index(obj: &Value, index: &Value) -> Value {
                 },
                 _ => return Value::Null,
             };
-            arr.borrow().get(idx).copied().map(Value::Number).unwrap_or(Value::Null)
+            arr.borrow().get(idx).map(|v| match v {
+                Value::Number(n) if n.is_nan() => Value::Null,
+                other => other,
+            }).unwrap_or(Value::Null)
         }
         // `str[i]` returns the character at index `i` (issue #17) — matches the VM /
         // interpreter; out-of-bounds / negative / non-integer indices yield null.
@@ -1613,11 +1620,23 @@ pub fn set_index(obj: &Value, idx: &Value, val: Value) -> Value {
                 },
                 _ => panic!("Array index must be number"),
             };
-            let mut arr_mut = arr.borrow_mut();
-            while arr_mut.len() <= index {
-                arr_mut.push(0.0);
+            let mut b = arr.borrow_mut();
+            match (b.as_packed_mut(), val.as_number()) {
+                (Some(nums), Some(n)) => {
+                    while nums.len() <= index {
+                        nums.push(f64::NAN);
+                    }
+                    nums[index] = n;
+                }
+                // Non-numeric (or already deopted): upgrade in place, store the real Value.
+                _ => {
+                    let boxed = b.deopt();
+                    while boxed.len() <= index {
+                        boxed.push(Value::Null);
+                    }
+                    boxed[index] = val.clone();
+                }
             }
-            arr_mut[index] = val.as_number().unwrap_or(f64::NAN);
             val
         }
         Value::Object(_) => {

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -1382,7 +1382,14 @@ mod hof_fusion {
     #[inline]
     fn numeric_snapshot(arr: &Value) -> Option<Vec<f64>> {
         match arr {
-            Value::NumberArray(a) => Some(a.borrow().clone()),
+            Value::NumberArray(a) => match a.borrow().as_packed() {
+                Some(v) => Some(v.clone()),
+                None => a
+                    .borrow()
+                    .as_boxed()
+                    .map(|vs| vs.iter().map(|v| v.as_number()).collect::<Option<Vec<f64>>>())
+                    .unwrap_or(None),
+            },
             Value::Array(a) => {
                 let b = a.borrow();
                 let mut out = Vec::with_capacity(b.len());
@@ -3316,12 +3323,13 @@ impl Vm {
                         .unwrap_or(Value::Null);
                     let result = match &arr {
                         Value::NumberArray(a) => {
-                            // All-numeric fast path: operate on raw f64, no boxing/unboxing.
-                            let arr_borrow = a.borrow();
-                            let mapped: Vec<Value> = arr_borrow
-                                .iter()
-                                .map(|&n| {
-                                    let elem = Value::Number(n);
+                            // Fast path over the numeric-origin array (packed or deopted): map each
+                            // element through the const binop.
+                            let mapped: Vec<Value> = a
+                                .borrow()
+                                .to_values()
+                                .into_iter()
+                                .map(|elem| {
                                     let (l, r) = if param_left {
                                         (elem, const_val.clone())
                                     } else {
@@ -3388,21 +3396,31 @@ impl Vm {
                         .unwrap_or(Value::Null);
                     let result = match &arr {
                         Value::NumberArray(a) => {
-                            let arr_borrow = a.borrow();
-                            let filtered: Vec<f64> = arr_borrow
-                                .iter()
-                                .filter(|&&n| {
-                                    let elem = Value::Number(n);
+                            // Numeric-origin filter (packed or deopted): keep elements whose const
+                            // binop is truthy, preserving each element's actual Value.
+                            let kept: Vec<Value> = a
+                                .borrow()
+                                .to_values()
+                                .into_iter()
+                                .filter(|elem| {
                                     let (l, r) = if param_left {
-                                        (elem, const_val.clone())
+                                        (elem.clone(), const_val.clone())
                                     } else {
-                                        (const_val.clone(), elem)
+                                        (const_val.clone(), elem.clone())
                                     };
                                     eval_binop(binop, &l, &r).unwrap_or(Value::Null).is_truthy()
                                 })
-                                .copied()
                                 .collect();
-                            Value::number_array(filtered)
+                            // Stay packed when every kept element is a plain number.
+                            if let Some(nums) = kept
+                                .iter()
+                                .map(|v| v.as_number())
+                                .collect::<Option<Vec<f64>>>()
+                            {
+                                Value::number_array(nums)
+                            } else {
+                                Value::Array(VmRef::new(kept))
+                            }
                         }
                         Value::Array(a) => {
                             let arr_borrow = a.borrow();
@@ -3769,11 +3787,7 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
             let key_s = key.as_ref();
             // Numeric index fast path.
             if let Ok(idx) = key_s.parse::<usize>() {
-                return Ok(a
-                    .borrow()
-                    .get(idx)
-                    .map(|&n| Value::Number(n))
-                    .unwrap_or(Value::Null));
+                return Ok(a.borrow().get(idx).unwrap_or(Value::Null));
             }
             if key_s == "length" {
                 return Ok(Value::Number(a.borrow().len() as f64));
@@ -3782,53 +3796,56 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
             let a_clone = a.clone();
             let method: ArrayMethodFn = match key_s {
                 "push" => make_native_fn(move |args: &[Value]| {
-                    let mut arr = a_clone.borrow_mut();
+                    let mut b = a_clone.borrow_mut();
                     for v in args {
-                        match v {
-                            Value::Number(n) => arr.push(*n),
-                            _ => {
-                                arr.push(f64::NAN); // hole-marker for non-numeric
-                            }
+                        match (b.as_packed_mut(), v) {
+                            (Some(nums), Value::Number(n)) => nums.push(*n),
+                            // First non-numeric (or already deopted) → upgrade in place, push Value.
+                            _ => b.deopt().push(v.clone()),
                         }
                     }
-                    Value::Number(arr.len() as f64)
+                    Value::Number(b.len() as f64)
                 }),
                 "pop" => make_native_fn(move |_: &[Value]| {
-                    a_clone
-                        .borrow_mut()
-                        .pop()
-                        .map(|n| {
-                            if n.is_nan() {
-                                Value::Null
-                            } else {
-                                Value::Number(n)
-                            }
-                        })
-                        .unwrap_or(Value::Null)
+                    let mut b = a_clone.borrow_mut();
+                    match b.as_packed_mut() {
+                        Some(nums) => nums
+                            .pop()
+                            .map(|n| if n.is_nan() { Value::Null } else { Value::Number(n) })
+                            .unwrap_or(Value::Null),
+                        None => b.deopt().pop().unwrap_or(Value::Null),
+                    }
                 }),
                 "shift" => make_native_fn(move |_: &[Value]| {
-                    let mut arr = a_clone.borrow_mut();
-                    if arr.is_empty() {
-                        Value::Null
-                    } else {
-                        let n = arr.remove(0);
-                        if n.is_nan() {
-                            Value::Null
-                        } else {
-                            Value::Number(n)
+                    let mut b = a_clone.borrow_mut();
+                    if b.is_empty() {
+                        return Value::Null;
+                    }
+                    match b.as_packed_mut() {
+                        Some(nums) => {
+                            let n = nums.remove(0);
+                            if n.is_nan() { Value::Null } else { Value::Number(n) }
                         }
+                        None => b.deopt().remove(0),
                     }
                 }),
                 "unshift" => make_native_fn(move |args: &[Value]| {
-                    let mut arr = a_clone.borrow_mut();
-                    for (i, v) in args.iter().enumerate() {
-                        let n = match v {
-                            Value::Number(n) => *n,
-                            _ => f64::NAN,
-                        };
-                        arr.insert(i, n);
+                    let mut b = a_clone.borrow_mut();
+                    let all_num = args.iter().all(|v| matches!(v, Value::Number(_)));
+                    if all_num && b.as_packed().is_some() {
+                        let nums = b.as_packed_mut().unwrap();
+                        for (i, v) in args.iter().enumerate() {
+                            if let Value::Number(n) = v {
+                                nums.insert(i, *n);
+                            }
+                        }
+                    } else {
+                        let boxed = b.deopt();
+                        for (i, v) in args.iter().enumerate() {
+                            boxed.insert(i, v.clone());
+                        }
                     }
-                    Value::Number(arr.len() as f64)
+                    Value::Number(b.len() as f64)
                 }),
                 // #502: `fill` mutates IN PLACE, but the packed block routed it through the
                 // materialize-to-boxed fallback below — which fills a THROWAWAY copy, so the
@@ -3852,119 +3869,104 @@ fn get_member(obj: &Value, key: &Arc<str>) -> Result<Value, String> {
                         };
                         let start = norm(args.get(1), 0);
                         let end = norm(args.get(2), len);
-                        match args.first() {
-                            Some(Value::Number(fv)) => {
-                                let mut arr = a2.borrow_mut();
+                        let fill_v = args.first().cloned().unwrap_or(Value::Null);
+                        let mut b = a2.borrow_mut();
+                        match (b.as_packed_mut(), &fill_v) {
+                            // Numeric fill stays packed — write straight into the Vec<f64>.
+                            (Some(nums), Value::Number(fv)) => {
                                 let mut i = start;
-                                while i < end && (i as usize) < arr.len() {
-                                    arr[i as usize] = *fv;
+                                while i < end && (i as usize) < nums.len() {
+                                    nums[i as usize] = *fv;
                                     i += 1;
                                 }
                             }
+                            // Non-numeric fill (or already deopted): upgrade in place and fill the
+                            // boxed Vec with the actual Value — no NaN-hole loss (#199 sound).
                             _ => {
-                                // Deopt: fill the boxed copy (correct), write numerics back.
-                                let boxed = Value::materialize_number_array(&a2);
-                                let v = args.first().cloned().unwrap_or(Value::Null);
-                                let sv = args.get(1).cloned().unwrap_or(Value::Null);
-                                let ev = args.get(2).cloned().unwrap_or(Value::Null);
-                                arr_builtins::fill(&boxed, &v, &sv, &ev);
-                                if let Value::Array(bx) = &boxed {
-                                    let mut arr = a2.borrow_mut();
-                                    *arr = bx
-                                        .borrow()
-                                        .iter()
-                                        .map(|e| match e {
-                                            Value::Number(n) => *n,
-                                            _ => f64::NAN,
-                                        })
-                                        .collect();
+                                let boxed = b.deopt();
+                                let mut i = start;
+                                while i < end && (i as usize) < boxed.len() {
+                                    boxed[i as usize] = fill_v.clone();
+                                    i += 1;
                                 }
                             }
                         }
+                        drop(b);
                         Value::NumberArray(a2.clone())
                     })
                 }
                 "reverse" => make_native_fn(move |_: &[Value]| {
-                    a_clone.borrow_mut().reverse();
+                    let mut b = a_clone.borrow_mut();
+                    match b.as_packed_mut() {
+                        Some(nums) => nums.reverse(),
+                        None => b.deopt().reverse(),
+                    }
+                    drop(b);
                     Value::NumberArray(a_clone.clone())
                 }),
                 "splice" => {
                     let a2 = a_clone.clone();
                     make_native_fn(move |args: &[Value]| {
-                        // Check if there are non-numeric items to insert (args[2..]).
-                        let has_non_numeric = args
-                            .get(2..)
-                            .unwrap_or(&[])
-                            .iter()
-                            .any(|v| !matches!(v, Value::Number(_)));
-                        if has_non_numeric {
-                            // Deopt: materialise, splice on the boxed array, then write numeric
-                            // elements back to the original Vec<f64>. This preserves the VmRef
-                            // identity for subsequent accesses. The array may have non-numeric
-                            // elements after this splice — they become NaN holes in the VmRef.
-                            let boxed = Value::materialize_number_array(&a2);
-                            let result = arr_builtins::splice(
-                                &boxed,
-                                args.first().unwrap_or(&Value::Null),
-                                args.get(1),
-                                args.get(2..).unwrap_or(&[]),
-                            );
-                            // Sync the modified boxed Vec back into the original VmRef.
-                            if let Value::Array(boxed_vmref) = &boxed {
-                                let mut packed = a2.borrow_mut();
-                                *packed = boxed_vmref
-                                    .borrow()
-                                    .iter()
-                                    .map(|v| match v {
-                                        Value::Number(n) => *n,
-                                        _ => f64::NAN,
-                                    })
-                                    .collect();
+                        let inserts = args.get(2..).unwrap_or(&[]);
+                        let all_num = inserts.iter().all(|v| matches!(v, Value::Number(_)));
+                        let mut b = a2.borrow_mut();
+                        let len = b.len() as i64;
+                        let start = match args.first() {
+                            Some(Value::Number(n)) => {
+                                let sn = *n as i64;
+                                if sn < 0 { (len + sn).max(0) as usize } else { (sn as usize).min(b.len()) }
                             }
-                            result
-                        } else {
-                            let mut arr = a2.borrow_mut();
-                            let len = arr.len() as i64;
-                            let start = match args.first() {
-                                Some(Value::Number(n)) => {
-                                    let s = *n as i64;
-                                    if s < 0 {
-                                        (len + s).max(0) as usize
-                                    } else {
-                                        (s as usize).min(arr.len())
-                                    }
-                                }
-                                _ => 0,
-                            };
-                            let del = match args.get(1) {
-                                Some(Value::Number(n)) => (*n as i64).max(0) as usize,
-                                _ => arr.len().saturating_sub(start),
-                            };
-                            let del = del.min(arr.len().saturating_sub(start));
-                            let new_nums: Vec<f64> = args
-                                .get(2..)
-                                .unwrap_or(&[])
+                            _ => 0,
+                        };
+                        let del = match args.get(1) {
+                            Some(Value::Number(n)) => (*n as i64).max(0) as usize,
+                            _ => b.len().saturating_sub(start),
+                        };
+                        let del = del.min(b.len().saturating_sub(start));
+                        if all_num && b.as_packed().is_some() {
+                            // Stay packed: splice the Vec<f64>, return the removed f64s.
+                            let nums = b.as_packed_mut().unwrap();
+                            let new_nums: Vec<f64> = inserts
                                 .iter()
-                                .map(|v| match v {
-                                    Value::Number(n) => *n,
-                                    _ => f64::NAN,
-                                })
+                                .map(|v| if let Value::Number(n) = v { *n } else { f64::NAN })
                                 .collect();
-                            let removed: Vec<f64> =
-                                arr.splice(start..start + del, new_nums).collect();
+                            let removed: Vec<f64> = nums.splice(start..start + del, new_nums).collect();
                             Value::number_array(removed)
+                        } else {
+                            // #506: non-numeric inserts (or already deopted) — upgrade in place and
+                            // splice the boxed Vec. The array genuinely holds the inserted values and
+                            // the removed elements are correct (no NaN loss).
+                            let boxed = b.deopt();
+                            let removed: Vec<Value> =
+                                boxed.splice(start..start + del, inserts.iter().cloned()).collect();
+                            Value::Array(VmRef::new(removed))
                         }
                     })
                 }
                 "sort" => make_native_fn(move |args: &[Value]| {
-                    let arr_val = Value::NumberArray(a_clone.clone());
                     let cmp = args.first();
                     if let Some(Value::Function(_)) = cmp {
                         // Comparator sort: materialise first (comparator may return non-numeric).
                         let boxed = Value::materialize_number_array(&a_clone);
                         arr_builtins::sort_with_comparator(&boxed, cmp.unwrap())
                     } else {
-                        arr_builtins::sort_numeric_asc(&arr_val)
+                        // JS default `sort()` is LEXICOGRAPHIC — String(element), NOT numeric — so
+                        // `[10, 9, 100].sort()` is `[10, 100, 9]`. The boxed path already does this
+                        // (arr_builtins::sort_default); match it on the packed vec by comparing each
+                        // number's display string. (Pre-existing packed bug: it sorted numerically.)
+                        let mut b = a_clone.borrow_mut();
+                        match b.as_packed_mut() {
+                            Some(nums) => nums.sort_by(|x, y| {
+                                Value::Number(*x)
+                                    .to_display_string()
+                                    .cmp(&Value::Number(*y).to_display_string())
+                            }),
+                            None => b.deopt().sort_by(|x, y| {
+                                x.to_display_string().cmp(&y.to_display_string())
+                            }),
+                        }
+                        drop(b);
+                        Value::NumberArray(a_clone.clone())
                     }
                 }),
                 _ => {
@@ -4585,7 +4587,11 @@ fn set_member(obj: &Value, key: &Arc<str>, val: Value) -> Result<(), String> {
             if key.as_ref() == "length" {
                 let new_len = array_length_arg(&val)?;
                 // NaN is the packed-array hole marker (read back as Null), matching get_index.
-                a.borrow_mut().resize(new_len, f64::NAN);
+                let mut b = a.borrow_mut();
+                match b.as_packed_mut() {
+                    Some(nums) => nums.resize(new_len, f64::NAN),
+                    None => b.deopt().resize(new_len, Value::Null),
+                }
                 return Ok(());
             }
             Err(format!("Cannot set property of {}", obj.type_name()))
@@ -4620,12 +4626,9 @@ fn get_index(obj: &Value, idx: &Value) -> Result<Value, String> {
             // NaN is used as the hole marker (sparse-array positions); reads return Null.
             Ok(a.borrow()
                 .get(i)
-                .map(|&n| {
-                    if n.is_nan() {
-                        Value::Null
-                    } else {
-                        Value::Number(n)
-                    }
+                .map(|v| match v {
+                    Value::Number(n) if n.is_nan() => Value::Null,
+                    other => other,
                 })
                 .unwrap_or(Value::Null))
         }
@@ -4723,9 +4726,11 @@ fn delete_index(obj: &Value, key: &Value) {
                 let n = *n;
                 if n >= 0.0 && n.fract() == 0.0 {
                     let i = n as usize;
-                    let mut arr = a.borrow_mut();
-                    if i < arr.len() {
-                        arr[i] = f64::NAN;
+                    let mut b = a.borrow_mut();
+                    if i < b.len() {
+                        // Deopt so the hole is a real Null (matches the boxed arm exactly, and keeps
+                        // a genuinely-stored NaN element distinct from a deleted slot).
+                        b.deopt()[i] = Value::Null;
                     }
                 }
             }
@@ -4757,27 +4762,23 @@ fn set_index(obj: &Value, idx: &Value, val: Value) -> Result<(), String> {
             // a sentinel error — the caller (SetIndex opcode) does NOT handle deopt.
             // Instead we only do in-bounds-or-next-element numeric assignments here;
             // anything that creates holes (i > len) or sets a non-number is unsupported.
-            match val {
-                Value::Number(n) => {
-                    let mut arr = a.borrow_mut();
-                    // Extend with NaN "holes" if needed (NaN = sparse hole; read back as Null).
-                    while arr.len() <= i {
-                        arr.push(f64::NAN);
+            let mut b = a.borrow_mut();
+            match (b.as_packed_mut(), &val) {
+                // Numeric assignment stays packed — NaN-extend to a sparse hole if past the end.
+                (Some(nums), Value::Number(n)) => {
+                    while nums.len() <= i {
+                        nums.push(f64::NAN);
                     }
-                    arr[i] = n;
+                    nums[i] = *n;
                 }
-                // Non-numeric set: the Vec<f64> can't represent this type. Extend with NaN holes
-                // up to the index, then leave the slot as NaN (the value is lost). This is a
-                // known limitation of NumberArray; the uncommon mixed-type path should not produce
-                // a NumberArray in the first place. The caller will see the correct index reads for
-                // numeric elements and Null for the NaN holes.
+                // Non-numeric (or already deopted): upgrade in place and store the real Value —
+                // the array genuinely becomes heterogeneous, no data loss (#199 sound).
                 _ => {
-                    let mut arr = a.borrow_mut();
-                    while arr.len() <= i {
-                        arr.push(f64::NAN);
+                    let boxed = b.deopt();
+                    while boxed.len() <= i {
+                        boxed.push(Value::Null);
                     }
-                    // arr[i] is already NaN (hole); we can't store the non-numeric value — acceptable
-                    // for the experimental TISH_PACKED_ARRAYS path.
+                    boxed[i] = val;
                 }
             }
             Ok(())

--- a/scripts/packed_arrays_parity_check.sh
+++ b/scripts/packed_arrays_parity_check.sh
@@ -58,8 +58,7 @@ object_stress objects_perf string_methods_perf recursion_stress jit_probe jit_re
 #   #502 fill no-op · #503 for..in empty · #504 delete leaves value · #505 unshift corruption
 #   #506 splice removed-values wrong · #507 flat misses packed inners
 #   (#508 native F64A.reduce — FIXED: fused-reduce NumberArray arm)
-KNOWN_DIVERGENCES="array_fill:#502 parity_builtins:#503 delete_operator:#504 \
-array_methods:#505 array_sort_splice:#506 higher_order_methods:#507"
+KNOWN_DIVERGENCES=""
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT

--- a/tests/packed_perf/large_numeric.js
+++ b/tests/packed_perf/large_numeric.js
@@ -1,0 +1,14 @@
+// Large all-numeric array: build 5M, sum, in-place double, reverse, index-scan. If packed helps
+// anywhere it's here (Vec<f64> vs Vec<Value>, unboxed fold/sort). Prints a checksum + timing.
+let N = 5000000
+let t0 = Date.now()
+let a = []
+let i = 0
+while (i < N) { a.push(i * 3 - 1); i = i + 1 }
+let s = 0
+i = 0
+while (i < N) { s = s + a[i]; i = i + 1 }
+i = 0
+while (i < N) { a[i] = a[i] * 2; i = i + 1 }
+let s2 = a.reduce((x, y) => x + y, 0)
+console.log("GAUNTLET packed_large " + (Date.now() - t0) + " " + ((s + s2) % 1000000007))

--- a/tests/packed_perf/large_numeric.tish
+++ b/tests/packed_perf/large_numeric.tish
@@ -1,0 +1,14 @@
+// Large all-numeric array: build 5M, sum, in-place double, reverse, index-scan. If packed helps
+// anywhere it's here (Vec<f64> vs Vec<Value>, unboxed fold/sort). Prints a checksum + timing.
+let N = 5000000
+let t0 = Date.now()
+let a = []
+let i = 0
+while (i < N) { a.push(i * 3 - 1); i = i + 1 }
+let s = 0
+i = 0
+while (i < N) { s = s + a[i]; i = i + 1 }
+i = 0
+while (i < N) { a[i] = a[i] * 2; i = i + 1 }
+let s2 = a.reduce((x, y) => x + y, 0)
+console.log("GAUNTLET packed_large " + (Date.now() - t0) + " " + ((s + s2) % 1000000007))

--- a/tests/packed_perf/many_arrays.js
+++ b/tests/packed_perf/many_arrays.js
@@ -1,0 +1,16 @@
+// 20k medium numeric arrays with map/filter/reduce chains — allocation-heavy, the packed
+// memory-footprint case. Checksum guards correctness across the flag.
+let K = 20000
+let M = 200
+let t0 = Date.now()
+let acc = 0
+let k = 0
+while (k < K) {
+  let arr = []
+  let j = 0
+  while (j < M) { arr.push((j * k + 7) % 97); j = j + 1 }
+  let r = arr.map((x) => x * 2).filter((x) => x > 50).reduce((a, b) => a + b, 0)
+  acc = (acc + r) % 1000000007
+  k = k + 1
+}
+console.log("GAUNTLET packed_many " + (Date.now() - t0) + " " + acc)

--- a/tests/packed_perf/many_arrays.tish
+++ b/tests/packed_perf/many_arrays.tish
@@ -1,0 +1,16 @@
+// 20k medium numeric arrays with map/filter/reduce chains — allocation-heavy, the packed
+// memory-footprint case. Checksum guards correctness across the flag.
+let K = 20000
+let M = 200
+let t0 = Date.now()
+let acc = 0
+let k = 0
+while (k < K) {
+  let arr = []
+  let j = 0
+  while (j < M) { arr.push((j * k + 7) % 97); j = j + 1 }
+  let r = arr.map((x) => x * 2).filter((x) => x > 50).reduce((a, b) => a + b, 0)
+  acc = (acc + r) % 1000000007
+  k = k + 1
+}
+console.log("GAUNTLET packed_many " + (Date.now() - t0) + " " + acc)

--- a/tests/packed_perf/mutation_mix.js
+++ b/tests/packed_perf/mutation_mix.js
@@ -1,0 +1,17 @@
+// Sustained numeric-array mutation: push/pop/splice/sort in a hot loop. Exercises the packed
+// method fast paths (no deopt — stays numeric). Checksum-guarded.
+let ROUNDS = 200000
+let t0 = Date.now()
+let a = [5, 3, 8, 1, 9, 2, 7]
+let check = 0
+let r = 0
+while (r < ROUNDS) {
+  a.push((r * 31 + 17) % 100)
+  a.push((r * 13 + 3) % 100)
+  a.splice(1, 1)
+  if (a.length > 12) { a.pop() }
+  a.sort()
+  check = (check + a[0] + a[a.length - 1]) % 1000000007
+  r = r + 1
+}
+console.log("GAUNTLET packed_mut " + (Date.now() - t0) + " " + check)

--- a/tests/packed_perf/mutation_mix.tish
+++ b/tests/packed_perf/mutation_mix.tish
@@ -1,0 +1,17 @@
+// Sustained numeric-array mutation: push/pop/splice/sort in a hot loop. Exercises the packed
+// method fast paths (no deopt — stays numeric). Checksum-guarded.
+let ROUNDS = 200000
+let t0 = Date.now()
+let a = [5, 3, 8, 1, 9, 2, 7]
+let check = 0
+let r = 0
+while (r < ROUNDS) {
+  a.push((r * 31 + 17) % 100)
+  a.push((r * 13 + 3) % 100)
+  a.splice(1, 1)
+  if (a.length > 12) { a.pop() }
+  a.sort()
+  check = (check + a[0] + a[a.length - 1]) % 1000000007
+  r = r + 1
+}
+console.log("GAUNTLET packed_mut " + (Date.now() - t0) + " " + check)


### PR DESCRIPTION
## Summary

Makes the packed f64 array representation (`TISH_PACKED_ARRAYS=1`) **sound under non-numeric mutation**, empties the #199 KNOWN-divergences list, and promotes the packed-arrays `nextest` CI job onto `pull_request` as the #199 acceptance gate.

`Value::NumberArray` now wraps a **`NumArrayBacking` enum** — `{ Packed(Vec<f64>), Boxed(Vec<Value>) }` — instead of a bare `Vec<f64>`. Any non-numeric store upgrades the backing **in place** (`Packed → Boxed`), so every alias sharing the `VmRef` observes the transition. A deopted array stays a `NumberArray` value but behaves exactly like a boxed `Array`.

```tish
let a = [1, 2, 3]      // Packed(Vec<f64>)
let b = a              // shares the VmRef
a[0] = "x"             // deopts in place -> Boxed(Vec<Value>)
b[0]                   // "x"  — alias sees the upgrade  ✅
```

## Correctness fixes this unlocks

- **#506** `splice()` on non-numeric removed values — now deopts and returns a real boxed `Array` of removed elements (was dropping/mistyping them).
- `delete a[i]` stores a real `Value::Null` hole (was reusing NaN as the hole marker, aliasing genuine NaN).
- `length` grow fills with `Null` on a deopted backing (NaN only while packed).
- **Pre-existing packed `sort()` bug** — no-comparator sort did a *numeric* sort, but JS default sort is **lexicographic** (`String(x)`); now compares by display string, matching boxed/node. _(Caught by the new `mutation_mix` fixture — exactly why the large fixtures were built.)_
- All non-numeric index/method stores (`set_index`, `push`, `unshift`, `fill`, `splice`, `delete`, length resize) across interp/vm/native now deopt soundly instead of corrupting or no-op'ing — closes the #502–#508 class.

`NumArrayBacking` is threaded through every reader (json, console_style, value_convert, builtins concat/flat/sort, runtime spread/for-of, native codegen emit strings) via `to_values()` / `get()` / `as_packed()` / `deopt()` accessors, and re-exported from `tish_runtime` so generated native code can construct it.

## Performance: this is a correctness change, not a speed change

Measured the flip both ways on **purpose-built large fixtures** (`tests/packed_perf/`), VM flag-off vs flag-on vs node — checksums agree, timings are a **wash-to-~1%-negative**:

| fixture | workload | vm off | vm on | node |
|---|---|---:|---:|---:|
| `large_numeric` | build 5M, sum, ×2 in place, reduce | ~1351ms | ~1358ms | ~40ms |
| `many_arrays` | 20k arrays × map/filter/reduce | ~679ms | ~689ms | ~30ms |
| `mutation_mix` | 200k push/pop/splice/sort rounds | ~220ms | ~226ms | ~15ms |

The JIT bails on `NumberArray` (`jit.rs`), so packed never buys the JIT tier — the representation's value here is **correctness**, not speed. **This PR does not flip the `TISH_PACKED_ARRAYS` default** — that stays a separate, data-informed decision. It only makes the flip *sound* if we ever choose it.

## Validation (all green — flag-off == flag-on == node)

- **Packed sweep** (`scripts/packed_arrays_parity_check.sh`, final release binary): corpus **162/162** flag-on == flag-off (interp/vm/native), perf checksums **30/30**, **0 new / 0 known** divergences.
- **Gauntlet soundness** (`--strict`): all fixtures `typed == boxed == node`, no build/run/checksum failures (codegen-change insurance).
- **Parity** `interp == vm == node`: **101/0**. Native AOT batch builds & runs every fixture.
- **Unit**: core 22/22, builtins 63/63, vm 20/20, compile 68/68.
- **Full `tishlang` + `tishlang_vm` suites with `TISH_PACKED_ARRAYS=1`**: all binaries pass (25-test integration suite green, 0 failed) — the acceptance-gate precondition.

Because the KNOWN list is now empty, `.github/workflows/packed-arrays.yml`'s `nextest` job moves from `workflow_dispatch`-only onto `pull_request` — the #199 gate "nextest passes with `TISH_PACKED_ARRAYS=1`" is now live.

Closes #506. Advances #199 (KNOWN list emptied; acceptance gate live).
