### PR TITLE
docs(packed-arrays): authoritative doc + decision to keep default OFF (#199, #520)

### DIFF
--- a/docs/packed-arrays.md
+++ b/docs/packed-arrays.md
@@ -1,0 +1,78 @@
+# Packed f64 arrays (`TISH_PACKED_ARRAYS`)
+
+**Status: sound, opt-in, default OFF. Kept off deliberately — it is a performance wash, not a win.**
+
+Packed arrays give `Value` an unboxed numeric-array representation: `Value::NumberArray`, a
+contiguous `Vec<f64>` instead of a `Vec<Value>` of individually-boxed numbers. It is gated behind the
+`TISH_PACKED_ARRAYS` env var (read once per process via a `OnceLock`, so it is a whole-run mode, not a
+per-value decision).
+
+## Representation (as of #520)
+
+```rust
+Value::NumberArray(VmRef<NumArrayBacking>)
+
+pub enum NumArrayBacking {
+    Packed(Vec<f64>),    // fast path: all-numeric, unboxed
+    Boxed(Vec<Value>),   // deopted: behaves exactly like a boxed Array
+}
+```
+
+An array literal / numeric `map`/`filter` result starts `Packed`. **Any non-numeric store deopts the
+backing in place** — `Packed → Boxed` — via `NumArrayBacking::deopt()`. Because the upgrade mutates
+the value behind the shared `VmRef`, **every alias observes the transition**:
+
+```tish
+let a = [1, 2, 3]   // Packed(Vec<f64>)
+let b = a           // shares the VmRef
+a[0] = "x"          // deopts in place -> Boxed(Vec<Value>)
+b[0]                // "x"  — the alias sees the upgrade
+```
+
+A deopted array stays a `NumberArray` *value* (its aliases can't be rewritten to `Array`), but it
+behaves identically to a boxed `Array` from that point on. The paths that deopt: `set_index` with a
+non-number, `push`/`unshift`/`fill`/`splice` with any non-numeric element, `delete` (stores a real
+`Value::Null` hole), and a `length` grow (fills with `Null` once deopted; `NaN` only while packed).
+
+### Why the enum (history)
+
+The original representation was a bare `VmRef<Vec<f64>>` and used **NaN as a hole/sparse marker**;
+storing a non-numeric value was either silently lossy or a no-op, because a shared `&Value` mutation
+can't rewrite the aliases' scope bindings from `NumberArray` to `Array`. #520 replaced that with the
+in-place-upgradable enum, which *is* the mechanism that lets a shared value deopt soundly without
+touching any binding. That fixed #506 (splice non-numeric removed values) and the whole #502–#508
+non-numeric-mutation class, plus a pre-existing bug where the no-comparator packed `sort()` sorted
+numerically instead of lexicographically (JS default is `String(x)` order).
+
+## Soundness gate (#199)
+
+`TISH_PACKED_ARRAYS=1` must be **observationally identical** to flag-off. Enforced by:
+
+- `scripts/packed_arrays_parity_check.sh` — every `tests/core/*` fixture runs flag-off and flag-on on
+  interp / vm / native and must match per backend; every `tests/perf/*` GAUNTLET checksum must be
+  identical for vm-off, vm-on, and node. Current: **corpus 162/162, perf 30/30, 0 divergences.**
+- `.github/workflows/packed-arrays.yml` — runs that sweep on PRs touching the owning crates, plus a
+  `nextest` job that runs the full `tishlang` + `tishlang_vm` suites with `TISH_PACKED_ARRAYS=1`. That
+  job is the #199 acceptance gate; it went live on `pull_request` once the sweep's `KNOWN_DIVERGENCES`
+  list emptied (#520).
+
+## Performance: why the default stays OFF
+
+The flip was measured both ways on purpose-built large fixtures (`tests/packed_perf/`), VM flag-off vs
+flag-on vs node — checksums identical, timings a **wash-to-~1%**:
+
+| fixture | workload | vm off | vm on | node |
+|---|---|---:|---:|---:|
+| `large_numeric` | build 5M, sum, ×2 in place, reduce | ~1332ms | ~1297ms | ~75ms |
+| `many_arrays` | 20k arrays × map/filter/reduce | ~657ms | ~654ms | ~28ms |
+| `mutation_mix` | 200k push/pop/splice/sort rounds | ~211ms | ~213ms | ~36ms |
+
+The reason there is no win: **the VM JIT bails on `NumberArray`**, so a packed array never reaches the
+JIT tier that actually moves numbers — it stays ~17–23× node either way. Packed's fused HOF paths
+(map/filter/reduce staying packed) can show ~1.1–1.24× on isolated chains (see `docs/perf.md` PHASE 2),
+but that does not generalize to real workloads.
+
+**Decision:** keep `TISH_PACKED_ARRAYS` default **off**. #520 makes flipping it *sound* if a future
+JIT path consumes packed arrays and turns the representation into an actual speed win — until then
+there is no performance justification to flip, only representation churn. The flip itself is a
+one-line change to `packed_arrays_enabled()`'s default.

--- a/docs/perf-branch-breaking-changes.md
+++ b/docs/perf-branch-breaking-changes.md
@@ -39,10 +39,15 @@ native extensions. They are compile-time breaks (the compiler will flag them).
    - **Migration:** matching — `s.as_str()` (bare `s.as_ref()` is now ambiguous: `ArcStr` impls both
      `AsRef<str>` and `AsRef<[u8]>`); constructing — `Value::String(x.into())` from `&str`/`String`.
 
-3. **New `Value` variant: `NumberArray(VmRef<Vec<f64>>)`** (packed f64 arrays).
+3. **New `Value` variant: `NumberArray(VmRef<NumArrayBacking>)`** (packed f64 arrays). As of #520 the
+   backing is an enum `NumArrayBacking { Packed(Vec<f64>), Boxed(Vec<Value>) }` (was a bare
+   `VmRef<Vec<f64>>`) so a non-numeric store can upgrade it in place; see docs/packed-arrays.md.
    - Any **exhaustive** `match value { … }` over `Value` in downstream code now fails to compile and
      must add an arm (or `_`). The variant *exists* in every build; it is only *constructed* under
      `TISH_PACKED_ARRAYS=1` (off by default), so a missing arm is a compile break, not a runtime one.
+   - Readers that pattern-matched `NumberArray(v)` as `VmRef<Vec<f64>>` must go through the enum
+     (`.borrow().to_values()` / `as_packed()` / `get(i)`); `NumArrayBacking` is re-exported from
+     `tishlang_runtime` for generated native code.
 
 4. **Object storage: `PropMap` is now an `IndexMap`-backed `pub struct`** (was a `pub type PropMap =
    AHashMap<Arc<str>, Value>` alias). `ObjectData` construction helpers changed. Embedders building

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -288,6 +288,10 @@ handled via NaN-as-hole marker. Suite 17/0 at flag=0 (byte-identical to interp).
     semantic loss is expected and documented — mixed-type splice requires scope-binding update to
     fully deopt, which `&Value` can't do without architectural changes).
 
+    ⤷ SUPERSEDED by PHASE 2c / #520 (2026-07-17): the "architectural change" is now done — the
+      backing is an in-place-upgradable enum, so non-numeric mutation deopts soundly and this edge
+      case (and the whole class) is gone. See docs/packed-arrays.md.
+
 FINDING — does NOT move array_stress (32ms → 32ms with flag=1). Root cause:
   - array_stress builds arrays via `push()` into empty `[]` literals
   - Empty `[]` stays regular Array (can't infer numeric from zero elements)


### PR DESCRIPTION
## Summary

Documents the packed-arrays state after #520 and records the decision to **keep `TISH_PACKED_ARRAYS` default OFF**.

- **New `docs/packed-arrays.md`** — single source of truth: the `NumArrayBacking { Packed, Boxed }` enum + in-place deopt (aliases observe the upgrade), the #199 soundness gate (sweep 162/162, perf 30/30, the `nextest` acceptance gate now live on PRs), and the perf finding with the measured A/B table.
- **Decision:** default stays **off**. The flip is a wash-to-~1% — the VM JIT bails on `NumberArray`, so packed never reaches the tier that moves numbers (~17–23× node either way). #520 makes flipping *sound* if a future JIT path consumes packed arrays; until then there's no perf justification, only representation churn.
- **Stale-doc fixes:** `perf-branch-breaking-changes.md` (variant is `NumberArray(VmRef<NumArrayBacking>)`, not `VmRef<Vec<f64>>`); `perf.md` PHASE 2 (the "can't fully deopt without architectural changes" note is superseded — #520 is that change).

Docs-only; no code change.