### PR TITLE
fix(errors): unify call-of-non-function error across interp/vm/native (#437)

### DIFF
--- a/crates/tish_core/src/value.rs
+++ b/crates/tish_core/src/value.rs
@@ -1175,15 +1175,15 @@ pub fn value_call(callee: &Value, args: &[Value]) -> Value {
                 return value_call(&inner, args);
             }
             crate::set_pending_throw(crate::not_a_function_error(format!(
-                "{} is not a function",
-                callee.to_display_string()
+                "Call of non-function: {}",
+                callee.type_name()
             )));
             Value::Null
         }
         _ => {
             crate::set_pending_throw(crate::not_a_function_error(format!(
-                "{} is not a function",
-                callee.to_display_string()
+                "Call of non-function: {}",
+                callee.type_name()
             )));
             Value::Null
         }

--- a/crates/tish_eval/src/eval.rs
+++ b/crates/tish_eval/src/eval.rs
@@ -3916,7 +3916,23 @@ impl Evaluator {
                 if let Some(call) = o.borrow().strings.get("__call").cloned() {
                     return self.call_func(&call, args);
                 }
-                Err(EvalError::Error("Not a function".to_string()))
+                Err(EvalError::Throw(
+                    crate::natives::type_error_construct(&[Value::String(
+                        format!(
+                            "Call of non-function: {}",
+                            match f {
+                                Value::Number(_) => "number",
+                                Value::String(_) => "string",
+                                Value::Bool(_) => "boolean",
+                                Value::Null => "null",
+                                Value::Symbol(_) => "symbol",
+                                _ => "object",
+                            }
+                        )
+                        .into(),
+                    )])
+                    .unwrap_or(Value::Null),
+                ))
             }
             Value::Native(native_fn) => {
                 // #122: Node fs callback form — `readFile(path, (err, data) => …)`. The self-less
@@ -4158,7 +4174,23 @@ impl Evaluator {
                     }
                 }
             }
-            _ => Err(EvalError::Error("Not a function".to_string())),
+            _ => Err(EvalError::Throw(
+                    crate::natives::type_error_construct(&[Value::String(
+                        format!(
+                            "Call of non-function: {}",
+                            match f {
+                                Value::Number(_) => "number",
+                                Value::String(_) => "string",
+                                Value::Bool(_) => "boolean",
+                                Value::Null => "null",
+                                Value::Symbol(_) => "symbol",
+                                _ => "object",
+                            }
+                        )
+                        .into(),
+                    )])
+                    .unwrap_or(Value::Null),
+                )),
         }
     }
 

--- a/tests/core/parity_call_nonfn.tish
+++ b/tests/core/parity_call_nonfn.tish
@@ -1,0 +1,12 @@
+// #437: calling a non-function / missing method throws a catchable TypeError on every backend
+// (interp == vm == native), and a program observing it sees the same shape as node. The exact
+// message wording is tish's own ("Call of non-function: <type>"); node uses the source expression,
+// so this asserts the node-safe invariants: name === "TypeError" and the message mentions "function".
+let missing_method = "none"
+let non_fn = "none"
+let o = {}
+try { o.missing() } catch (e) { missing_method = e.name + "/" + e.message.includes("function") }
+let n = 5
+try { n() } catch (e) { non_fn = e.name + "/" + e.message.includes("function") }
+console.log(missing_method)
+console.log(non_fn)

--- a/tests/core/parity_call_nonfn.tish.expected
+++ b/tests/core/parity_call_nonfn.tish.expected
@@ -1,0 +1,2 @@
+TypeError/true
+TypeError/true


### PR DESCRIPTION
Advances #437 (bucket-A: interp≠vm / typed≠boxed).

## The divergence

Calling a non-function or a missing method produced **three different messages** — a try/catch saw a different `e.message` on each backend (the #437 audit's "missing-method error text differs" item):

| backend | before |
|---|---|
| interp | `Error: Not a function` (untyped) |
| vm | `TypeError: Call of non-function: <type>` |
| native | `TypeError: <display> is not a function` |
| node | `TypeError: <expr> is not a function` |

## Fix

Unify all three tish backends on the VM's catchable form — `TypeError: Call of non-function: <type>`:
- **interp** (`eval.rs`): the two non-callable `call_func` arms now throw a catchable `TypeError` with that message (was a plain, non-typed `EvalError::Error`).
- **native** (`tish_core::value_call`): use `callee.type_name()` + the same message (was `to_display_string()` + `"is not a function"`) — matching the comment's own stated intent to "match the VM/interpreter".

```
let o = {}; try { o.missing() } catch (e) { … }
// interp == vm == native:  e.name = "TypeError",  e.message = "Call of non-function: null"
```

`e.name` is `TypeError` on every backend **including node**; the message text is tish's own convention (node uses the source expression, which the runtime can't reconstruct — so message parity vs node is out of scope, like the #438 self-owned-spec items).

## Validation

- Regression `tests/core/parity_call_nonfn.tish`: asserts the node-safe invariants (`name === "TypeError"`, message mentions `"function"`) for both missing-method and call-non-function, across interp/vm/native/node.
- core 22/0, eval 19/0, vm 23/0; **interp==vm==node parity 101/0**; native integration batch green.

After this + #527 (fn-error swallowing) land, the only remaining #437 item is the Object-metamodel (`freeze`/`create`/`defineProperty`) — a deferred design decision, not a divergence bug.