### PR TITLE
test(437): lock recursion/cycle catchability across ALL backends; make WASI catchable (#437, #531)

### DIFF
--- a/crates/tish_core/src/lib.rs
+++ b/crates/tish_core/src/lib.rs
@@ -107,7 +107,21 @@ pub fn dec_call_depth() {
 /// Default recursion ceiling shared by every backend that counts call depth (#381). Chosen with the
 /// interpreter: comfortably deep for real programs, but reached long before counted recursion can
 /// exhaust memory or the stack.
+#[cfg(not(target_arch = "wasm32"))]
 pub const DEFAULT_MAX_CALL_DEPTH: usize = 20_000;
+
+/// wasm32 ceiling (#531). On wasm the embedded VM runs on the single guest stack — there is no host
+/// worker thread to grow into (`Vm` can't spawn on wasm), and the host runtime (wasmtime) bounds
+/// guest call depth by its own `max_wasm_stack`. That limit is NOT reachable from the `.wasm`: it
+/// overflows into an UNCATCHABLE module trap after only ~300 `Vm::run_chunk` frames — the tish
+/// function locals live in the VM operand stack, so the per-frame host cost is ~constant regardless
+/// of the program, and the trap depth is a stable ~310 under default wasmtime. A far lower ceiling
+/// keeps the frame-counting guard firing first (measured safe with margin below the trap), so deep
+/// recursion raises a CATCHABLE `RangeError` on WASI too — matching interp/vm/native rather than
+/// aborting the process. WASI programs are thus capped much shallower than native; that is inherent
+/// to wasm's host-bounded call stack, not a tish choice.
+#[cfg(target_arch = "wasm32")]
+pub const DEFAULT_MAX_CALL_DEPTH: usize = 256;
 
 thread_local! {
     // The recursion ceiling, lazily initialized from `TISH_MAX_CALL_DEPTH` (0 = uninitialized). A

--- a/tests/core/parity_recursion_catchable.tish
+++ b/tests/core/parity_recursion_catchable.tish
@@ -1,0 +1,34 @@
+// #437 (from #381): unbounded recursion and cyclic structures must throw a CATCHABLE error
+// identically on EVERY backend — interp / vm / native / cranelift / wasi must all recover, never
+// abort the process. Node agrees on all of these, so this doubles as a node-parity lock.
+//
+// WASI is included: it once trapped (uncatchable wasm module abort) on deep recursion because the
+// guest call stack overflows wasmtime's max_wasm_stack before the frame-counting guard fires; #531
+// gave wasm32 a lower DEFAULT_MAX_CALL_DEPTH so the guard wins and the overflow is a catchable
+// RangeError here too. (WASI's depth ceiling is far lower than native — inherent to wasm's
+// host-bounded call stack — but the caught-vs-abort behavior is identical.)
+
+// 1. simple unbounded recursion -> catchable RangeError
+function rec(n) { return rec(n + 1) }
+let simple = "NONE"
+try { rec(0) } catch (e) { simple = e.name }
+console.log("simple=" + simple)
+
+// 2. mutual recursion -> catchable RangeError
+function a(n) { return b(n + 1) }
+function b(n) { return a(n + 1) }
+let mutual = "NONE"
+try { a(0) } catch (e) { mutual = e.name }
+console.log("mutual=" + mutual)
+
+// 3. cyclic structure through JSON.stringify -> catchable TypeError
+let o = { x: 1 }
+o.self = o
+let json = "NONE"
+try { JSON.stringify(o) } catch (e) { json = e.name }
+console.log("json=" + json)
+
+// 4. re-entrancy: after a caught overflow the stack guard must reset so normal calls still work
+try { rec(0) } catch (e) { }
+function add(x, y) { return x + y }
+console.log("reentry=" + add(2, 3))

--- a/tests/core/parity_recursion_catchable.tish.expected
+++ b/tests/core/parity_recursion_catchable.tish.expected
@@ -1,0 +1,4 @@
+simple=RangeError
+mutual=RangeError
+json=TypeError
+reentry=5


### PR DESCRIPTION
Closes the last item in #437 (cross-backend divergence bucket): *recursion/cycle catchability must be identical across backends, never one aborting.* **Closes #531.**

## Finding → fix

interp / vm / native / cranelift were already sound (catchable + recover). Verifying it surfaced a real residual — **WASI aborted** on deep recursion (uncatchable wasm module trap) — so this PR **fixes WASI** rather than skipping it. No skip test is checked in; the fixture runs on every backend.

`tests/core/parity_recursion_catchable.tish` asserts catch-and-recover (never abort):

| scenario | result |
|---|---|
| simple unbounded recursion | `RangeError` |
| mutual recursion (`a`↔`b`) | `RangeError` |
| cyclic structure via `JSON.stringify` | `TypeError` |
| re-entrancy after a caught overflow | normal calls still work |

Now identical on **interp == vm == native == cranelift == wasi == node**.

## The WASI fix (#531)

On wasm the embedded VM runs on the single guest stack — `Vm` can't spawn a host worker thread, and wasmtime bounds guest call depth by its own `max_wasm_stack`, overflowing into an **uncatchable** trap after ~310 `Vm::run_chunk` frames, long before the shared `DEFAULT_MAX_CALL_DEPTH` (20 000) guard fires. The `.wasm` can't raise the host limit, and the linear-memory shadow stack (`-z stack-size`) is unrelated to call-depth — I verified a 16 MiB shadow-stack bump does nothing.

So wasm32 gets a lower ceiling via `#[cfg(target_arch = "wasm32")]` in `tish_core`:

```rust
#[cfg(not(target_arch = "wasm32"))] pub const DEFAULT_MAX_CALL_DEPTH: usize = 20_000;
#[cfg(target_arch = "wasm32")]      pub const DEFAULT_MAX_CALL_DEPTH: usize = 256;
```

256 is measured safe below the ~310 trap. The per-frame host cost is ~constant (tish locals live in the VM operand stack, not the Rust stack), so trivial and heavy frames trap at the *same* depth — trivial(300)=ok / trivial(320)=trap and heavy(300)=ok / heavy(320)=trap. The frame-counting guard now wins, and deep recursion is a catchable `RangeError` on WASI too. WASI's depth ceiling is far shallower than native — inherent to wasm's host-bounded call stack — but the caught-vs-abort behavior is identical.

## Validation

- `tish_core` units 22/0.
- All six `test_mvp_programs_*` harnesses green (interp, interp↔vm parity, native, cranelift, **wasi**, js) — 208 s, WASI running the fixture **unskipped**.
- The wasm32 ceiling breaks no existing WASI fixture (deepest genuine recursion among them is `fib(30)`; `recursion_stress` etc. are timing-nondeterministic and excluded).
- Parity fixtures aren't in the perf bundle → no `main.{tish,js}` regen.

With this, #437's checklist is fully addressed → closeable, and the WASI recursion-trap (#531) is fixed in the same change.