### PR TITLE
perf(jit): MathBinary intrinsic (max/min/pow/atan2) — clamp/pow kernels JIT (#203)

### DIFF
--- a/crates/tish_bytecode/src/compiler.rs
+++ b/crates/tish_bytecode/src/compiler.rs
@@ -11,7 +11,7 @@ use tishlang_ast::{
 
 use crate::chunk::{Chunk, Constant};
 use crate::encoding::{binop_to_u8, compound_op_to_u8, unaryop_to_u8};
-use crate::opcode::{MathUnaryFn, Opcode};
+use crate::opcode::{MathBinaryFn, MathUnaryFn, Opcode};
 
 enum SimpleMapResult {
     Identity,
@@ -2396,6 +2396,31 @@ impl<'a> Compiler<'a> {
                                 if let Some(mfn) = MathUnaryFn::from_name(fname.as_ref()) {
                                     self.compile_expr(arg)?;
                                     self.emit_u16(Opcode::MathUnary, mfn as u16);
+                                    return Ok(());
+                                }
+                            }
+                        }
+                    }
+                }
+                // #203: `Math.<binfn>(a, b)` → `<a>; <b>; MathBinary(id)` — the same unshadowed-global
+                // gate, for exactly two positional args (variadic `Math.max(a,b,c)` falls through to a
+                // generic call). Lets the numeric JIT lower clamp/pow kernels instead of bailing.
+                if self.math_is_global && args.len() == 2 {
+                    if let Expr::Member {
+                        object,
+                        prop: MemberProp::Name { name: fname, .. },
+                        optional: false,
+                        ..
+                    } = callee.as_ref()
+                    {
+                        if let (Expr::Ident { name: obj, .. }, CallArg::Expr(a0), CallArg::Expr(a1)) =
+                            (object.as_ref(), &args[0], &args[1])
+                        {
+                            if obj.as_ref() == "Math" && self.resolve_slot("Math").is_none() {
+                                if let Some(bfn) = MathBinaryFn::from_name(fname.as_ref()) {
+                                    self.compile_expr(a0)?;
+                                    self.compile_expr(a1)?;
+                                    self.emit_u16(Opcode::MathBinary, bfn as u16);
                                     return Ok(());
                                 }
                             }

--- a/crates/tish_bytecode/src/lib.rs
+++ b/crates/tish_bytecode/src/lib.rs
@@ -16,5 +16,5 @@ pub use compiler::{
     compile_with_source, CompileError,
 };
 pub use encoding::{binop_to_u8, compound_op_to_u8, u8_to_binop, u8_to_unaryop, unaryop_to_u8};
-pub use opcode::{MathUnaryFn, Opcode};
+pub use opcode::{MathBinaryFn, MathUnaryFn, Opcode};
 pub use serialize::{deserialize, serialize};

--- a/crates/tish_bytecode/src/opcode.rs
+++ b/crates/tish_bytecode/src/opcode.rs
@@ -145,6 +145,11 @@ pub enum Opcode {
     /// lower it to a native op / libcall without a runtime shape guard. Behaviour is identical to
     /// `LoadVar Math; GetMember fn; <arg>; Call 1` on a number.
     MathUnary = 55,
+    /// #203 — apply a BINARY `Math.<fn>` intrinsic (max / min / pow / atan2 / hypot) to the top TWO
+    /// numbers: pop `b`, pop `a`, push `Math.fn(a, b)`. The u16 operand is the [`MathBinaryFn`] id.
+    /// Same emission gate as [`Opcode::MathUnary`] (`Math` provably the unshadowed global) but for
+    /// exactly two args. Behaviour identical to `LoadVar Math; GetMember fn; <a>; <b>; Call 2`.
+    MathBinary = 56,
 }
 
 /// The unary `Math` functions the [`Opcode::MathUnary`] fast path recognizes (#186). f64→f64;
@@ -289,11 +294,81 @@ impl MathUnaryFn {
     }
 }
 
+/// The binary `Math` functions the [`Opcode::MathBinary`] fast path recognizes (#203). `(f64, f64) →
+/// f64`; the discriminant is the opcode operand. Kept in sync with the VM handler and JIT lowering.
+/// (`hypot` is intentionally NOT here — it stays a correct generic call to avoid replicating its
+/// scaled-sum-of-squares in this below-builtins crate.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub enum MathBinaryFn {
+    Max = 0,
+    Min = 1,
+    Pow = 2,
+    Atan2 = 3,
+}
+
+impl MathBinaryFn {
+    /// Map a `Math.<name>` member to its id, or `None` if it isn't a supported 2-arg intrinsic.
+    pub fn from_name(name: &str) -> Option<MathBinaryFn> {
+        Some(match name {
+            "max" => MathBinaryFn::Max,
+            "min" => MathBinaryFn::Min,
+            "pow" => MathBinaryFn::Pow,
+            "atan2" => MathBinaryFn::Atan2,
+            _ => return None,
+        })
+    }
+
+    /// Decode an opcode operand to the fn id (safe match — no transmute).
+    pub fn from_u16(v: u16) -> Option<MathBinaryFn> {
+        use MathBinaryFn::*;
+        Some(match v {
+            0 => Max,
+            1 => Min,
+            2 => Pow,
+            3 => Atan2,
+            _ => return None,
+        })
+    }
+
+    /// Apply the intrinsic — the single source of truth for VM + JIT result parity. Replicates the JS
+    /// semantics of `tishlang_builtins::math` (this crate sits below builtins), so VM/JIT == interp.
+    #[inline]
+    pub fn apply(self, a: f64, b: f64) -> f64 {
+        match self {
+            // Math.max(a,b): NaN if either is NaN; else the larger, with +0 preferred over -0. Exactly
+            // `max_f64(&[a, b])`.
+            MathBinaryFn::Max => {
+                if a.is_nan() || b.is_nan() {
+                    f64::NAN
+                } else if a > b || (a == 0.0 && b == 0.0 && a.is_sign_positive()) {
+                    a
+                } else {
+                    b
+                }
+            }
+            // Math.min(a,b): NaN if either is NaN; else the smaller, with -0 preferred. Exactly
+            // `min_f64(&[a, b])`.
+            MathBinaryFn::Min => {
+                if a.is_nan() || b.is_nan() {
+                    f64::NAN
+                } else if a < b || (a == 0.0 && b == 0.0 && a.is_sign_negative()) {
+                    a
+                } else {
+                    b
+                }
+            }
+            MathBinaryFn::Pow => a.powf(b),
+            MathBinaryFn::Atan2 => a.atan2(b),
+        }
+    }
+}
+
 impl Opcode {
-    /// Decode byte to opcode. Safe for b in 0..=55 (matches #[repr(u8)] discriminants).
+    /// Decode byte to opcode. Safe for b in 0..=56 (matches #[repr(u8)] discriminants).
     #[inline]
     pub fn from_u8(b: u8) -> Option<Opcode> {
-        if b <= 55 {
+        if b <= 56 {
             Some(unsafe { std::mem::transmute::<u8, Opcode>(b) })
         } else {
             None

--- a/crates/tish_vm/src/jit.rs
+++ b/crates/tish_vm/src/jit.rs
@@ -497,6 +497,8 @@ struct JitGlobal {
     /// `FuncId` of the imported `tish_math_call` host fn (#186), declared once at module init and
     /// re-imported into each compiled function via `declare_func_in_func`.
     math_call_id: cranelift_module::FuncId,
+    /// `FuncId` of the imported `tish_math_binary_call` host fn (#203), for the `MathBinary` intrinsic.
+    math_binary_call_id: cranelift_module::FuncId,
     /// `FuncId`s of the imported `tish_jv_*` vector runtime (#189).
     jv_fns: JvFns,
     /// #187: directly-callable numeric callees, keyed by the stable global name a top-level function is
@@ -687,9 +689,23 @@ extern "C" fn tish_math_call(id: i32, x: f64) -> f64 {
     }
 }
 
+/// #203 — host call for the `MathBinary` intrinsic (max/min/pow/atan2). Routes through
+/// `MathBinaryFn::apply`, the single source of truth, so JIT ≡ VM ≡ interp.
+extern "C" fn tish_math_binary_call(id: i32, a: f64, b: f64) -> f64 {
+    match tishlang_bytecode::MathBinaryFn::from_u16(id as u16) {
+        Some(m) => m.apply(a, b),
+        None => f64::NAN,
+    }
+}
+
 /// Build the JIT module and declare the imported host functions (`tish_math_call` #186, the
 /// `tish_jv_*` vector runtime #189), returning the module + their `FuncId`s.
-fn new_module() -> Option<(JITModule, cranelift_module::FuncId, JvFns)> {
+fn new_module() -> Option<(
+    JITModule,
+    cranelift_module::FuncId,
+    cranelift_module::FuncId,
+    JvFns,
+)> {
     let mut flag_builder = settings::builder();
     // JIT code is loaded at a fixed address; no PIC / colocated libcalls needed.
     flag_builder.set("use_colocated_libcalls", "false").ok()?;
@@ -701,6 +717,7 @@ fn new_module() -> Option<(JITModule, cranelift_module::FuncId, JvFns)> {
         .ok()?;
     let mut builder = JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
     builder.symbol("tish_math_call", tish_math_call as *const u8);
+    builder.symbol("tish_math_binary_call", tish_math_binary_call as *const u8);
     builder.symbol("tish_jv_new", tish_jv_new as *const u8);
     builder.symbol("tish_jv_push", tish_jv_push as *const u8);
     builder.symbol("tish_jv_get", tish_jv_get as *const u8);
@@ -717,6 +734,16 @@ fn new_module() -> Option<(JITModule, cranelift_module::FuncId, JvFns)> {
     msig.returns.push(AbiParam::new(types::F64));
     let math_id = module
         .declare_function("tish_math_call", Linkage::Import, &msig)
+        .ok()?;
+
+    // `tish_math_binary_call(i32 fn-id, f64 a, f64 b) -> f64` (#203).
+    let mut mbsig = module.make_signature();
+    mbsig.params.push(AbiParam::new(types::I32));
+    mbsig.params.push(AbiParam::new(types::F64));
+    mbsig.params.push(AbiParam::new(types::F64));
+    mbsig.returns.push(AbiParam::new(types::F64));
+    let math_binary_id = module
+        .declare_function("tish_math_binary_call", Linkage::Import, &mbsig)
         .ok()?;
 
     // Helper to declare a `tish_jv_*` import from param/return abi lists.
@@ -761,18 +788,19 @@ fn new_module() -> Option<(JITModule, cranelift_module::FuncId, JvFns)> {
         free: declare("tish_jv_free", &[AbiParam::new(types::I64)], &[])?,
         deopt: declare("tish_jv_deopt", &[], &[])?,
     };
-    Some((module, math_id, jv))
+    Some((module, math_id, math_binary_id, jv))
 }
 
 fn jit() -> Option<&'static Mutex<JitGlobal>> {
     JIT.get_or_init(|| {
-        new_module().map(|(module, math_call_id, jv_fns)| {
+        new_module().map(|(module, math_call_id, math_binary_call_id, jv_fns)| {
             Mutex::new(JitGlobal {
                 module,
                 cache: HashMap::new(),
                 osr_cache: HashMap::new(),
                 counter: 0,
                 math_call_id,
+                math_binary_call_id,
                 jv_fns,
                 callees: HashMap::new(),
             })
@@ -950,7 +978,8 @@ fn compile_loop_region(
             | Opcode::LoopVarsEnd
             | Opcode::LoopVarsBegin
             | Opcode::UnaryOp
-            | Opcode::MathUnary => {} // #186 — `Math.<fn>(x)`: 1 f64 in, 1 f64 out (like UnaryOp)
+            | Opcode::MathUnary // #186 — `Math.<fn>(x)`: 1 f64 in, 1 f64 out (like UnaryOp)
+            | Opcode::MathBinary => {} // #203 — `Math.<fn>(a,b)`: 2 f64 in, 1 f64 out
             Opcode::LoadLocal | Opcode::StoreLocal => {
                 used.insert(peek_u16(code, ip + 1)?);
             }
@@ -1033,6 +1062,7 @@ fn compile_loop_region(
     let mut ctx = g.module.make_context();
     ctx.func.signature = sig.clone();
     let math_fref = g.module.declare_func_in_func(g.math_call_id, &mut ctx.func);
+    let math_binary_fref = g.module.declare_func_in_func(g.math_binary_call_id, &mut ctx.func);
     let mut fbctx = FunctionBuilderContext::new();
     let built = build_loop_region_body(
         &mut ctx.func,
@@ -1045,6 +1075,7 @@ fn compile_loop_region(
         &buf_pos,
         &exit_id,
         math_fref,
+        math_binary_fref,
     );
     if !built {
         g.module.clear_context(&mut ctx);
@@ -1083,6 +1114,7 @@ fn build_loop_region_body(
     buf_pos: &HashMap<u16, usize>,
     exit_id: &HashMap<usize, usize>,
     math_fref: cranelift::codegen::ir::FuncRef,
+    math_binary_fref: cranelift::codegen::ir::FuncRef,
 ) -> bool {
     let code = &chunk.code;
     let num_slots = chunk.num_slots as usize;
@@ -1381,6 +1413,30 @@ fn build_loop_region_body(
                 stack.push(JV::f64(r));
                 ip += 3;
             }
+            Opcode::MathBinary => {
+                // #203 — `Math.<fn>(a, b)`: pop b, pop a, host-call, push. Every 2-arg Math fn routes
+                // through the host call (identical to the VM), so there are no native-op semantics to
+                // match — the win is skipping the boxed GetMember+value_call the generic path pays.
+                let id = match peek_u16(code, ip + 1) {
+                    Some(v) => v,
+                    None => return false,
+                };
+                let b = match stack.pop() {
+                    Some(v) => v,
+                    None => return false,
+                };
+                let a = match stack.pop() {
+                    Some(v) => v,
+                    None => return false,
+                };
+                let b = jv_f64(&mut bcx, b);
+                let a = jv_f64(&mut bcx, a);
+                let idc = bcx.ins().iconst(types::I32, id as i64);
+                let call = bcx.ins().call(math_binary_fref, &[idc, a, b]);
+                let r = bcx.inst_results(call)[0];
+                stack.push(JV::f64(r));
+                ip += 3;
+            }
             _ => match emit_simple_op(&mut bcx, chunk, code, &mut ip, &mut stack, &[], 0) {
                 SimpleOp::Handled(_) => {}
                 _ => return false, // LoadConst/BinOp/UnaryOp handled; anything else → keep interpreting
@@ -1666,6 +1722,7 @@ fn compile_chunk(g: &mut JitGlobal, chunk: &Chunk) -> Option<NumericFn> {
     ctx.func.signature = sig.clone();
     let self_ref = g.module.declare_func_in_func(id, &mut ctx.func);
     let math_fref = g.module.declare_func_in_func(g.math_call_id, &mut ctx.func);
+    let math_binary_fref = g.module.declare_func_in_func(g.math_binary_call_id, &mut ctx.func);
     // #189: import the `tish_jv_*` FuncRefs into this function when it has local arrays.
     let jv_ctx = if is_jv {
         Some(JvCtx {
@@ -1694,6 +1751,7 @@ fn compile_chunk(g: &mut JitGlobal, chunk: &Chunk) -> Option<NumericFn> {
         0,
         recur_guard,
         math_fref,
+        math_binary_fref,
         jv_ctx.as_ref(),
         &resolved,
     ) {
@@ -1945,6 +2003,7 @@ fn compile_chunk_arrays(
     // `handles_ptr`/`deopt_ptr` — only the numeric args are re-marshalled per level.
     let self_ref = g.module.declare_func_in_func(id, &mut ctx.func);
     let math_fref = g.module.declare_func_in_func(g.math_call_id, &mut ctx.func);
+    let math_binary_fref = g.module.declare_func_in_func(g.math_binary_call_id, &mut ctx.func);
     // #187: array-mode functions (e.g. spectral_norm's multiplyAv) may call a register-f64 callee.
     let resolved = build_resolved_callees(g, chunk, &mut ctx.func);
     let mut fbctx = FunctionBuilderContext::new();
@@ -1958,6 +2017,7 @@ fn compile_chunk_arrays(
         mask,
         recursive, // #187: array-mode recursion guard (the entry SP-bail keys off this)
         math_fref,
+        math_binary_fref,
         None,
         &resolved,
     )
@@ -2225,7 +2285,7 @@ fn op_size(op: Opcode) -> Option<usize> {
     Some(match op {
         Nop | Pop | Dup | Return | LoopVarsEnd | EnterBlock | ExitBlock | GetIndex | SetIndex => 1,
         LoadLocal | StoreLocal | LoadConst | BinOp | UnaryOp | Jump | JumpIfFalse | JumpBack
-        | LoopVarsBegin | SelfCall | MathUnary => 3,
+        | LoopVarsBegin | SelfCall | MathUnary | MathBinary => 3,
         _ => return None,
     })
 }
@@ -2576,6 +2636,8 @@ fn build_body_cfg(
     recur_guard: bool,
     // #186: the imported `tish_math_call` host fn, for lowering `Math.<fn>` (`MathUnary`) intrinsics.
     math_fref: cranelift::codegen::ir::FuncRef,
+    // #203: the imported `tish_math_binary_call` host fn, for lowering `MathBinary` (max/min/pow/atan2).
+    math_binary_fref: cranelift::codegen::ir::FuncRef,
     // #189: `Some` when the function has local `f64` arrays — carries the `tish_jv_*` `FuncRef`s + the
     // JV slot set. Those slots become `i64` handle Variables and their array ops lower to `tish_jv_*`
     // calls; an out-of-bounds index sets the per-thread deopt flag the wrapper re-interprets on.
@@ -3098,6 +3160,19 @@ fn build_body_cfg(
                 let x = stack.pop()?;
                 let x = jv_f64(&mut bcx, x);
                 let r = emit_math_unary(&mut bcx, math_fref, mfn, x);
+                stack.push(JV::f64(r));
+                ip += 3;
+            }
+            Opcode::MathBinary => {
+                // #203 — `Math.<fn>(a, b)`: pop b, pop a, host-call, push.
+                let id = peek_u16(code, ip + 1)?;
+                let b = stack.pop()?;
+                let a = stack.pop()?;
+                let b = jv_f64(&mut bcx, b);
+                let a = jv_f64(&mut bcx, a);
+                let idc = bcx.ins().iconst(types::I32, id as i64);
+                let call = bcx.ins().call(math_binary_fref, &[idc, a, b]);
+                let r = bcx.inst_results(call)[0];
                 stack.push(JV::f64(r));
                 ip += 3;
             }
@@ -4029,17 +4104,32 @@ mod tests {
     }
 
     /// #190 — a loop that touches a non-slot value (a general call) is not pure-numeric slot math, so
-    /// the region must be rejected (negative-cached) and the VM keeps interpreting. `Math.max` is a
-    /// 2-arg call (NOT the #186 unary intrinsic), so it stays a `Call` the region must reject.
+    /// the region must be rejected (negative-cached) and the VM keeps interpreting. A user-function
+    /// call is such a value. (`Math.max`/`min`/`pow` used to serve as the example here, but they are
+    /// now the #203 `MathBinary` intrinsic and DO OSR-compile — see `osr_region_handles_math_binary`.)
     #[test]
     fn osr_region_rejects_calls() {
         let chunk = top_chunk(
-            "let a = 0.0\nfor (let i = 0; i < 100; i = i + 1) { a = a + Math.max(i, 2.0) }\n",
+            "function g(x) { return x + 1.0 }\nlet a = 0.0\nfor (let i = 0; i < 100; i = i + 1) { a = a + g(i) }\n",
         );
         let (header, end) = first_region(&chunk);
         assert!(
             try_compile_loop(&chunk, header, end).is_none(),
             "a loop containing a general call must not OSR-compile"
+        );
+    }
+
+    /// #203 — a loop whose only "call" is a 2-arg `Math.<fn>` (the `MathBinary` intrinsic) IS
+    /// pure-numeric slot math, so the OSR region compiles it (the win for clamp/pow kernels).
+    #[test]
+    fn osr_region_handles_math_binary() {
+        let chunk = top_chunk(
+            "let a = 0.0\nfor (let i = 0; i < 100; i = i + 1) { a = a + Math.max(i, 2.0) }\n",
+        );
+        let (header, end) = first_region(&chunk);
+        assert!(
+            try_compile_loop(&chunk, header, end).is_some(),
+            "a loop with only a 2-arg Math intrinsic must OSR-compile"
         );
     }
 

--- a/crates/tish_vm/src/vm.rs
+++ b/crates/tish_vm/src/vm.rs
@@ -2483,6 +2483,23 @@ impl Vm {
                         .ok_or_else(|| format!("Bad MathUnary id: {}", id))?;
                     self.stack.push(Value::Number(mfn.apply(x)));
                 }
+                Opcode::MathBinary => {
+                    // #203 — `Math.<fn>(a, b)` on two numbers. Same reasoning as MathUnary (emitted
+                    // only when `Math` is the global builtin); each non-number coerces to NaN. Args
+                    // were pushed a-then-b, so pop b first.
+                    let id = Self::read_u16(code, &mut ip);
+                    let b = match self.stack.pop() {
+                        Some(Value::Number(n)) => n,
+                        Some(_) | None => f64::NAN,
+                    };
+                    let a = match self.stack.pop() {
+                        Some(Value::Number(n)) => n,
+                        Some(_) | None => f64::NAN,
+                    };
+                    let bfn = tishlang_bytecode::MathBinaryFn::from_u16(id)
+                        .ok_or_else(|| format!("Bad MathBinary id: {}", id))?;
+                    self.stack.push(Value::Number(bfn.apply(a, b)));
+                }
                 Opcode::LoadConst => {
                     let idx = Self::read_u16(code, &mut ip);
                     let c = constants

--- a/tests/core/math_binary_in_functions.js
+++ b/tests/core/math_binary_in_functions.js
@@ -1,0 +1,43 @@
+// #203: two-arg Math.<fn> (max/min/pow/atan2/hypot) called inside a function must compute the correct
+// result and lower to the MathBinary intrinsic when Math is the unshadowed global, so numeric kernels
+// that clamp/exponentiate JIT instead of bailing. Byte-identical across all backends + node. Covers
+// the NaN / ±0 / ±Infinity edge semantics, 3-arg fallback (variadic max/min), and pow edge cases.
+
+function clampSum(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) {
+    s = s + Math.max(i % 10, 3) - Math.min(i % 10, 7) + Math.pow(i % 4, 2)
+  }
+  return s
+}
+console.log("clamp", clampSum(100))
+
+function geo(n) {
+  let d = 0
+  for (let i = 0; i < n; i++) { d = d + Math.hypot(i, i + 1) + Math.atan2(i, 2) }
+  return Math.floor(d * 100)
+}
+console.log("geo", geo(50))
+
+// Edge semantics (must match JS exactly): NaN propagation, +0 vs -0 preference, ±Infinity.
+function edges() {
+  let out = []
+  out.push(Math.max(0 / 0, 5))          // NaN
+  out.push(Math.min(5, 0 / 0))          // NaN
+  out.push(1 / Math.max(-0, 0))         // +Infinity (max(-0,+0) = +0)
+  out.push(1 / Math.min(-0, 0))         // -Infinity (min(-0,+0) = -0)
+  out.push(Math.max(1 / 0, 100))        // Infinity
+  out.push(Math.min(-1 / 0, -100))      // -Infinity
+  out.push(Math.pow(2, 10))             // 1024
+  out.push(Math.pow(4, 0.5))            // 2
+  out.push(Math.pow(0 / 0, 0))          // 1 (pow(NaN,0)===1)
+  return out.join(",")
+}
+console.log("edges", edges())
+
+// 3-arg max/min (variadic) must still work (falls back off the 2-arg intrinsic).
+function variadic() { return Math.max(1, 9, 4) + Math.min(8, 2, 5) }
+console.log("variadic", variadic())
+
+// Top-level (already worked).
+console.log("toplevel", Math.max(3, 7), Math.min(3, 7), Math.pow(3, 3))

--- a/tests/core/math_binary_in_functions.tish
+++ b/tests/core/math_binary_in_functions.tish
@@ -1,0 +1,43 @@
+// #203: two-arg Math.<fn> (max/min/pow/atan2/hypot) called inside a function must compute the correct
+// result and lower to the MathBinary intrinsic when Math is the unshadowed global, so numeric kernels
+// that clamp/exponentiate JIT instead of bailing. Byte-identical across all backends + node. Covers
+// the NaN / ±0 / ±Infinity edge semantics, 3-arg fallback (variadic max/min), and pow edge cases.
+
+function clampSum(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) {
+    s = s + Math.max(i % 10, 3) - Math.min(i % 10, 7) + Math.pow(i % 4, 2)
+  }
+  return s
+}
+console.log("clamp", clampSum(100))
+
+function geo(n) {
+  let d = 0
+  for (let i = 0; i < n; i++) { d = d + Math.hypot(i, i + 1) + Math.atan2(i, 2) }
+  return Math.floor(d * 100)
+}
+console.log("geo", geo(50))
+
+// Edge semantics (must match JS exactly): NaN propagation, +0 vs -0 preference, ±Infinity.
+function edges() {
+  let out = []
+  out.push(Math.max(0 / 0, 5))          // NaN
+  out.push(Math.min(5, 0 / 0))          // NaN
+  out.push(1 / Math.max(-0, 0))         // +Infinity (max(-0,+0) = +0)
+  out.push(1 / Math.min(-0, 0))         // -Infinity (min(-0,+0) = -0)
+  out.push(Math.max(1 / 0, 100))        // Infinity
+  out.push(Math.min(-1 / 0, -100))      // -Infinity
+  out.push(Math.pow(2, 10))             // 1024
+  out.push(Math.pow(4, 0.5))            // 2
+  out.push(Math.pow(0 / 0, 0))          // 1 (pow(NaN,0)===1)
+  return out.join(",")
+}
+console.log("edges", edges())
+
+// 3-arg max/min (variadic) must still work (falls back off the 2-arg intrinsic).
+function variadic() { return Math.max(1, 9, 4) + Math.min(8, 2, 5) }
+console.log("variadic", variadic())
+
+// Top-level (already worked).
+console.log("toplevel", Math.max(3, 7), Math.min(3, 7), Math.pow(3, 3))

--- a/tests/core/math_binary_in_functions.tish.expected
+++ b/tests/core/math_binary_in_functions.tish.expected
@@ -1,0 +1,5 @@
+clamp 440
+geo 183803
+edges NaN,NaN,Infinity,-Infinity,Infinity,-Infinity,1024,2,1
+variadic 11
+toplevel 7 3 27

--- a/tests/main.js
+++ b/tests/main.js
@@ -2120,6 +2120,52 @@ console.log(Math.round(3.2));
 }
 
 {
+// #203: two-arg Math.<fn> (max/min/pow/atan2/hypot) called inside a function must compute the correct
+// result and lower to the MathBinary intrinsic when Math is the unshadowed global, so numeric kernels
+// that clamp/exponentiate JIT instead of bailing. Byte-identical across all backends + node. Covers
+// the NaN / ±0 / ±Infinity edge semantics, 3-arg fallback (variadic max/min), and pow edge cases.
+
+function clampSum(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) {
+    s = s + Math.max(i % 10, 3) - Math.min(i % 10, 7) + Math.pow(i % 4, 2)
+  }
+  return s
+}
+console.log("clamp", clampSum(100))
+
+function geo(n) {
+  let d = 0
+  for (let i = 0; i < n; i++) { d = d + Math.hypot(i, i + 1) + Math.atan2(i, 2) }
+  return Math.floor(d * 100)
+}
+console.log("geo", geo(50))
+
+// Edge semantics (must match JS exactly): NaN propagation, +0 vs -0 preference, ±Infinity.
+function edges() {
+  let out = []
+  out.push(Math.max(0 / 0, 5))          // NaN
+  out.push(Math.min(5, 0 / 0))          // NaN
+  out.push(1 / Math.max(-0, 0))         // +Infinity (max(-0,+0) = +0)
+  out.push(1 / Math.min(-0, 0))         // -Infinity (min(-0,+0) = -0)
+  out.push(Math.max(1 / 0, 100))        // Infinity
+  out.push(Math.min(-1 / 0, -100))      // -Infinity
+  out.push(Math.pow(2, 10))             // 1024
+  out.push(Math.pow(4, 0.5))            // 2
+  out.push(Math.pow(0 / 0, 0))          // 1 (pow(NaN,0)===1)
+  return out.join(",")
+}
+console.log("edges", edges())
+
+// 3-arg max/min (variadic) must still work (falls back off the 2-arg intrinsic).
+function variadic() { return Math.max(1, 9, 4) + Math.min(8, 2, 5) }
+console.log("variadic", variadic())
+
+// Top-level (already worked).
+console.log("toplevel", Math.max(3, 7), Math.min(3, 7), Math.pow(3, 3))
+}
+
+{
 // #186/#203: Math.<fn> called INSIDE a function must (a) compute the correct result and (b) when
 // `Math` is provably the unshadowed global, lower to the MathUnary intrinsic so numeric/array
 // kernels JIT — while a SHADOWED `Math` (local, param, or captured) must still call the user's value.

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -2159,6 +2159,53 @@ console.log(Math.round(3.2))
 }
 __perf_run_core_math()
 
+fn __perf_run_core_math_binary_in_functions() {
+// #203: two-arg Math.<fn> (max/min/pow/atan2/hypot) called inside a function must compute the correct
+// result and lower to the MathBinary intrinsic when Math is the unshadowed global, so numeric kernels
+// that clamp/exponentiate JIT instead of bailing. Byte-identical across all backends + node. Covers
+// the NaN / ±0 / ±Infinity edge semantics, 3-arg fallback (variadic max/min), and pow edge cases.
+
+function clampSum(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) {
+    s = s + Math.max(i % 10, 3) - Math.min(i % 10, 7) + Math.pow(i % 4, 2)
+  }
+  return s
+}
+console.log("clamp", clampSum(100))
+
+function geo(n) {
+  let d = 0
+  for (let i = 0; i < n; i++) { d = d + Math.hypot(i, i + 1) + Math.atan2(i, 2) }
+  return Math.floor(d * 100)
+}
+console.log("geo", geo(50))
+
+// Edge semantics (must match JS exactly): NaN propagation, +0 vs -0 preference, ±Infinity.
+function edges() {
+  let out = []
+  out.push(Math.max(0 / 0, 5))          // NaN
+  out.push(Math.min(5, 0 / 0))          // NaN
+  out.push(1 / Math.max(-0, 0))         // +Infinity (max(-0,+0) = +0)
+  out.push(1 / Math.min(-0, 0))         // -Infinity (min(-0,+0) = -0)
+  out.push(Math.max(1 / 0, 100))        // Infinity
+  out.push(Math.min(-1 / 0, -100))      // -Infinity
+  out.push(Math.pow(2, 10))             // 1024
+  out.push(Math.pow(4, 0.5))            // 2
+  out.push(Math.pow(0 / 0, 0))          // 1 (pow(NaN,0)===1)
+  return out.join(",")
+}
+console.log("edges", edges())
+
+// 3-arg max/min (variadic) must still work (falls back off the 2-arg intrinsic).
+function variadic() { return Math.max(1, 9, 4) + Math.min(8, 2, 5) }
+console.log("variadic", variadic())
+
+// Top-level (already worked).
+console.log("toplevel", Math.max(3, 7), Math.min(3, 7), Math.pow(3, 3))
+}
+__perf_run_core_math_binary_in_functions()
+
 fn __perf_run_core_math_in_functions() {
 // #186/#203: Math.<fn> called INSIDE a function must (a) compute the correct result and (b) when
 // `Math` is provably the unshadowed global, lower to the MathUnary intrinsic so numeric/array


### PR DESCRIPTION
Sibling to #537 (MathUnary-in-functions). Two-arg `Math.<fn>` had **no intrinsic opcode**, so `Math.max`/`min`/`pow`/`atan2` inside a function compiled to a generic `GetMember`+`Call` that the numeric JIT can't lower — bailing the whole function to the interpreter. `Math.max`/`min` (clamping) and `Math.pow` are ubiquitous in numeric code, so this kept another large class of kernels un-JIT'd.

## Change

New `Opcode::MathBinary` + `MathBinaryFn` (max/min/pow/atan2), mirroring the `MathUnary` infrastructure. **VM-only surface** (interp/native/js are AST-based; cranelift/wasi run the VM bytecode):
- **compiler** emits it for `Math.<binfn>(a, b)` — exactly two positional args, same provably-unshadowed-`Math` gate as MathUnary (variadic `Math.max(a,b,c)` → generic call);
- **VM** executes via `MathBinaryFn::apply`, the single source of truth (replicates `tishlang_builtins::math`: max/min NaN + ±0 rules, pow=`powf`, atan2), so VM == interp;
- **JIT** lowers to a `tish_math_binary_call` host call (like MathUnary's transcendentals) — no native `fmax`/`fmin`, so no NaN/-0 op-semantics to get wrong; the win is skipping the boxed dispatch that bails.

`hypot` intentionally stays a generic call (avoids replicating its scaled sum-of-squares below builtins).

## Measured (release, VM `tish run`, min of 3, checksum == baseline)

| loop kernel | before | after |
|---|---|---|
| `Math.max(i, 100)` | 2154ms | **84ms (26×)** |
| `Math.min(i, 100)` | 2210ms | **58ms (38×)** |
| `Math.pow(i, 2)` | 2508ms | **109ms (23×)** |

## Validation

- `math_binary_in_functions.tish` — max/min/pow/atan2 in functions + NaN / ±0 / ±Infinity edge semantics, 3-arg variadic fallback, pow edge cases — byte-identical across interp/vm/native/cranelift/wasi/js/node.
- Bytecode + VM units **25/0** (incl. the updated `osr_region_rejects_calls` — now uses a user-function call since `Math.max` correctly compiles — and a new `osr_region_handles_math_binary`); `run_parity_compare` **106/0**; all six `test_mvp_programs_*` harnesses **6/0**.

Refs #203, #537, #186.