### PR TITLE
test(resolve): lock merged @scope/pkg resolution + document convention (#38)

### DIFF
--- a/crates/tish/tests/scope_merge.rs
+++ b/crates/tish/tests/scope_merge.rs
@@ -1,0 +1,79 @@
+//! Regression for #38: a merged `@scope/pkg` package (declared via `tish.module`, `exports.tish`,
+//! etc.) must resolve as merged **Tish source**, not be routed to the native Rust-crate path (which
+//! would reject it with "not a Tish native module" or mis-treat it as a crate). Native `@scope`
+//! crates (marked with `tish.crate` / `tish.rustDependencies`) remain native and are exercised by
+//! the downstream regression (tish-apple/tish-macos).
+
+use std::fs;
+
+use tishlang_ast::{Expr, Statement};
+use tishlang_compile::{merge_modules, resolve_project};
+
+/// Build a tempdir project whose `main.tish` imports a merged `@test/greet` package. `tish_field`
+/// is the extra package.json snippet declaring how the package presents itself (`,"tish":{…}` etc.).
+fn setup(tish_field: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let pkg = root.join("node_modules/@test/greet");
+    fs::create_dir_all(&pkg).unwrap();
+    fs::write(
+        pkg.join("package.json"),
+        format!(r#"{{"name":"@test/greet","version":"1.0.0"{tish_field}}}"#),
+    )
+    .unwrap();
+    fs::write(pkg.join("index.tish"), "export fn greet() { return \"hi\" }\n").unwrap();
+    fs::write(
+        root.join("main.tish"),
+        "import { greet } from \"@test/greet\"\nconsole.log(greet())\n",
+    )
+    .unwrap();
+    dir
+}
+
+fn assert_merged_as_source(dir: &tempfile::TempDir) {
+    let root = dir.path();
+    let modules = resolve_project(&root.join("main.tish"), Some(root)).expect("resolve");
+    let merged = merge_modules(modules).expect("merge");
+    // Merged as source ⇒ the package's `greet` fn is folded into the top-level program.
+    let has_greet = merged
+        .program
+        .statements
+        .iter()
+        .any(|s| matches!(s, Statement::FunDecl { name, .. } if name.as_ref() == "greet"));
+    assert!(
+        has_greet,
+        "merged @scope package's fn must be folded into the program (merged as Tish source)"
+    );
+    // ...and NOT lowered to a native module load (the #38 mis-routing).
+    let native_scope = merged.program.statements.iter().any(|s| {
+        matches!(
+            s,
+            Statement::VarDecl { init: Some(Expr::NativeModuleLoad { spec, .. }), .. }
+            if spec.contains("@test")
+        )
+    });
+    assert!(
+        !native_scope,
+        "a merged @scope package must NOT be routed to the native Rust-crate path (#38)"
+    );
+}
+
+#[test]
+fn scope_tish_module_true_merges_as_source() {
+    assert_merged_as_source(&setup(r#","tish":{"module":true}"#));
+}
+
+#[test]
+fn scope_tish_module_string_path_merges_as_source() {
+    assert_merged_as_source(&setup(r#","tish":{"module":"index.tish"}"#));
+}
+
+#[test]
+fn scope_exports_tish_merges_as_source() {
+    assert_merged_as_source(&setup(r#","exports":{"tish":"./index.tish"}"#));
+}
+
+#[test]
+fn scope_plain_main_merges_as_source() {
+    assert_merged_as_source(&setup(r#","main":"index.tish""#));
+}

--- a/crates/tish_compile/src/resolve.rs
+++ b/crates/tish_compile/src/resolve.rs
@@ -978,7 +978,13 @@ fn load_module_recursive(
 /// - cargo:… (Cargo `rustDependencies` + generated wrapper; Rust native backend)
 /// - ffi:… (a C-ABI cdylib loaded via `tish_ffi::load_module` — portable across backends)
 ///
-/// Scoped npm packages (`@scope/pkg`) are merged as Tish source unless imported via `tish:…`.
+/// Scoped npm packages (`@scope/pkg`) are **merged as Tish source** by default — they are NOT
+/// native imports and fall through to the module-merge resolver (`exports.tish` / `tish.module`
+/// path / `tish.source` / `index.tish`). A scoped package is only treated as a native Rust crate
+/// when it opts in via `tish.crate` / `tish.rustDependencies` in its package.json (the tish-apple
+/// crates). This split is why `@scope` is intentionally absent below (#38): matching the ecosystem's
+/// resolution for `import … from "@scope/pkg"` is interop, and the native-vs-merged axis is the one
+/// piece tish adds on top, keyed off the native markers rather than mere presence of `tish.module`.
 pub fn is_native_import(spec: &str) -> bool {
     // A leading `node:` (node:fs, node:fs/promises) resolves the same as the bare form.
     let spec = spec.strip_prefix("node:").unwrap_or(spec);


### PR DESCRIPTION
Closes #38.

## Finding

#38 was triaged on the old `feature/types` branch (`resolve_native_modules` routed every non-builtin/non-`cargo:` spec — including `@scope/pkg` — straight to the native resolver). On **main** that's no longer the case: `is_native_import` doesn't match `@scope`, so scoped packages fall through to the module-merge resolver. Verified with a minimal reproduction that a merged `@scope/pkg` resolves as Tish source and **builds + runs on interp / vm / native** across every declaration shape:

| package.json | interp | vm | native |
|---|:--:|:--:|:--:|
| `tish.module: true` | ✅ | ✅ | ✅ |
| `tish.module: "index.tish"` | ✅ | ✅ | ✅ |
| `exports.tish` | ✅ | ✅ | ✅ |
| plain `main` / `tish.source` | ✅ | ✅ | ✅ |

The reported bug (`@scope` + `tish.module` mis-treated as a native Rust crate) does not reproduce.

## What's here

- **Regression test** (`crates/tish/tests/scope_merge.rs`): tempdir project importing a merged `@test/greet` package; asserts its `fn` is folded into the merged program and is **not** lowered to a native module load — for `tish.module: true`, string path, `exports.tish`, and plain `main`.
- **Documented the convention** on `is_native_import`: `@scope` is merged-as-source by default; it's native only when it opts in via `tish.crate` / `tish.rustDependencies`. Presence of `tish.module` does **not** make it native. This is the native-vs-merged split #38 asked to pin down.

Native `@scope` crates stay native and are exercised by the downstream regression (tish-apple / tish-macos), which builds them.