### PR TITLE
fix(number)+docs: settle & lock tish numeric/formatting semantics; node-exact toFixed (#438)

### DIFF
--- a/crates/tish_builtins/src/number.rs
+++ b/crates/tish_builtins/src/number.rs
@@ -25,8 +25,16 @@ pub fn to_fixed(n: &Value, digits: &Value) -> Value {
 }
 
 /// f64-domain `Number.prototype.toFixed` so the tree-walk interpreter (distinct `Value`) shares the
-/// exact behavior. Rust's `{:.*}` rounds half-to-even (`(2.5).toFixed(0)` → "2"); JS rounds half away
-/// from zero (→ "3"), so pre-round the scaled value with `.round()` (half-away) before formatting. #247
+/// exact behavior. tish's rule (#438): round the number's *true* decimal value to `digits` places,
+/// ties away from zero — matching V8/node's observable `toFixed`.
+///
+/// The obvious `(num * 10^digits).round()` is wrong: float scaling nudges values that are actually
+/// just below a tie up over it, so `(2.675).toFixed(2)` came out `2.68` where node gives `2.67`
+/// (2.675 is stored as 2.67499999…). Instead we render the double's exact decimal expansion to well
+/// beyond `digits` — f64 fractions terminate, so a generous precision captures the real digits — then
+/// round that digit string: if the first dropped digit is ≥ 5, increment with decimal carry; else
+/// truncate. On the magnitude, "first dropped ≥ 5" is round-half-up = round-half-away-from-zero, and
+/// because the expansion is exact, non-ties round the way the true value dictates. #438
 pub fn to_fixed_str(num: f64, digits: usize) -> String {
     if num.is_nan() {
         return "NaN".to_string();
@@ -38,9 +46,61 @@ pub fn to_fixed_str(num: f64, digits: usize) -> String {
     if num.abs() >= 1e21 {
         return format!("{}", num);
     }
-    let factor = 10f64.powi(digits as i32);
-    let rounded = (num * factor).round() / factor;
-    format!("{:.*}", digits, rounded)
+
+    let negative = num.is_sign_negative() && num != 0.0;
+    let magnitude = num.abs();
+
+    // Exact-enough decimal expansion. The digit just past `digits` then reflects the double's TRUE
+    // value; +25 guard digits sit far beyond any position we inspect, so the half-to-even rounding
+    // Rust applies at the cutoff can't perturb our decision (it would take 25 consecutive 9s to carry
+    // back that far, and such a value already rounds up under the exact rule anyway).
+    let guard = digits + 25;
+    let rendered = format!("{:.*}", guard, magnitude);
+    let dot = rendered.find('.').expect("fixed formatting always has a decimal point");
+    let int_str = &rendered[..dot];
+    let frac = rendered[dot + 1..].as_bytes();
+
+    // Kept digits: the whole integer part, then `digits` fractional digits.
+    let mut ds: Vec<u8> = int_str
+        .bytes()
+        .chain(frac[..digits].iter().copied())
+        .map(|b| b - b'0')
+        .collect();
+
+    // Round half-away-from-zero on the magnitude: increment iff the first dropped digit is >= 5.
+    if frac[digits] - b'0' >= 5 {
+        let mut i = ds.len();
+        loop {
+            if i == 0 {
+                ds.insert(0, 1);
+                break;
+            }
+            i -= 1;
+            if ds[i] == 9 {
+                ds[i] = 0;
+            } else {
+                ds[i] += 1;
+                break;
+            }
+        }
+    }
+
+    // Split back into integer (all but the last `digits`) and fractional digits.
+    let int_len = ds.len() - digits;
+    let mut out = String::with_capacity(ds.len() + 2);
+    if negative {
+        out.push('-');
+    }
+    for &d in &ds[..int_len] {
+        out.push((d + b'0') as char);
+    }
+    if digits > 0 {
+        out.push('.');
+        for &d in &ds[int_len..] {
+            out.push((d + b'0') as char);
+        }
+    }
+    out
 }
 
 /// `Number.prototype.toExponential(fractionDigits?)` — ECMA-262 §21.1.3.2. Exponential notation with

--- a/docs/ecma-alignment.md
+++ b/docs/ecma-alignment.md
@@ -87,7 +87,7 @@ This document maps Tish behavior to ECMA-262 and test262. Each concept has a dec
 - **JSON** — Follow (parse, stringify)
 - **global, Infinity, NaN** — Follow
 - **Error, NativeErrors** — Follow or Simplify
-- **parseInt, parseFloat, isFinite, isNaN** — Follow
+- **parseInt, parseFloat, isFinite, isNaN** — Follow (radix inference, rounding, etc. documented in [numeric-formatting-semantics.md](numeric-formatting-semantics.md), #438)
 - **decodeURI, encodeURI** — Follow
 - **ArrayBuffer, BigInt, Date, Map, Set** — Omit or optional
 - **Promise** — Follow (§27.2): `Promise(executor)`, `.then`, `.catch`, `.finally`, `Promise.resolve`, `Promise.reject`, `Promise.all`, `Promise.race`. Host APIs: `setTimeout`, `setInterval`, `clearTimeout`, `clearInterval`.

--- a/docs/numeric-formatting-semantics.md
+++ b/docs/numeric-formatting-semantics.md
@@ -1,0 +1,63 @@
+# Tish Numeric & Formatting Semantics
+
+Tish's chosen rules for numeric formatting and parsing built-ins (#438, split from #247). These are
+**tish's own documented semantics** — node/V8 is our benchmark and reference, not the correctness
+oracle. In every row below the chosen rule happens to coincide with V8/node (these are user-facing
+format/parse surfaces where matching the ecosystem minimizes surprise), so the same tests double as a
+node-parity lock.
+
+Every rule is asserted across **interp / vm / native / cranelift / wasi / js** by
+[`tests/core/parity_builtins.tish`](../tests/core/parity_builtins.tish) — all backends must agree.
+
+## `Number.prototype.toFixed(digits)`
+
+Round the number's **true decimal value** to `digits` fraction digits, **ties away from zero**.
+
+The value is a binary double, so an input that *looks* like a tie usually isn't: `2.675` is stored as
+`2.67499999999999982…`, so `(2.675).toFixed(2)` is **`2.67`** (rounds down), while a genuine tie like
+`(2.5).toFixed(0)` is **`3`** and `(0.125).toFixed(2)` is **`0.13`** (round away from zero).
+
+Implementation note: computing `(num * 10^digits).round() / 10^digits` is **wrong** — float scaling
+nudges just-below-tie values up over the tie (it produced `2.68`). The shared implementation
+(`tish_builtins::to_fixed_str`) instead renders the double's exact decimal expansion well past
+`digits` and rounds that digit string, so non-ties round the way the real value dictates.
+
+| input | `toFixed` | why |
+|---|---|---|
+| `(2.675).toFixed(2)` | `2.67` | stored as 2.6749…, rounds down |
+| `(1.45).toFixed(1)` | `1.4` | stored as 1.4499… |
+| `(5.55).toFixed(1)` | `5.5` | stored as 5.5499… |
+| `(2.5).toFixed(0)` | `3` | exact tie → away from zero |
+| `(0.125).toFixed(2)` | `0.13` | exact tie → away from zero |
+| `(9.999).toFixed(2)` | `10.00` | carry propagates into integer part |
+
+`NaN` → `"NaN"`, `±Infinity` → `"Infinity"`/`"-Infinity"`, and `|num| ≥ 1e21` falls back to the
+default (exponential) formatting, all matching JS.
+
+## `parseInt(string, radix?)`
+
+Radix inference: a leading `0x`/`0X` (after an optional sign and trimmed leading whitespace) implies
+base 16; otherwise base 10. A leading `0` is **decimal**, not octal (`parseInt("077") === 77`).
+Parsing consumes the longest valid prefix and ignores trailing junk (`parseInt("  42abc") === 42`);
+no valid digits yields `NaN`.
+
+## `Math.round(x)`
+
+Round half **up toward +∞**: `round(2.5) === 3`, `round(-2.5) === -2`, `round(0.5) === 1`,
+`round(-0.5) === -0`. (This is JS's rule, not round-half-to-even.)
+
+## `Math.min()` / `Math.max()`
+
+Empty-args identity: `Math.min() === +Infinity`, `Math.max() === -Infinity`. Any `NaN` argument makes
+the result `NaN`.
+
+## `includes` / `indexOf` / `Set` / `Map` keys
+
+Collection membership uses **SameValueZero**: `NaN` matches `NaN`, and `+0`/`-0` are equal.
+So `[NaN].includes(NaN)` is `true`, `[0].includes(-0)` is `true`, `new Set([NaN]).has(NaN)` is
+`true`. `Array.prototype.indexOf` uses **strict equality** instead, so `[NaN].indexOf(NaN) === -1`.
+
+## `-0` stringification (already decided; recorded here)
+
+`ToString` drops the sign: `String(-0)`, `"" + (-0)`, `` `${-0}` ``, and `(-0).toString()` all yield
+`"0"`. Only the `console.log` **inspect** form preserves `-0`.

--- a/tests/core/parity_builtins.js
+++ b/tests/core/parity_builtins.js
@@ -68,6 +68,12 @@ console.log("parseint-neg", parseInt("-0x10", 16))
 console.log("tofixed", (2.5).toFixed(0))
 console.log("tofixed-neg", (-2.5).toFixed(0))
 console.log("tofixed-pi", (3.14159).toFixed(2))
+// #438: toFixed rounds the number's TRUE decimal value, ties away from zero. Values stored just
+// below an apparent tie (2.675 is really 2.67499…) round DOWN — the old `(n*10^d).round()` impl
+// rounded these UP. These lock the node-exact behavior across every backend.
+console.log("tofixed-tielo", (2.675).toFixed(2), (0.615).toFixed(2), (1.45).toFixed(1), (5.55).toFixed(1))
+console.log("tofixed-tielo2", (4.55).toFixed(1), (0.015).toFixed(2), (0.045).toFixed(2), (8.575).toFixed(2))
+console.log("tofixed-exact", (0.125).toFixed(2), (0.5).toFixed(0), (9.999).toFixed(2), (999.995).toFixed(2))
 // -0 ToString drops the sign (`String(-0) === "0"`); the console *inspect* form keeps it.
 console.log("negzero-tostring", (-0).toString())
 console.log("negzero-string", String(-0))

--- a/tests/core/parity_builtins.tish
+++ b/tests/core/parity_builtins.tish
@@ -68,6 +68,12 @@ console.log("parseint-neg", parseInt("-0x10", 16))
 console.log("tofixed", (2.5).toFixed(0))
 console.log("tofixed-neg", (-2.5).toFixed(0))
 console.log("tofixed-pi", (3.14159).toFixed(2))
+// #438: toFixed rounds the number's TRUE decimal value, ties away from zero. Values stored just
+// below an apparent tie (2.675 is really 2.67499…) round DOWN — the old `(n*10^d).round()` impl
+// rounded these UP. These lock the node-exact behavior across every backend.
+console.log("tofixed-tielo", (2.675).toFixed(2), (0.615).toFixed(2), (1.45).toFixed(1), (5.55).toFixed(1))
+console.log("tofixed-tielo2", (4.55).toFixed(1), (0.015).toFixed(2), (0.045).toFixed(2), (8.575).toFixed(2))
+console.log("tofixed-exact", (0.125).toFixed(2), (0.5).toFixed(0), (9.999).toFixed(2), (999.995).toFixed(2))
 // -0 ToString drops the sign (`String(-0) === "0"`); the console *inspect* form keeps it.
 console.log("negzero-tostring", (-0).toString())
 console.log("negzero-string", String(-0))

--- a/tests/core/parity_builtins.tish.expected
+++ b/tests/core/parity_builtins.tish.expected
@@ -54,6 +54,9 @@ parseint-neg -16
 tofixed 3
 tofixed-neg -3
 tofixed-pi 3.14
+tofixed-tielo 2.67 0.61 1.4 5.5
+tofixed-tielo2 4.5 0.01 0.04 8.57
+tofixed-exact 0.13 1 10.00 1000.00
 negzero-tostring 0
 negzero-string 0
 negzero-concat 0

--- a/tests/main.js
+++ b/tests/main.js
@@ -3531,6 +3531,12 @@ console.log("parseint-neg", parseInt("-0x10", 16))
 console.log("tofixed", (2.5).toFixed(0))
 console.log("tofixed-neg", (-2.5).toFixed(0))
 console.log("tofixed-pi", (3.14159).toFixed(2))
+// #438: toFixed rounds the number's TRUE decimal value, ties away from zero. Values stored just
+// below an apparent tie (2.675 is really 2.67499…) round DOWN — the old `(n*10^d).round()` impl
+// rounded these UP. These lock the node-exact behavior across every backend.
+console.log("tofixed-tielo", (2.675).toFixed(2), (0.615).toFixed(2), (1.45).toFixed(1), (5.55).toFixed(1))
+console.log("tofixed-tielo2", (4.55).toFixed(1), (0.015).toFixed(2), (0.045).toFixed(2), (8.575).toFixed(2))
+console.log("tofixed-exact", (0.125).toFixed(2), (0.5).toFixed(0), (9.999).toFixed(2), (999.995).toFixed(2))
 // -0 ToString drops the sign (`String(-0) === "0"`); the console *inspect* form keeps it.
 console.log("negzero-tostring", (-0).toString())
 console.log("negzero-string", String(-0))

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -3586,6 +3586,12 @@ console.log("parseint-neg", parseInt("-0x10", 16))
 console.log("tofixed", (2.5).toFixed(0))
 console.log("tofixed-neg", (-2.5).toFixed(0))
 console.log("tofixed-pi", (3.14159).toFixed(2))
+// #438: toFixed rounds the number's TRUE decimal value, ties away from zero. Values stored just
+// below an apparent tie (2.675 is really 2.67499…) round DOWN — the old `(n*10^d).round()` impl
+// rounded these UP. These lock the node-exact behavior across every backend.
+console.log("tofixed-tielo", (2.675).toFixed(2), (0.615).toFixed(2), (1.45).toFixed(1), (5.55).toFixed(1))
+console.log("tofixed-tielo2", (4.55).toFixed(1), (0.015).toFixed(2), (0.045).toFixed(2), (8.575).toFixed(2))
+console.log("tofixed-exact", (0.125).toFixed(2), (0.5).toFixed(0), (9.999).toFixed(2), (999.995).toFixed(2))
 // -0 ToString drops the sign (`String(-0) === "0"`); the console *inspect* form keeps it.
 console.log("negzero-tostring", (-0).toString())
 console.log("negzero-string", String(-0))


### PR DESCRIPTION
Resolves #438 (bucket B of #247): *decide + document tish's own numeric/formatting rules and lock them with a `typed==boxed` parity test — node is our benchmark, not the oracle.*

## What each row needed

Probing all 5 rows across interp/vm/native/node, **4 already agreed with node on every backend** → pure document-and-lock, no code change:

| row | rule (documented) |
|---|---|
| `parseInt` radix | leading `0x`→16, leading `0`→**decimal**, trims ws, longest-prefix |
| `Math.round` | half **up toward +∞** (`round(-2.5) === -2`) |
| `Math.min`/`max` | empty → `±Infinity`; any `NaN` → `NaN` |
| `includes`/`Set`/`Map` | **SameValueZero** (`NaN` matches, `±0` equal); `indexOf` strict |

`-0` stringification was already decided (`String(-0) === "0"`, inspect keeps `-0`) — recorded.

## The one real fix: `toFixed`

The shared impl rounded the **float-scaled** value (`(num * 10^d).round() / 10^d`), which pushes values stored *just below* a tie up over it:

```
(2.675).toFixed(2)  →  tish 2.68   node 2.67   (2.675 is stored as 2.67499…)
```

A battery found **7 / 195** such cases wrong, and the **js backend** (native `toFixed`) diverged from interp/vm/native there — a genuine cross-backend split hiding inside a "bucket B" row. Node is objectively correct (it rounds the *true* double value), so "match JS" is right.

Rewrote `tish_builtins::to_fixed_str` to render the double's **exact decimal expansion** past `digits` and round that digit string half-away-from-zero (with decimal carry). Now node-exact and identical on interp/vm/native/cranelift/wasi/js.

**Validation:** compared against node on **1779 cases** (31 edge values × 9 digits + 1500 deterministic pseudo-random) — zero divergences; interp == vm == native == js == node.

## Deliverables

- `docs/numeric-formatting-semantics.md` — the decided rules (pointer added from `ecma-alignment.md`).
- `tests/core/parity_builtins.{tish,js}` — `toFixed` float-edge cases added (additive); `.expected` and the perf bundle (`tests/main.{tish,js}`) regenerated.

## Checks

- `tishlang_builtins` units **63/0**.
- All six `test_mvp_programs_*` harnesses green (interp, interp↔vm, native, cranelift, wasi, js).
- Existing `toFixed` fixtures (`number_tofixed`, `parity_number_methods`) unchanged by the fix.

Closes #438. With #437 (bucket A) already closed, this empties #247's actionable split buckets.