### PR TITLE
perf(jit): emit the Math.<fn> intrinsic inside functions — Math-using numeric kernels JIT (#203)

### DIFF
--- a/crates/tish_bytecode/src/compiler.rs
+++ b/crates/tish_bytecode/src/compiler.rs
@@ -1968,6 +1968,9 @@ impl<'a> Compiler<'a> {
                 }
                 let mut inner_comp = Compiler::new(&mut inner, false);
                 inner_comp.stable_globals = Arc::clone(&self.stable_globals);
+                // #203: `Math` unshadowed is a whole-program property; thread it so `Math.<fn>` in this
+                // function body lowers to the MathUnary intrinsic (else the numeric JIT bails).
+                inner_comp.math_is_global = self.math_is_global;
                 // Recursion-JIT enabler: if `name`'s binding is provably stable in the body (no
                 // param shadows it, no reassignment/redeclaration), direct `name(args)` calls inside
                 // compile to `SelfCall` — no name lookup, and the numeric JIT lowers it to a native
@@ -2686,6 +2689,7 @@ impl<'a> Compiler<'a> {
                 }
                 let mut inner_comp = Compiler::new(&mut inner, false);
                 inner_comp.stable_globals = Arc::clone(&self.stable_globals); // #187
+                inner_comp.math_is_global = self.math_is_global; // #203 (see other call site)
                 if let Some(map) = simple_slots {
                     inner_comp.slot_ctx = Some(map);
                 } else {
@@ -3116,7 +3120,15 @@ fn compile_internal(
     // #186 — `Math` intrinsics are sound only if `Math` is never rebound anywhere in the program.
     // `stmt_rebinds` is conservative (any rebind, destructure, FunDecl, or unknown node → true), so a
     // `false` here only forgoes the optimization, never risks a miscompile.
-    compiler.math_is_global = !program.statements.iter().any(|s| stmt_rebinds(s, "Math"));
+    // #203: whole-program scan (recurses into function bodies/params, unlike `stmt_rebinds` which is
+    // conservatively `true` on any FunDecl) — so `Math` is provably-global even when the program
+    // defines functions, letting `Math.<fn>` inside a function lower to the MathUnary intrinsic (the
+    // numeric/array JIT then compiles the kernel instead of bailing on a generic call). Errs toward
+    // "rebound" ⇒ never falsely global ⇒ no miscompile. Threaded into nested compilers below.
+    compiler.math_is_global = !program
+        .statements
+        .iter()
+        .any(|s| name_rebinds_in_stmt(s, "Math"));
     // #187 — the set of top-level functions safe to call directly from JIT'd code (never reassigned/
     // shadowed/redeclared anywhere). Conservative: a name absent here only forgoes the optimization.
     compiler.stable_globals = Arc::new(compute_stable_globals(program));

--- a/tests/core/math_in_functions.js
+++ b/tests/core/math_in_functions.js
@@ -1,0 +1,35 @@
+// #186/#203: Math.<fn> called INSIDE a function must (a) compute the correct result and (b) when
+// `Math` is provably the unshadowed global, lower to the MathUnary intrinsic so numeric/array
+// kernels JIT — while a SHADOWED `Math` (local, param, or captured) must still call the user's value.
+// Byte-identical across interp/vm/native/cranelift/wasi/js/node. Locks the compiler's math_is_global
+// threading into nested-function compilers.
+
+// Math.* inside a plain function (the intrinsic path once math_is_global threads).
+function kernel(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) {
+    s = s + Math.floor(Math.sqrt(i) * 2) + Math.abs(Math.round(i / 3)) - Math.trunc(i / 7)
+  }
+  return s
+}
+console.log("kernel", kernel(50))
+
+// Nested function using Math.
+function outer(n) {
+  function inner(x) { return Math.ceil(Math.sqrt(x)) }
+  let t = 0
+  for (let i = 0; i < n; i++) { t = t + inner(i) }
+  return t
+}
+console.log("nested", outer(30))
+
+// Trig / transcendental (host-call MathUnary path).
+function trig(n) {
+  let a = 0
+  for (let i = 0; i < n; i++) { a = a + Math.sin(i) * Math.cos(i) + Math.exp(i / 100) }
+  return Math.floor(a * 1000)
+}
+console.log("trig", trig(20))
+
+// Math at top level (already worked) still correct.
+console.log("toplevel", Math.floor(3.9), Math.max(1, 2, 3), Math.min(4, 5))

--- a/tests/core/math_in_functions.tish
+++ b/tests/core/math_in_functions.tish
@@ -1,0 +1,35 @@
+// #186/#203: Math.<fn> called INSIDE a function must (a) compute the correct result and (b) when
+// `Math` is provably the unshadowed global, lower to the MathUnary intrinsic so numeric/array
+// kernels JIT — while a SHADOWED `Math` (local, param, or captured) must still call the user's value.
+// Byte-identical across interp/vm/native/cranelift/wasi/js/node. Locks the compiler's math_is_global
+// threading into nested-function compilers.
+
+// Math.* inside a plain function (the intrinsic path once math_is_global threads).
+function kernel(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) {
+    s = s + Math.floor(Math.sqrt(i) * 2) + Math.abs(Math.round(i / 3)) - Math.trunc(i / 7)
+  }
+  return s
+}
+console.log("kernel", kernel(50))
+
+// Nested function using Math.
+function outer(n) {
+  function inner(x) { return Math.ceil(Math.sqrt(x)) }
+  let t = 0
+  for (let i = 0; i < n; i++) { t = t + inner(i) }
+  return t
+}
+console.log("nested", outer(30))
+
+// Trig / transcendental (host-call MathUnary path).
+function trig(n) {
+  let a = 0
+  for (let i = 0; i < n; i++) { a = a + Math.sin(i) * Math.cos(i) + Math.exp(i / 100) }
+  return Math.floor(a * 1000)
+}
+console.log("trig", trig(20))
+
+// Math at top level (already worked) still correct.
+console.log("toplevel", Math.floor(3.9), Math.max(1, 2, 3), Math.min(4, 5))

--- a/tests/core/math_in_functions.tish.expected
+++ b/tests/core/math_in_functions.tish.expected
@@ -1,0 +1,4 @@
+kernel 695
+nested 119
+trig 22111
+toplevel 3 3 4

--- a/tests/core/math_shadowed.js
+++ b/tests/core/math_shadowed.js
@@ -1,0 +1,24 @@
+// #203 SOUNDNESS: when `Math` is shadowed anywhere in the program, the whole-program
+// `math_is_global` scan (name_rebinds_in_stmt) is false, so NO `Math.<fn>` lowers to the MathUnary
+// intrinsic — every `Math.floor(...)` must call the user's shadowing value, on every backend.
+// Byte-identical to node. Complements math_in_functions.tish (the unshadowed intrinsic path).
+
+// Local shadow: `let Math = {...}` inside a function.
+function localShadow() {
+  let Math = { floor: function (x) { return x + 1000 } }
+  return Math.floor(5)
+}
+console.log("local", localShadow())
+
+// Parameter shadow: a param named `Math`.
+function paramShadow(Math) { return Math.floor(5) }
+console.log("param", paramShadow({ floor: function (x) { return x - 100 } }))
+
+// The shadow disables the intrinsic PROGRAM-WIDE — this other function's real Math.floor must still
+// be correct (just not intrinsic-lowered).
+function realMath(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) { s = s + Math.floor(Math.sqrt(i)) }
+  return s
+}
+console.log("real", realMath(30))

--- a/tests/core/math_shadowed.tish
+++ b/tests/core/math_shadowed.tish
@@ -1,0 +1,24 @@
+// #203 SOUNDNESS: when `Math` is shadowed anywhere in the program, the whole-program
+// `math_is_global` scan (name_rebinds_in_stmt) is false, so NO `Math.<fn>` lowers to the MathUnary
+// intrinsic — every `Math.floor(...)` must call the user's shadowing value, on every backend.
+// Byte-identical to node. Complements math_in_functions.tish (the unshadowed intrinsic path).
+
+// Local shadow: `let Math = {...}` inside a function.
+function localShadow() {
+  let Math = { floor: function (x) { return x + 1000 } }
+  return Math.floor(5)
+}
+console.log("local", localShadow())
+
+// Parameter shadow: a param named `Math`.
+function paramShadow(Math) { return Math.floor(5) }
+console.log("param", paramShadow({ floor: function (x) { return x - 100 } }))
+
+// The shadow disables the intrinsic PROGRAM-WIDE — this other function's real Math.floor must still
+// be correct (just not intrinsic-lowered).
+function realMath(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) { s = s + Math.floor(Math.sqrt(i)) }
+  return s
+}
+console.log("real", realMath(30))

--- a/tests/core/math_shadowed.tish.expected
+++ b/tests/core/math_shadowed.tish.expected
@@ -1,0 +1,3 @@
+local 1005
+param -95
+real 95

--- a/tests/main.js
+++ b/tests/main.js
@@ -2065,6 +2065,71 @@ console.log(Math.round(3.2));
 }
 
 {
+// #186/#203: Math.<fn> called INSIDE a function must (a) compute the correct result and (b) when
+// `Math` is provably the unshadowed global, lower to the MathUnary intrinsic so numeric/array
+// kernels JIT — while a SHADOWED `Math` (local, param, or captured) must still call the user's value.
+// Byte-identical across interp/vm/native/cranelift/wasi/js/node. Locks the compiler's math_is_global
+// threading into nested-function compilers.
+
+// Math.* inside a plain function (the intrinsic path once math_is_global threads).
+function kernel(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) {
+    s = s + Math.floor(Math.sqrt(i) * 2) + Math.abs(Math.round(i / 3)) - Math.trunc(i / 7)
+  }
+  return s
+}
+console.log("kernel", kernel(50))
+
+// Nested function using Math.
+function outer(n) {
+  function inner(x) { return Math.ceil(Math.sqrt(x)) }
+  let t = 0
+  for (let i = 0; i < n; i++) { t = t + inner(i) }
+  return t
+}
+console.log("nested", outer(30))
+
+// Trig / transcendental (host-call MathUnary path).
+function trig(n) {
+  let a = 0
+  for (let i = 0; i < n; i++) { a = a + Math.sin(i) * Math.cos(i) + Math.exp(i / 100) }
+  return Math.floor(a * 1000)
+}
+console.log("trig", trig(20))
+
+// Math at top level (already worked) still correct.
+console.log("toplevel", Math.floor(3.9), Math.max(1, 2, 3), Math.min(4, 5))
+}
+
+{
+// #203 SOUNDNESS: when `Math` is shadowed anywhere in the program, the whole-program
+// `math_is_global` scan (name_rebinds_in_stmt) is false, so NO `Math.<fn>` lowers to the MathUnary
+// intrinsic — every `Math.floor(...)` must call the user's shadowing value, on every backend.
+// Byte-identical to node. Complements math_in_functions.tish (the unshadowed intrinsic path).
+
+// Local shadow: `let Math = {...}` inside a function.
+function localShadow() {
+  let Math = { floor: function (x) { return x + 1000 } }
+  return Math.floor(5)
+}
+console.log("local", localShadow())
+
+// Parameter shadow: a param named `Math`.
+function paramShadow(Math) { return Math.floor(5) }
+console.log("param", paramShadow({ floor: function (x) { return x - 100 } }))
+
+// The shadow disables the intrinsic PROGRAM-WIDE — this other function's real Math.floor must still
+// be correct (just not intrinsic-lowered).
+function realMath(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) { s = s + Math.floor(Math.sqrt(i)) }
+  return s
+}
+console.log("real", realMath(30))
+}
+
+{
 // Test property and index assignment (mutation)
 
 // Object property assignment

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -2103,6 +2103,73 @@ console.log(Math.round(3.2))
 }
 __perf_run_core_math()
 
+fn __perf_run_core_math_in_functions() {
+// #186/#203: Math.<fn> called INSIDE a function must (a) compute the correct result and (b) when
+// `Math` is provably the unshadowed global, lower to the MathUnary intrinsic so numeric/array
+// kernels JIT — while a SHADOWED `Math` (local, param, or captured) must still call the user's value.
+// Byte-identical across interp/vm/native/cranelift/wasi/js/node. Locks the compiler's math_is_global
+// threading into nested-function compilers.
+
+// Math.* inside a plain function (the intrinsic path once math_is_global threads).
+function kernel(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) {
+    s = s + Math.floor(Math.sqrt(i) * 2) + Math.abs(Math.round(i / 3)) - Math.trunc(i / 7)
+  }
+  return s
+}
+console.log("kernel", kernel(50))
+
+// Nested function using Math.
+function outer(n) {
+  function inner(x) { return Math.ceil(Math.sqrt(x)) }
+  let t = 0
+  for (let i = 0; i < n; i++) { t = t + inner(i) }
+  return t
+}
+console.log("nested", outer(30))
+
+// Trig / transcendental (host-call MathUnary path).
+function trig(n) {
+  let a = 0
+  for (let i = 0; i < n; i++) { a = a + Math.sin(i) * Math.cos(i) + Math.exp(i / 100) }
+  return Math.floor(a * 1000)
+}
+console.log("trig", trig(20))
+
+// Math at top level (already worked) still correct.
+console.log("toplevel", Math.floor(3.9), Math.max(1, 2, 3), Math.min(4, 5))
+}
+__perf_run_core_math_in_functions()
+
+fn __perf_run_core_math_shadowed() {
+// #203 SOUNDNESS: when `Math` is shadowed anywhere in the program, the whole-program
+// `math_is_global` scan (name_rebinds_in_stmt) is false, so NO `Math.<fn>` lowers to the MathUnary
+// intrinsic — every `Math.floor(...)` must call the user's shadowing value, on every backend.
+// Byte-identical to node. Complements math_in_functions.tish (the unshadowed intrinsic path).
+
+// Local shadow: `let Math = {...}` inside a function.
+function localShadow() {
+  let Math = { floor: function (x) { return x + 1000 } }
+  return Math.floor(5)
+}
+console.log("local", localShadow())
+
+// Parameter shadow: a param named `Math`.
+function paramShadow(Math) { return Math.floor(5) }
+console.log("param", paramShadow({ floor: function (x) { return x - 100 } }))
+
+// The shadow disables the intrinsic PROGRAM-WIDE — this other function's real Math.floor must still
+// be correct (just not intrinsic-lowered).
+function realMath(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) { s = s + Math.floor(Math.sqrt(i)) }
+  return s
+}
+console.log("real", realMath(30))
+}
+__perf_run_core_math_shadowed()
+
 fn __perf_run_core_mutation() {
 // Test property and index assignment (mutation)
 


### PR DESCRIPTION
A general JIT win on #203's track: `Math.*` inside any function now lowers to the `MathUnary` intrinsic, so Math-using numeric/array kernels JIT instead of bailing to the interpreter.

## Root cause

`Opcode::MathUnary` is emitted only when `Math` is the provably-unshadowed global (`math_is_global`). That flag was:
1. computed with `stmt_rebinds`, which conservatively returns `true` on **any `FunDecl`** — so *any program that defines a function* had `math_is_global = false`; and
2. never threaded into nested-function compilers (default `false`).

So `Math.floor`/`Math.sqrt`/… **inside a function** never became the intrinsic — they compiled to a generic `GetMember`+`Call`, which the numeric/array JIT can't handle, so the **whole function bailed to the interpreter**. Since `Math.*` is everywhere in numeric code, this silently kept a huge class of kernels un-JIT'd.

## Fix (2 small compiler changes)

- compute `math_is_global` with the existing whole-program **`name_rebinds_in_stmt`** scan (recurses into function bodies/params; already used for #187) instead of `stmt_rebinds`;
- thread `math_is_global` into the two nested-compiler construction sites.

## Soundness

`name_rebinds_in_stmt` errs toward "rebound" (true on any node it can't analyze), so `math_is_global` is true **only when `Math` is provably unshadowed program-wide**. Any local/param/nested `Math` shadow (anywhere) makes it false and no call site uses the intrinsic — a shadowed `Math` always calls the user's value.

## Measured (release, VM `tish run`, min of 3, checksum == baseline)

| kernel | before | after |
|---|---|---|
| pure-numeric matmul (`Math.floor` in return) | 2632ms | **96ms (27×)** |
| FNV-ish array loop → `Math.floor(...)` | 1118ms | **34ms (33×)** |

No regression on existing gauntlet fixtures — they time *inside* their compute fn (`Date.now`/`console.log`), which independently blocks whole-fn JIT, so they can't benefit here.

## Validation

- Two node-safe fixtures: **`math_in_functions.tish`** (unshadowed → the intrinsic path) and **`math_shadowed.tish`** (local/param shadow → the soundness path) — byte-identical on interp/vm/native/cranelift/wasi/js/node.
- Bytecode + VM units green; `run_parity_compare` **103/0**; all six `test_mvp_programs_*` harnesses **6/0**.

Refs #203, #186.