### PR TITLE
perf(vm-jit): OSR loop-region int-typed slots — top-level int loops match the fn path (#514)

### DIFF
--- a/crates/tish_vm/src/jit.rs
+++ b/crates/tish_vm/src/jit.rs
@@ -1101,25 +1101,95 @@ fn build_loop_region_body(
     bcx.append_block_params_for_function_params(entry);
     bcx.switch_to_block(entry);
     let params: Vec<ClifValue> = bcx.block_params(entry).to_vec();
-    let slots_ptr = params[0]; // params[1] = deopt flag, reserved (v1 never writes it)
+    let slots_ptr = params[0];
+    let deopt_ptr = params[1]; // #514: set when an int-slot live-in guard fails → the VM re-interprets
+
+    // #514: port the fn-body int-typed slots (#511) into the OSR loop region. A slot whose every store
+    // is integer-typed lives in an `i64` Variable (`Repr::I64Num`), so an integer hash/PRNG accumulator
+    // stays in integer registers across the loop instead of an f64 materialize per store + ToInt32 per
+    // load. `arity` is 0 at top level (no params). `classify_int_slots` is chunk-level, so a slot that
+    // is int-stored in the region but f64-stored elsewhere in the chunk is (safely) NOT tagged.
+    let int_slots = classify_int_slots(chunk, 0);
     let vars: Vec<Variable> = (0..num_slots)
-        .map(|_| bcx.declare_var(types::F64))
+        .map(|slot| {
+            let ty = if int_slots.contains(&slot) {
+                types::I64
+            } else {
+                types::F64
+            };
+            bcx.declare_var(ty)
+        })
         .collect();
+
+    // Entry marshalling. A non-int slot loads its f64 live-in straight. An int slot's live-in arrives
+    // as f64 from the VM frame, so it must be an EXACT integer that round-trips through i64 — this
+    // rejects non-integers, NaN / ±Inf, out-of-i64-range, and -0 — or the `I64Num` invariant breaks.
+    // On any failure we set the deopt flag and return; the VM discards the (still-pristine) slots and
+    // re-interprets the loop. The guard runs once at region entry, off the per-iteration path.
+    let mut all_ok: Option<ClifValue> = None;
     for (slot, &var) in vars.iter().enumerate() {
-        // Live slots load from their buffer position; slots the region never touches init to 0 (dead).
-        let init = if let Some(&p) = buf_pos.get(&(slot as u16)) {
-            bcx.ins()
-                .load(types::F64, MemFlags::new(), slots_ptr, (p * 8) as i32)
+        let live: Option<ClifValue> = if let Some(&p) = buf_pos.get(&(slot as u16)) {
+            Some(
+                bcx.ins()
+                    .load(types::F64, MemFlags::new(), slots_ptr, (p * 8) as i32),
+            )
         } else {
-            bcx.ins().f64const(0.0)
+            None
         };
-        bcx.def_var(var, init);
+        if int_slots.contains(&slot) {
+            match live {
+                Some(x) => {
+                    let i64c = bcx.ins().fcvt_to_sint_sat(types::I64, x);
+                    let back = bcx.ins().fcvt_from_sint(types::F64, i64c);
+                    let exact = bcx.ins().fcmp(FloatCC::Equal, back, x);
+                    // -0 round-trips to +0 (IEEE `==` is true) but differs as an f64 read, so reject
+                    // it explicitly: 1/(-0) is -∞, 1/(+0) is +∞.
+                    let zero = bcx.ins().f64const(0.0);
+                    let is_zero = bcx.ins().fcmp(FloatCC::Equal, x, zero);
+                    let one = bcx.ins().f64const(1.0);
+                    let recip = bcx.ins().fdiv(one, x);
+                    let recip_neg = bcx.ins().fcmp(FloatCC::LessThan, recip, zero);
+                    let is_neg0 = bcx.ins().band(is_zero, recip_neg);
+                    let not_neg0 = bcx.ins().bxor_imm(is_neg0, 1);
+                    let ok = bcx.ins().band(exact, not_neg0);
+                    all_ok = Some(match all_ok {
+                        Some(a) => bcx.ins().band(a, ok),
+                        None => ok,
+                    });
+                    bcx.def_var(var, i64c);
+                }
+                None => {
+                    let z = bcx.ins().iconst(types::I64, 0);
+                    bcx.def_var(var, z);
+                }
+            }
+        } else {
+            let init = match live {
+                Some(x) => x,
+                None => bcx.ins().f64const(0.0),
+            };
+            bcx.def_var(var, init);
+        }
     }
     let header_block = match blocks.get(&header_ip) {
         Some(&b) => b,
         None => return false,
     };
-    bcx.ins().jump(header_block, &[]);
+    match all_ok {
+        // At least one int slot has a live-in: enter the loop only if every guard passed, else deopt.
+        Some(ok) => {
+            let deopt_block = bcx.create_block();
+            bcx.ins().brif(ok, header_block, &[], deopt_block, &[]);
+            bcx.switch_to_block(deopt_block);
+            let flag = bcx.ins().iconst(types::I8, 1);
+            bcx.ins().store(MemFlags::new(), flag, deopt_ptr, 0);
+            let zero_id = bcx.ins().iconst(types::I32, 0);
+            bcx.ins().return_(&[zero_id]);
+        }
+        None => {
+            bcx.ins().jump(header_block, &[]);
+        }
+    }
 
     // Translate the region. Operand stack is empty at every block boundary (statement-level flow).
     let mut stack: Vec<JV> = Vec::new();
@@ -1163,7 +1233,14 @@ fn build_loop_region_body(
                     Some(v) => *v,
                     None => return false,
                 };
-                stack.push(JV::f64(bcx.use_var(v)));
+                // #514: an int slot's `use_var` is an i64 carrying the exact number (`I64Num`);
+                // downstream int ops take it as identity, one exact convert at an f64 boundary.
+                let lv = bcx.use_var(v);
+                stack.push(if int_slots.contains(&slot) {
+                    JV::i64num(lv)
+                } else {
+                    JV::f64(lv)
+                });
                 ip += 3;
             }
             Opcode::StoreLocal => {
@@ -1182,10 +1259,27 @@ fn build_loop_region_body(
                     Some(v) => *v,
                     None => return false,
                 };
-                // Slots are f64 Variables — one materialize at the store boundary (int-typed
-                // slots are #168's follow-up).
-                let val = jv_f64(&mut bcx, jval);
-                bcx.def_var(v, val);
+                if int_slots.contains(&slot) {
+                    // #514/#168: store the EXACT number as i64 — I32 stores sign-extend, U32
+                    // zero-extend, I64Num is identity, an integral constant re-derives its exact
+                    // i64. Anything else means the optimistic pre-pass mis-tagged this slot (e.g. a
+                    // merge point whose linear predecessor differed) → bail; the VM keeps semantics.
+                    let iv = match jval.repr {
+                        Repr::I32 => bcx.ins().sextend(types::I64, jval.v),
+                        Repr::U32 => bcx.ins().uextend(types::I64, jval.v),
+                        Repr::I64Num => jval.v,
+                        Repr::F64 => match int_const_i64(&mut bcx, chunk, code, ip) {
+                            Some(iv) => iv,
+                            None => return false,
+                        },
+                        Repr::Bool => return false,
+                    };
+                    bcx.def_var(v, iv);
+                } else {
+                    // f64 Variable — one materialize at the store boundary.
+                    let val = jv_f64(&mut bcx, jval);
+                    bcx.def_var(v, val);
+                }
                 ip += 3;
             }
             Opcode::Pop => {
@@ -1301,7 +1395,13 @@ fn build_loop_region_body(
     for (&t, &blk) in &exit_blocks {
         bcx.switch_to_block(blk);
         for (p, &slot) in used_slots.iter().enumerate() {
-            let v = bcx.use_var(vars[slot as usize]);
+            let raw = bcx.use_var(vars[slot as usize]);
+            // #514: an int slot holds an i64 — flush its exact f64 value back to the buffer.
+            let v = if int_slots.contains(&(slot as usize)) {
+                bcx.ins().fcvt_from_sint(types::F64, raw)
+            } else {
+                raw
+            };
             bcx.ins()
                 .store(MemFlags::new(), v, slots_ptr, (p * 8) as i32);
         }

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -1918,6 +1918,11 @@ impl Vm {
         // SAFETY: `buf` is a valid `[f64; used_slots.len()]`; `deopt` is a valid `*mut u8`. The region
         // was compiled for exactly this chunk+header (fingerprint-checked in the cache).
         let exit_id = loopfn.call(&mut buf, &mut deopt);
+        if deopt != 0 {
+            // #514: an int-slot live-in wasn't an exact in-range integer, so the region bailed at
+            // entry BEFORE touching `buf` — the slots are still their pre-loop values. Re-interpret.
+            return OsrResult::LiveInMiss;
+        }
         for (p, &slot) in loopfn.used_slots.iter().enumerate() {
             if let Some(d) = slots.get_mut(slot_base + slot as usize) {
                 *d = Value::Number(buf[p]);

--- a/tests/core/jit_osr_int_slots.js
+++ b/tests/core/jit_osr_int_slots.js
@@ -1,0 +1,52 @@
+// #514: top-level hot integer loops take the OSR loop-region JIT path (#408), which now keeps
+// integer accumulators in i64 slots (Repr::I64Num) like the fn-body path (#511) instead of an
+// f64 materialize per store. Covers: an FNV rolling hash at top level (the flagship win), an int
+// slot ALSO read as f64 in the same loop, an out-of-2^32-range integer live-in (round-trips, int
+// ops still ToInt32), and the entry live-in DEOPT guard (non-integer / NaN / -0 live-ins fall back
+// to the interpreter). Identical output on interp / vm / native / cranelift / wasi / node.
+
+// FNV-1a rolling hash, top level — the OSR int-slot fast path.
+let h = 2166136261
+let i = 0
+while (i < 20000) {
+  h = h ^ (i & 255)
+  h = (h * 16777619) >>> 0
+  h = ((h << 13) | (h >>> 19)) >>> 0
+  i = i + 1
+}
+console.log("fnv", h)
+
+// An int slot (a) read as f64 (added into a float sum) in the same loop.
+let a = 305419896
+let sum = 0
+let j = 0
+while (j < 1000) {
+  a = (a << 1) ^ (a >>> 5)
+  sum = sum + (a >>> 0)
+  j = j + 1
+}
+console.log("mixed", a >>> 0, sum)
+
+// Out-of-2^32-range integer live-in: round-trips through i64; int ops still ToInt32.
+let big = 10000000000
+let k = 0
+while (k < 5) { big = (big ^ 1) + 0; k = k + 1 }
+console.log("big", big >>> 0)
+
+// Deopt guard: a non-integer live-in reaching an int-typed slot bails the region to the interpreter.
+let f = 3.14
+let m = 0
+while (m < 4) { f = f ^ 7; m = m + 1 }
+console.log("deopt-frac", f)
+
+// Deopt guard: NaN live-in.
+let g = 0 / 0
+let p = 0
+while (p < 4) { g = g | 3; p = p + 1 }
+console.log("deopt-nan", g)
+
+// Deopt guard: -0 live-in (must not be treated as +0).
+let z = -0
+let q = 0
+while (q < 3) { z = z | 0; q = q + 1 }
+console.log("deopt-negzero", 1 / z)

--- a/tests/core/jit_osr_int_slots.tish
+++ b/tests/core/jit_osr_int_slots.tish
@@ -1,0 +1,52 @@
+// #514: top-level hot integer loops take the OSR loop-region JIT path (#408), which now keeps
+// integer accumulators in i64 slots (Repr::I64Num) like the fn-body path (#511) instead of an
+// f64 materialize per store. Covers: an FNV rolling hash at top level (the flagship win), an int
+// slot ALSO read as f64 in the same loop, an out-of-2^32-range integer live-in (round-trips, int
+// ops still ToInt32), and the entry live-in DEOPT guard (non-integer / NaN / -0 live-ins fall back
+// to the interpreter). Identical output on interp / vm / native / cranelift / wasi / node.
+
+// FNV-1a rolling hash, top level — the OSR int-slot fast path.
+let h = 2166136261
+let i = 0
+while (i < 20000) {
+  h = h ^ (i & 255)
+  h = (h * 16777619) >>> 0
+  h = ((h << 13) | (h >>> 19)) >>> 0
+  i = i + 1
+}
+console.log("fnv", h)
+
+// An int slot (a) read as f64 (added into a float sum) in the same loop.
+let a = 305419896
+let sum = 0
+let j = 0
+while (j < 1000) {
+  a = (a << 1) ^ (a >>> 5)
+  sum = sum + (a >>> 0)
+  j = j + 1
+}
+console.log("mixed", a >>> 0, sum)
+
+// Out-of-2^32-range integer live-in: round-trips through i64; int ops still ToInt32.
+let big = 10000000000
+let k = 0
+while (k < 5) { big = (big ^ 1) + 0; k = k + 1 }
+console.log("big", big >>> 0)
+
+// Deopt guard: a non-integer live-in reaching an int-typed slot bails the region to the interpreter.
+let f = 3.14
+let m = 0
+while (m < 4) { f = f ^ 7; m = m + 1 }
+console.log("deopt-frac", f)
+
+// Deopt guard: NaN live-in.
+let g = 0 / 0
+let p = 0
+while (p < 4) { g = g | 3; p = p + 1 }
+console.log("deopt-nan", g)
+
+// Deopt guard: -0 live-in (must not be treated as +0).
+let z = -0
+let q = 0
+while (q < 3) { z = z | 0; q = q + 1 }
+console.log("deopt-negzero", 1 / z)

--- a/tests/core/jit_osr_int_slots.tish.expected
+++ b/tests/core/jit_osr_int_slots.tish.expected
@@ -1,0 +1,6 @@
+fnv 1589739541
+mixed 242607933 2203235918557
+big 1410065409
+deopt-frac 3
+deopt-nan 3
+deopt-negzero Infinity

--- a/tests/main.js
+++ b/tests/main.js
@@ -1811,6 +1811,61 @@ console.log(pick(3, 10), pick(2, 10))
 }
 
 {
+// #514: top-level hot integer loops take the OSR loop-region JIT path (#408), which now keeps
+// integer accumulators in i64 slots (Repr::I64Num) like the fn-body path (#511) instead of an
+// f64 materialize per store. Covers: an FNV rolling hash at top level (the flagship win), an int
+// slot ALSO read as f64 in the same loop, an out-of-2^32-range integer live-in (round-trips, int
+// ops still ToInt32), and the entry live-in DEOPT guard (non-integer / NaN / -0 live-ins fall back
+// to the interpreter). Identical output on interp / vm / native / cranelift / wasi / node.
+
+// FNV-1a rolling hash, top level — the OSR int-slot fast path.
+let h = 2166136261
+let i = 0
+while (i < 20000) {
+  h = h ^ (i & 255)
+  h = (h * 16777619) >>> 0
+  h = ((h << 13) | (h >>> 19)) >>> 0
+  i = i + 1
+}
+console.log("fnv", h)
+
+// An int slot (a) read as f64 (added into a float sum) in the same loop.
+let a = 305419896
+let sum = 0
+let j = 0
+while (j < 1000) {
+  a = (a << 1) ^ (a >>> 5)
+  sum = sum + (a >>> 0)
+  j = j + 1
+}
+console.log("mixed", a >>> 0, sum)
+
+// Out-of-2^32-range integer live-in: round-trips through i64; int ops still ToInt32.
+let big = 10000000000
+let k = 0
+while (k < 5) { big = (big ^ 1) + 0; k = k + 1 }
+console.log("big", big >>> 0)
+
+// Deopt guard: a non-integer live-in reaching an int-typed slot bails the region to the interpreter.
+let f = 3.14
+let m = 0
+while (m < 4) { f = f ^ 7; m = m + 1 }
+console.log("deopt-frac", f)
+
+// Deopt guard: NaN live-in.
+let g = 0 / 0
+let p = 0
+while (p < 4) { g = g | 3; p = p + 1 }
+console.log("deopt-nan", g)
+
+// Deopt guard: -0 live-in (must not be treated as +0).
+let z = -0
+let q = 0
+while (q < 3) { z = z | 0; q = q + 1 }
+console.log("deopt-negzero", 1 / z)
+}
+
+{
 // VM-JIT shift coverage (#168). Shifts live inside LOOP functions so the control-flow JIT
 // (build_body_cfg) compiles them — the realistic hot path. Results must be bit-identical to the
 // interpreter, native, and node. Covers JS count-masking (& 31, incl. i>31 in the loop), signed

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -1842,6 +1842,62 @@ console.log(pick(3, 10), pick(2, 10))
 }
 __perf_run_core_jit_bitwise()
 
+fn __perf_run_core_jit_osr_int_slots() {
+// #514: top-level hot integer loops take the OSR loop-region JIT path (#408), which now keeps
+// integer accumulators in i64 slots (Repr::I64Num) like the fn-body path (#511) instead of an
+// f64 materialize per store. Covers: an FNV rolling hash at top level (the flagship win), an int
+// slot ALSO read as f64 in the same loop, an out-of-2^32-range integer live-in (round-trips, int
+// ops still ToInt32), and the entry live-in DEOPT guard (non-integer / NaN / -0 live-ins fall back
+// to the interpreter). Identical output on interp / vm / native / cranelift / wasi / node.
+
+// FNV-1a rolling hash, top level — the OSR int-slot fast path.
+let h = 2166136261
+let i = 0
+while (i < 20000) {
+  h = h ^ (i & 255)
+  h = (h * 16777619) >>> 0
+  h = ((h << 13) | (h >>> 19)) >>> 0
+  i = i + 1
+}
+console.log("fnv", h)
+
+// An int slot (a) read as f64 (added into a float sum) in the same loop.
+let a = 305419896
+let sum = 0
+let j = 0
+while (j < 1000) {
+  a = (a << 1) ^ (a >>> 5)
+  sum = sum + (a >>> 0)
+  j = j + 1
+}
+console.log("mixed", a >>> 0, sum)
+
+// Out-of-2^32-range integer live-in: round-trips through i64; int ops still ToInt32.
+let big = 10000000000
+let k = 0
+while (k < 5) { big = (big ^ 1) + 0; k = k + 1 }
+console.log("big", big >>> 0)
+
+// Deopt guard: a non-integer live-in reaching an int-typed slot bails the region to the interpreter.
+let f = 3.14
+let m = 0
+while (m < 4) { f = f ^ 7; m = m + 1 }
+console.log("deopt-frac", f)
+
+// Deopt guard: NaN live-in.
+let g = 0 / 0
+let p = 0
+while (p < 4) { g = g | 3; p = p + 1 }
+console.log("deopt-nan", g)
+
+// Deopt guard: -0 live-in (must not be treated as +0).
+let z = -0
+let q = 0
+while (q < 3) { z = z | 0; q = q + 1 }
+console.log("deopt-negzero", 1 / z)
+}
+__perf_run_core_jit_osr_int_slots()
+
 fn __perf_run_core_jit_shifts() {
 // VM-JIT shift coverage (#168). Shifts live inside LOOP functions so the control-flow JIT
 // (build_body_cfg) compiles them — the realistic hot path. Results must be bit-identical to the


### PR DESCRIPTION
Closes #514 — the named successor on #203's real-integer-type track (#439 Math.imul → #510 typed repr → #511 int slots → **#514**).

## Problem

The fn-body JIT keeps integer accumulators in i64 slots (`Repr::I64Num`, #511), but #408's OSR **loop-region** builder declared every slot as f64. So a hot integer loop at **top level** paid the full f64-materialize-per-store + ToInt32-per-load seam the fn path had already shed — a 30M-iteration FNV body ran **2.25× slower** at top level than inside a `fn`.

## Fix

Ports #511 into `build_loop_region_body`:
- `classify_int_slots` over the region (chunk-level classifier, arity 0 at top level) → **i64 Variables** for tagged slots;
- `LoadLocal` pushes `I64Num`; `StoreLocal` does the same **bail-on-mis-tag** store as the fn path;
- exit blocks flush int slots back through the f64 buffer via an exact `fcvt_from_sint`.

**The OSR-specific part — live-in marshalling.** An int slot's live-in arrives as f64 from the VM frame (unlike fn locals, which start at 0). So the entry **guards** it: the value must be an exact integer that round-trips through i64 (`fcvt_from_sint(fcvt_to_sint_sat(x)) == x`), rejecting non-integers, NaN/±Inf, out-of-i64-range, and `-0`. On failure the region writes the previously-reserved **deopt flag** and returns without touching the slot buffer; `run_osr` sees the flag and re-interprets the loop from its original slots. The guard is one-time at entry, off the per-iteration path.

## Measured (release, VM `tish run`, min of 5, checksum `3295615320` == node)

| top-level FNV (30M) | ms |
|---|---|
| `TISH_JIT_INT_SLOTS=0` (pre-#514) | 690 |
| **#514** | **310** |
| fn-body path (reference) | 310 |
| node | 280 |

**690 → 310ms (2.23×)**; the top-level penalty is gone (now equal to the fn path), and it's 1.11× of node (was 2.46×). `TISH_JIT_INT_SLOTS=0` restores the pre-#514 behavior byte-for-byte.

## Soundness / validation

Because this is default-on, the guard was validated hard:
- `tests/core/jit_osr_int_slots.tish` — FNV at top level, an int slot **also read as f64**, an out-of-2³² live-in, and the **non-integer / NaN / -0** deopt-guard cases — identical on interp/vm/native/cranelift/wasi/js/node.
- **interp==vm parity across all core fixtures** (the direct OSR-miscompile gate), `run_parity_compare` **102/0**, all six `test_mvp_programs_*` harnesses **6/0**, VM units green.
- Edge battery (non-integer, out-of-range, NaN, -0, negative live-ins): vm == interp == node == `INT_SLOTS=0` on every case.

Refs #203, #168, #408, #510, #511.