### PR TITLE
ci(dune-server): pin fleet-safe target-cpu to stop the native SIGILL flake

### DIFF
--- a/.github/workflows/dune-server-regression.yml
+++ b/.github/workflows/dune-server-regression.yml
@@ -26,6 +26,13 @@ jobs:
   dune-server:
     name: distilled dune-server vs tish HEAD
     runs-on: ubuntu-latest
+    # Fleet-safe target-cpu (#223): `tish build` compiles server.tish natively and appends
+    # `-C target-cpu=native` UNLESS RUSTFLAGS already pins a target-cpu (tish_build_utils). On the
+    # virtualized runner `native` detects instructions that then SIGILL at runtime (Illegal
+    # instruction, core dumped) — the recurring dune-server flake. Pin x86-64-v3 so the native build
+    # is fleet-safe, mirroring packed-arrays.yml.
+    env:
+      RUSTFLAGS: "-C target-cpu=x86-64-v3"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

The `distilled dune-server` check fails intermittently with `Illegal instruction (core dumped)` — the native server binary SIGILLs at startup (right after `build OK`, before serving). It's machine-draw dependent (hit #520, #523, #525; re-running sometimes helps, sometimes not — #525 failed 3× in a row). The **sibling native jobs pass on the exact same code** (`Native apps — CLI + fs + serve`, gauntlet, packed sweep), so it's infra, not code.

## Root cause

`tish build` compiles `server.tish` natively and `tish_build_utils` appends `-C target-cpu=native` **unless RUSTFLAGS already pins a `target-cpu`** (crates/tish_build_utils/src/lib.rs). On the virtualized runner, `native` enables instructions that trap at runtime.

## Fix

Pin `RUSTFLAGS: "-C target-cpu=x86-64-v3"` at the `dune-server` job level — the repo's established fleet-safe pattern (`packed-arrays.yml`, #223). `tish build` then sees a `target-cpu` already set and does **not** append `native`, so the native binary runs on any fleet machine. This PR's own dune-server check exercises the fix.

Workflow-only change.