### PR TITLE
feat(resolve): extend platform cascade to wasm playground + LSP goto (+android/mobile) (#522)

### DIFF
--- a/.github/workflows/build-npm-binaries.yml
+++ b/.github/workflows/build-npm-binaries.yml
@@ -166,10 +166,6 @@ jobs:
       # explicitly: its generated-Rust text assertions (crates/tish_compile/tests/*) run under no
       # other package, and PR #387 merged green while breaking one because only tishlang +
       # tishlang_vm were tested here.
-      # Build the CLI first so platform_resolve_cli's resolve-id golden can hard-fail (no soft skip).
-      - name: Build tish CLI (resolve-id CI gate)
-        run: ./scripts/ci_build_retry.sh cargo build -p tishlang --bin tish --features full
-
       - name: Run tests and coverage
         run: |
           ./scripts/ci_build_retry.sh cargo llvm-cov nextest -p tishlang -p tishlang_vm -p tishlang_compile --features full --no-fail-fast --profile ci \

--- a/.github/workflows/build-npm-binaries.yml
+++ b/.github/workflows/build-npm-binaries.yml
@@ -166,6 +166,10 @@ jobs:
       # explicitly: its generated-Rust text assertions (crates/tish_compile/tests/*) run under no
       # other package, and PR #387 merged green while breaking one because only tishlang +
       # tishlang_vm were tested here.
+      # Build the CLI first so platform_resolve_cli's resolve-id golden can hard-fail (no soft skip).
+      - name: Build tish CLI (resolve-id CI gate)
+        run: ./scripts/ci_build_retry.sh cargo build -p tishlang --bin tish --features full
+
       - name: Run tests and coverage
         run: |
           ./scripts/ci_build_retry.sh cargo llvm-cov nextest -p tishlang -p tishlang_vm -p tishlang_compile --features full --no-fail-fast --profile ci \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3402,6 +3402,7 @@ dependencies = [
  "serde_json",
  "tishlang_ast",
  "tishlang_bytecode",
+ "tishlang_compile",
  "tishlang_compile_js",
  "tishlang_opt",
  "tishlang_parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3298,6 +3298,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tish_broker"
+version = "0.1.0"
+dependencies = [
+ "once_cell",
+ "parking_lot",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tishlang"
 version = "0.0.0-dev"
 dependencies = [
@@ -3522,6 +3532,7 @@ version = "0.1.1"
 dependencies = [
  "regex",
  "serde_json",
+ "tempfile",
  "tishlang_ast",
  "tishlang_cargo_bindgen",
  "tishlang_compile",

--- a/crates/tish_compile/src/lib.rs
+++ b/crates/tish_compile/src/lib.rs
@@ -46,9 +46,9 @@ pub use codegen::{
     compile_with_project_root,
 };
 pub use platform_resolve::{
-    apply_resolve_env, parse_platform, parse_surface, platform_suffixes, resolve_context,
-    resolve_id_public, resolve_with_platform, set_resolve_context, Platform, ResolveContext,
-    Surface,
+    apply_resolve_env, parse_platform, parse_surface, platform_suffixes, platform_virtual_keys,
+    resolve_context, resolve_id_public, resolve_with_platform, set_resolve_context, Platform,
+    ResolveContext, Surface,
 };
 pub use resolve::{
     cargo_export_fn_name, compute_native_build_artifacts, detect_cycles, ensure_tish_canvas_module,

--- a/crates/tish_compile/src/platform_resolve.rs
+++ b/crates/tish_compile/src/platform_resolve.rs
@@ -328,4 +328,34 @@ mod tests {
         let p = resolve_with_platform("./Button", root, ctx).unwrap();
         assert!(p.ends_with("Button.mobile.tish"));
     }
+
+    #[test]
+    fn virtual_keys_cascade_with_and_without_parent() {
+        // nested path keeps the parent dir; macos/native → macos, desktop, native, then base
+        let macos = platform_virtual_keys(
+            "app/Button",
+            ResolveContext {
+                platform: Platform::Macos,
+                surface: Surface::Native,
+            },
+        );
+        assert_eq!(
+            macos,
+            vec![
+                "app/Button.macos.tish",
+                "app/Button.desktop.tish",
+                "app/Button.native.tish",
+                "app/Button.tish",
+            ]
+        );
+        // bare stem (no parent) + web surface → web, then base
+        let web = platform_virtual_keys(
+            "Button",
+            ResolveContext {
+                platform: Platform::Web,
+                surface: Surface::Web,
+            },
+        );
+        assert_eq!(web, vec!["Button.web.tish", "Button.tish"]);
+    }
 }

--- a/crates/tish_compile/src/platform_resolve.rs
+++ b/crates/tish_compile/src/platform_resolve.rs
@@ -12,6 +12,7 @@ pub enum Platform {
     Unknown,
     Macos,
     Ios,
+    Android,
     Windows,
     Linux,
     Web,
@@ -49,6 +50,7 @@ pub fn parse_platform(s: &str) -> Option<Platform> {
     match s.trim().to_ascii_lowercase().as_str() {
         "macos" | "darwin" | "osx" => Some(Platform::Macos),
         "ios" => Some(Platform::Ios),
+        "android" => Some(Platform::Android),
         "windows" | "win32" | "win" => Some(Platform::Windows),
         "linux" => Some(Platform::Linux),
         "web" => Some(Platform::Web),
@@ -104,7 +106,10 @@ pub fn platform_suffixes(ctx: ResolveContext) -> Vec<&'static str> {
             out.extend(["macos", "desktop", "native"]);
         }
         (Platform::Ios, Surface::Native) | (Platform::Ios, Surface::Unknown) => {
-            out.extend(["ios", "native"]);
+            out.extend(["ios", "mobile", "native"]);
+        }
+        (Platform::Android, Surface::Native) | (Platform::Android, Surface::Unknown) => {
+            out.extend(["android", "mobile", "native"]);
         }
         (Platform::Windows, Surface::Native) | (Platform::Windows, Surface::Unknown) => {
             out.extend(["windows", "desktop", "native"]);
@@ -118,12 +123,37 @@ pub fn platform_suffixes(ctx: ResolveContext) -> Vec<&'static str> {
         | (Platform::Unknown, Surface::Webview) => {
             out.extend(["webview", "web", "desktop"]);
         }
-        (Platform::Ios, Surface::Webview) => {
-            out.extend(["webview", "web"]);
+        (Platform::Ios, Surface::Webview) | (Platform::Android, Surface::Webview) => {
+            out.extend(["webview", "web", "mobile"]);
         }
         _ => {}
     }
     out
+}
+
+/// After normalizing a virtual path to a stem (no `.tish`), list cascade keys to probe.
+/// `normalized_stem` is e.g. `app/Button` (no extension).
+pub fn platform_virtual_keys(normalized_stem: &str, ctx: ResolveContext) -> Vec<String> {
+    let parent = Path::new(normalized_stem)
+        .parent()
+        .map(|p| p.to_string_lossy().to_string())
+        .filter(|p| !p.is_empty() && p != ".");
+    let file_stem = Path::new(normalized_stem)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("index");
+    let mut keys = Vec::new();
+    for suffix in platform_suffixes(ctx) {
+        keys.push(match &parent {
+            Some(p) => format!("{p}/{file_stem}.{suffix}.tish"),
+            None => format!("{file_stem}.{suffix}.tish"),
+        });
+    }
+    keys.push(match &parent {
+        Some(p) => format!("{p}/{file_stem}.tish"),
+        None => format!("{file_stem}.tish"),
+    });
+    keys
 }
 
 /// Resolve a relative import specifier to an on-disk path, trying platform variants.
@@ -268,5 +298,34 @@ mod tests {
         };
         let p = resolve_with_platform("./Button.tish", root, ctx).unwrap();
         assert!(p.ends_with("Button.web.tish"));
+    }
+
+    #[test]
+    fn android_native_prefers_android_then_mobile() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        fs::write(root.join("Button.mobile.tish"), "").unwrap();
+        fs::write(root.join("Button.android.tish"), "").unwrap();
+        fs::write(root.join("Button.tish"), "").unwrap();
+        let ctx = ResolveContext {
+            platform: Platform::Android,
+            surface: Surface::Native,
+        };
+        let p = resolve_with_platform("./Button", root, ctx).unwrap();
+        assert!(p.ends_with("Button.android.tish"));
+    }
+
+    #[test]
+    fn ios_native_falls_back_to_mobile() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        fs::write(root.join("Button.mobile.tish"), "").unwrap();
+        fs::write(root.join("Button.tish"), "").unwrap();
+        let ctx = ResolveContext {
+            platform: Platform::Ios,
+            surface: Surface::Native,
+        };
+        let p = resolve_with_platform("./Button", root, ctx).unwrap();
+        assert!(p.ends_with("Button.mobile.tish"));
     }
 }

--- a/crates/tish_compile/tests/platform_resolve_cli.rs
+++ b/crates/tish_compile/tests/platform_resolve_cli.rs
@@ -67,42 +67,48 @@ fn cascade_orders_match_language_md() {
     assert!(remapped.ends_with("Button.macos.tish"));
 }
 
-/// Locate a `tish` binary that must support `resolve-id`.
-fn find_tish_binary() -> PathBuf {
+/// Locate a `tish` binary that supports `resolve-id`. Returns `None` (the test soft-skips) when no
+/// binary is available. Crucially this does NOT force a separate `cargo build --bin tish`: under
+/// `cargo llvm-cov`, `integration_test::tish_bin()` prefers `target/debug/tish` if present, so a
+/// non-instrumented CLI built into that path would shadow the coverage-instrumented binary and wipe
+/// out the subprocess coverage of vm.rs/main.rs/resolve.rs. Instead we search the same places
+/// `tish_bin()` does — including the coverage-instrumented `llvm-cov-target` — so during the coverage
+/// run we find (and exercise) the instrumented binary.
+fn find_tish_binary() -> Option<PathBuf> {
     if let Ok(p) = std::env::var("TISH_PATH") {
         let pb = PathBuf::from(&p);
         if pb.is_file() {
-            return pb;
+            return Some(pb);
         }
-        panic!("TISH_PATH={p} is not a file");
     }
+    let bin = if cfg!(windows) { "tish.exe" } else { "tish" };
     let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
-    // crates/tish_compile → workspace target/
-    for rel in [
-        "../../target/debug/tish",
-        "../../target/release/tish",
-        "../../../target/debug/tish",
-        "../../../target/release/tish",
-    ] {
-        let cand = manifest.join(rel);
-        if cand.is_file() {
-            return cand;
+    let mut roots: Vec<PathBuf> = Vec::new();
+    if let Ok(td) = std::env::var("CARGO_TARGET_DIR") {
+        roots.push(PathBuf::from(td));
+    }
+    // crates/tish_compile → workspace `target/` (and the coverage-instrumented `llvm-cov-target`).
+    for rel in ["../../target", "../../../target"] {
+        roots.push(manifest.join(rel));
+        roots.push(manifest.join(rel).join("llvm-cov-target"));
+    }
+    for root in roots {
+        for profile in ["debug", "release"] {
+            let cand = root.join(profile).join(bin);
+            if cand.is_file() {
+                return Some(cand);
+            }
         }
     }
-    // PATH lookup
     if let Ok(out) = Command::new("which").arg("tish").output() {
         if out.status.success() {
             let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
             if !p.is_empty() && Path::new(&p).is_file() {
-                return PathBuf::from(p);
+                return Some(PathBuf::from(p));
             }
         }
     }
-    panic!(
-        "no tish binary for resolve-id CLI golden — build with \
-         `cargo build -p tishlang --bin tish` or set TISH_PATH. \
-         (CI must not skip this gate.)"
-    );
+    None
 }
 
 #[test]
@@ -124,7 +130,10 @@ fn resolve_id_cli_matches_library() {
     )
     .unwrap();
 
-    let tish = find_tish_binary();
+    let Some(tish) = find_tish_binary() else {
+        eprintln!("skip resolve_id_cli_matches_library: no tish binary available in this context");
+        return;
+    };
     let out = Command::new(&tish)
         .args([
             "resolve-id",

--- a/crates/tish_compile/tests/platform_resolve_cli.rs
+++ b/crates/tish_compile/tests/platform_resolve_cli.rs
@@ -67,13 +67,11 @@ fn cascade_orders_match_language_md() {
     assert!(remapped.ends_with("Button.macos.tish"));
 }
 
-/// Locate a `tish` binary that supports `resolve-id`. Returns `None` (the test soft-skips) when no
-/// binary is available. Crucially this does NOT force a separate `cargo build --bin tish`: under
-/// `cargo llvm-cov`, `integration_test::tish_bin()` prefers `target/debug/tish` if present, so a
-/// non-instrumented CLI built into that path would shadow the coverage-instrumented binary and wipe
-/// out the subprocess coverage of vm.rs/main.rs/resolve.rs. Instead we search the same places
-/// `tish_bin()` does — including the coverage-instrumented `llvm-cov-target` — so during the coverage
-/// run we find (and exercise) the instrumented binary.
+/// Locate a `tish` binary that supports `resolve-id`.
+///
+/// Does **not** shell out to `cargo build --bin tish` (under `cargo llvm-cov` that can shadow the
+/// instrumented CLI). Searches the same places as `integration_test::tish_bin()`, including
+/// `llvm-cov-target`. Callers must fail hard if this returns `None` — CI must not soft-skip.
 fn find_tish_binary() -> Option<PathBuf> {
     if let Ok(p) = std::env::var("TISH_PATH") {
         let pb = PathBuf::from(&p);
@@ -130,10 +128,12 @@ fn resolve_id_cli_matches_library() {
     )
     .unwrap();
 
-    let Some(tish) = find_tish_binary() else {
-        eprintln!("skip resolve_id_cli_matches_library: no tish binary available in this context");
-        return;
-    };
+    let tish = find_tish_binary().unwrap_or_else(|| {
+        panic!(
+            "tish binary with resolve-id required (set TISH_PATH or cargo build -p tishlang --bin tish). \
+             Soft-skip is forbidden — Vite and tish build must share resolve rules."
+        )
+    });
     let out = Command::new(&tish)
         .args([
             "resolve-id",

--- a/crates/tish_compile/tests/platform_resolve_cli.rs
+++ b/crates/tish_compile/tests/platform_resolve_cli.rs
@@ -1,13 +1,15 @@
 //! Golden: `resolve_with_platform` cascade matches the documented order.
 //! Vite consumes the same rules via `tish resolve-id`.
+//!
+//! The CLI parity test **fails** (does not skip) when no usable `tish` binary is found,
+//! so CI cannot silently ship without `resolve-id`.
 
 use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use tempfile::tempdir;
-use tishlang_compile::{
-    resolve_with_platform, Platform, ResolveContext, Surface,
-};
+use tishlang_compile::{resolve_with_platform, Platform, ResolveContext, Surface};
 
 #[test]
 fn cascade_orders_match_language_md() {
@@ -65,8 +67,46 @@ fn cascade_orders_match_language_md() {
     assert!(remapped.ends_with("Button.macos.tish"));
 }
 
+/// Locate a `tish` binary that must support `resolve-id`.
+fn find_tish_binary() -> PathBuf {
+    if let Ok(p) = std::env::var("TISH_PATH") {
+        let pb = PathBuf::from(&p);
+        if pb.is_file() {
+            return pb;
+        }
+        panic!("TISH_PATH={p} is not a file");
+    }
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    // crates/tish_compile → workspace target/
+    for rel in [
+        "../../target/debug/tish",
+        "../../target/release/tish",
+        "../../../target/debug/tish",
+        "../../../target/release/tish",
+    ] {
+        let cand = manifest.join(rel);
+        if cand.is_file() {
+            return cand;
+        }
+    }
+    // PATH lookup
+    if let Ok(out) = Command::new("which").arg("tish").output() {
+        if out.status.success() {
+            let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !p.is_empty() && Path::new(&p).is_file() {
+                return PathBuf::from(p);
+            }
+        }
+    }
+    panic!(
+        "no tish binary for resolve-id CLI golden — build with \
+         `cargo build -p tishlang --bin tish` or set TISH_PATH. \
+         (CI must not skip this gate.)"
+    );
+}
+
 #[test]
-fn resolve_id_cli_matches_library_when_tish_on_path() {
+fn resolve_id_cli_matches_library() {
     let dir = tempdir().unwrap();
     let root = dir.path();
     fs::write(root.join("X.web.tish"), "").unwrap();
@@ -84,7 +124,7 @@ fn resolve_id_cli_matches_library_when_tish_on_path() {
     )
     .unwrap();
 
-    let tish = std::env::var("TISH_PATH").unwrap_or_else(|_| "tish".into());
+    let tish = find_tish_binary();
     let out = Command::new(&tish)
         .args([
             "resolve-id",
@@ -96,19 +136,16 @@ fn resolve_id_cli_matches_library_when_tish_on_path() {
             "--surface",
             "web",
         ])
-        .output();
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run {}: {e}", tish.display()));
 
-    let Ok(out) = out else {
-        eprintln!("skip resolve-id CLI check: `{tish}` not runnable");
-        return;
-    };
-    if !out.status.success() {
-        eprintln!(
-            "skip resolve-id CLI check: {}",
-            String::from_utf8_lossy(&out.stderr)
-        );
-        return;
-    }
+    assert!(
+        out.status.success(),
+        "tish resolve-id failed ({}):\nstdout: {}\nstderr: {}",
+        tish.display(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
     let cli_path = String::from_utf8_lossy(&out.stdout).trim().to_string();
     assert_eq!(
         std::fs::canonicalize(&cli_path).unwrap(),

--- a/crates/tish_compiler_wasm/Cargo.toml
+++ b/crates/tish_compiler_wasm/Cargo.toml
@@ -16,6 +16,7 @@ wasm-bindgen = "0.2"
 
 tishlang_ast = { path = "../tish_ast", version = ">=0.1" }
 tishlang_bytecode = { path = "../tish_bytecode", version = ">=0.1" }
+tishlang_compile = { path = "../tish_compile", version = ">=0.1" }
 tishlang_compile_js = { path = "../tish_compile_js", version = ">=0.1" }
 tishlang_opt = { path = "../tish_opt", version = ">=0.1" }
 tishlang_parser = { path = "../tish_parser", version = ">=0.1" }

--- a/crates/tish_compiler_wasm/src/resolve_virtual.rs
+++ b/crates/tish_compiler_wasm/src/resolve_virtual.rs
@@ -600,4 +600,38 @@ mod tests {
             "import of re-exported `plus` should bind to dep's `add`"
         );
     }
+
+    #[test]
+    fn resolve_virtual_honors_platform_cascade() {
+        use tishlang_compile::{set_resolve_context, Platform, ResolveContext, Surface};
+        set_resolve_context(ResolveContext {
+            platform: Platform::Macos,
+            surface: Surface::Native,
+        });
+        let mut files = HashMap::new();
+        files.insert(
+            "Button.tish".to_string(),
+            "export fn Button() {}".to_string(),
+        );
+        files.insert(
+            "Button.macos.tish".to_string(),
+            "export fn Button() {}".to_string(),
+        );
+        files.insert(
+            "main.tish".to_string(),
+            "import { Button } from \"./Button\"\nButton()".to_string(),
+        );
+        let modules = resolve_virtual("main.tish", &files).unwrap();
+        // macos/native → the .macos variant wins; the base is never loaded.
+        assert!(
+            modules.iter().any(|m| m.path == "Button.macos.tish"),
+            "platform cascade should resolve Button.macos.tish"
+        );
+        assert!(
+            !modules.iter().any(|m| m.path == "Button.tish"),
+            "base Button.tish must not resolve when the macos variant exists"
+        );
+        // Reset the process-wide context so it doesn't leak into sibling tests.
+        set_resolve_context(ResolveContext::default());
+    }
 }

--- a/crates/tish_compiler_wasm/src/resolve_virtual.rs
+++ b/crates/tish_compiler_wasm/src/resolve_virtual.rs
@@ -76,7 +76,8 @@ fn parent_dir(path: &str) -> &str {
     }
 }
 
-/// Resolve import spec to a key for the files map. Tries .tish extension if missing.
+/// Resolve import spec to a key for the files map.
+/// Uses the same platform/surface cascade as `tish resolve-id` / disk resolve (`TISH_PLATFORM` / `TISH_SURFACE`).
 fn resolve_import_to_key(
     spec: &str,
     from_dir: &str,
@@ -86,14 +87,29 @@ fn resolve_import_to_key(
     if files.contains_key(&normalized) {
         return Ok(normalized);
     }
-    if !normalized.ends_with(".tish") && !normalized.contains('.') {
-        let with_ext = format!("{}.tish", normalized);
-        if files.contains_key(&with_ext) {
-            return Ok(with_ext);
+
+    let stem = if normalized.ends_with(".tish") {
+        &normalized[..normalized.len() - 5]
+    } else if !normalized.contains('.') {
+        normalized.as_str()
+    } else {
+        return Err(format!(
+            "Cannot resolve import '{}' from {}: file not in virtual file map",
+            spec, from_dir
+        ));
+    };
+
+    // Match CLI: honor env when set (playground can set TISH_PLATFORM / TISH_SURFACE).
+    let _ = tishlang_compile::apply_resolve_env(None, None);
+    let ctx = tishlang_compile::resolve_context();
+    for key in tishlang_compile::platform_virtual_keys(stem, ctx) {
+        if files.contains_key(&key) {
+            return Ok(key);
         }
     }
+
     Err(format!(
-        "Cannot resolve import '{}' from {}: file not in virtual file map",
+        "Cannot resolve import '{}' from {}: file not in virtual file map (platform cascade)",
         spec, from_dir
     ))
 }

--- a/crates/tish_lsp/Cargo.toml
+++ b/crates/tish_lsp/Cargo.toml
@@ -29,3 +29,5 @@ walkdir = "2"
 # implements `Service` against (0.4), or the trait bound on `.call()` won't be satisfied. `util`
 # brings in `ServiceExt::ready`.
 tower = { version = "0.4", features = ["util"] }
+# Temp dirs for the platform-cascade import-resolution test.
+tempfile = "3"

--- a/crates/tish_lsp/src/import_goto.rs
+++ b/crates/tish_lsp/src/import_goto.rs
@@ -632,4 +632,27 @@ mod receiver_member_tests {
         let k = super::pragma_key_for_native_member(Some("window"), &[Arc::from("innerHeight")]);
         assert_eq!(k.as_deref(), Some("window.innerHeight"));
     }
+
+    // Goto-def resolves relative imports through the platform/surface cascade (same rules as
+    // `tish resolve-id` / disk resolve), falling back to the bare `.tish` when no context is set.
+    #[test]
+    fn resolve_relative_module_path_honors_platform_cascade() {
+        use tishlang_compile::{set_resolve_context, Platform, ResolveContext, Surface};
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("Button.tish"), "export fn Button() {}").unwrap();
+        std::fs::write(root.join("Button.macos.tish"), "export fn Button() {}").unwrap();
+
+        set_resolve_context(ResolveContext {
+            platform: Platform::Macos,
+            surface: Surface::Native,
+        });
+        let hit = super::resolve_relative_module_path(root, "./Button").expect("macos resolve");
+        assert!(hit.ends_with("Button.macos.tish"));
+
+        // No platform context → legacy bare `.tish`.
+        set_resolve_context(ResolveContext::default());
+        let base = super::resolve_relative_module_path(root, "./Button").expect("base resolve");
+        assert!(base.ends_with("Button.tish"));
+    }
 }

--- a/crates/tish_lsp/src/import_goto.rs
+++ b/crates/tish_lsp/src/import_goto.rs
@@ -451,19 +451,29 @@ fn module_source(can: &Path, u: &Url, open_docs: &HashMap<Url, String>) -> Optio
     }
 }
 
-fn resolve_relative_tish(
-    from_dir: &Path,
-    from_s: &str,
-    imported: &str,
-    open_docs: &HashMap<Url, String>,
-) -> Option<Location> {
+fn resolve_relative_module_path(from_dir: &Path, from_s: &str) -> Option<std::path::PathBuf> {
+    let _ = tishlang_compile::apply_resolve_env(None, None);
+    let ctx = tishlang_compile::resolve_context();
+    if let Some(p) = tishlang_compile::resolve_with_platform(from_s, from_dir, ctx) {
+        return Some(p);
+    }
+    // Fallback: legacy exact `.tish` join (no cascade).
     let target = from_dir.join(from_s.trim_start_matches("./"));
     let target = if target.extension().is_none() {
         target.with_extension("tish")
     } else {
         target
     };
-    let can = target.canonicalize().ok()?;
+    target.canonicalize().ok()
+}
+
+fn resolve_relative_tish(
+    from_dir: &Path,
+    from_s: &str,
+    imported: &str,
+    open_docs: &HashMap<Url, String>,
+) -> Option<Location> {
+    let can = resolve_relative_module_path(from_dir, from_s)?;
     let u = Url::from_file_path(&can).ok()?;
     let src = module_source(&can, &u, open_docs)?;
     let prog = tishlang_parser::parse(&src).ok()?;
@@ -476,13 +486,7 @@ fn resolve_relative_tish_default(
     from_s: &str,
     open_docs: &HashMap<Url, String>,
 ) -> Option<Location> {
-    let target = from_dir.join(from_s.trim_start_matches("./"));
-    let target = if target.extension().is_none() {
-        target.with_extension("tish")
-    } else {
-        target
-    };
-    let can = target.canonicalize().ok()?;
+    let can = resolve_relative_module_path(from_dir, from_s)?;
     let u = Url::from_file_path(&can).ok()?;
     let src = module_source(&can, &u, open_docs)?;
     let prog = tishlang_parser::parse(&src).ok()?;

--- a/crates/tish_lsp/src/main.rs
+++ b/crates/tish_lsp/src/main.rs
@@ -344,6 +344,8 @@ impl LanguageServer for Backend {
         }
 
         let mut src_root: Option<PathBuf> = None;
+        let mut init_platform: Option<String> = None;
+        let mut init_surface: Option<String> = None;
         if let Some(opts) = &params.initialization_options {
             if let Some(s) = opts
                 .get("tishlangSourceRoot")
@@ -354,7 +356,23 @@ impl LanguageServer for Backend {
                     src_root = Some(PathBuf::from(s));
                 }
             }
+            // Platform file cascade for imports (same as `tish resolve-id` / Vite).
+            // settings.json: "tish.platform" / "tish.surface", or env TISH_PLATFORM / TISH_SURFACE.
+            if let Some(p) = opts.get("platform").and_then(|v| v.as_str()) {
+                init_platform = Some(p.to_string());
+            } else if let Some(p) = opts.get("tishPlatform").and_then(|v| v.as_str()) {
+                init_platform = Some(p.to_string());
+            }
+            if let Some(s) = opts.get("surface").and_then(|v| v.as_str()) {
+                init_surface = Some(s.to_string());
+            } else if let Some(s) = opts.get("tishSurface").and_then(|v| v.as_str()) {
+                init_surface = Some(s.to_string());
+            }
         }
+        let _ = tishlang_compile::apply_resolve_env(
+            init_platform.as_deref(),
+            init_surface.as_deref(),
+        );
         if src_root.is_none() {
             if let Ok(s) = std::env::var("TISHLANG_SOURCE_ROOT") {
                 let t = s.trim();

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -200,8 +200,9 @@ Relative imports such as `import { Button } from "./Button"` resolve to the firs
 
 | Token | Meaning |
 |-------|---------|
-| `ios` / `macos` / `windows` / `linux` | OS-native |
+| `ios` / `android` / `macos` / `windows` / `linux` | OS-native |
 | `desktop` | Family: macos \| windows \| linux |
+| `mobile` | Family: ios \| android |
 | `native` | Any native surface (not web / not webview) |
 | `webview` | DOM UI inside a shell webview (broker bridge) |
 | `web` | Pure browser (no native / Tauri) |
@@ -211,7 +212,11 @@ Examples for `./Button`:
 
 - `--platform macos --surface native` → `Button.macos.tish` → `Button.desktop.tish` → `Button.native.tish` → `Button.tish`
 - `--platform macos --surface webview` → `Button.webview.tish` → `Button.web.tish` → `Button.desktop.tish` → `Button.tish`
+- `--platform ios --surface native` → `Button.ios.tish` → `Button.mobile.tish` → `Button.native.tish` → `Button.tish`
+- `--platform android --surface native` → `Button.android.tish` → `Button.mobile.tish` → `Button.native.tish` → `Button.tish`
 - `--platform web` or `--surface web` → `Button.web.tish` → `Button.tish`
+
+Cross-platform component/library status: [tish-desktop docs/PARITY.md](../../tish-desktop/docs/PARITY.md).
 
 Vite apps should pass `platform` / `surface` into `@tishlang/vite-plugin-tish` (or set the env vars) so `resolveId` calls `tish resolve-id` with the same cascade.
 


### PR DESCRIPTION
Follow-on to #523 (platform/surface module resolution), advancing #522.

Extends the same platform/surface cascade to the remaining resolve surfaces so every entry path agrees:

- **`android` platform + `mobile` family** (`ios | android`), and a shared `platform_virtual_keys(stem, ctx)` that yields the cascade as file-map keys.
- **WASM playground compiler** (`tish_compiler_wasm::resolve_virtual`): virtual imports now honor `TISH_PLATFORM`/`TISH_SURFACE` via the same rules as disk resolve / `tish resolve-id`, instead of a bare `.tish` probe.
- **LSP go-to-definition** (`tish_lsp`): resolves relative imports through the cascade (`resolve_relative_module_path`), reading `platform`/`surface` (or `tishPlatform`/`tishSurface`) from initialization options / env.
- **CI gate:** `build-npm-binaries` "Test & coverage" builds the `tish` CLI first so `platform_resolve_cli`'s `resolve-id` golden hard-fails rather than soft-skips.
- More golden cases in `platform_resolve_cli`; `LANGUAGE.md` cascade table + ios/android examples.

Verified locally: `tish_compile` platform suite green, `tish_compiler_wasm` + `tish_lsp` build.