### PR TITLE
test(jit): lock ternary-in-loop correctness across all backends (#203)

### DIFF
--- a/tests/core/ternary_in_loop.js
+++ b/tests/core/ternary_in_loop.js
@@ -1,0 +1,42 @@
+// #203: a ternary `cond ? a : b` inside a hot loop lowers to a branch-free `select` (like the
+// straight-line path already does), instead of bailing the whole function to the interpreter.
+// Byte-identical across all backends + node. Covers: simple ternary, comparison/logical conds,
+// multiple ternaries per iteration, the result assigned/added/compared, and a nested ternary
+// (control flow in an arm ⇒ conservatively bails ⇒ still correct via the VM).
+function signfold(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) {
+    let v = (i % 3 === 0) ? i : -i
+    s = s + v + (i < n / 2 ? 1 : 2)
+  }
+  return s
+}
+console.log("signfold", signfold(1000))
+
+// abs-via-ternary + clamp-via-ternary in a loop
+function absclamp(n) {
+  let s = 0
+  for (let i = -n; i < n; i++) {
+    let a = i < 0 ? -i : i
+    let c = a > 100 ? 100 : a
+    s = s + c
+  }
+  return s
+}
+console.log("absclamp", absclamp(300))
+
+// ternary result compared / used as a condition
+function pick(n) {
+  let t = 0
+  for (let i = 0; i < n; i++) { if ((i % 2 === 0 ? 10 : 20) > 15) { t = t + 1 } }
+  return t
+}
+console.log("pick", pick(500))
+
+// nested ternary (arm is itself a ternary) — must still be correct (bails to VM)
+function nested(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) { s = s + (i % 3 === 0 ? 1 : (i % 3 === 1 ? 2 : 3)) }
+  return s
+}
+console.log("nested", nested(600))

--- a/tests/core/ternary_in_loop.tish
+++ b/tests/core/ternary_in_loop.tish
@@ -1,0 +1,42 @@
+// #203: a ternary `cond ? a : b` inside a hot loop lowers to a branch-free `select` (like the
+// straight-line path already does), instead of bailing the whole function to the interpreter.
+// Byte-identical across all backends + node. Covers: simple ternary, comparison/logical conds,
+// multiple ternaries per iteration, the result assigned/added/compared, and a nested ternary
+// (control flow in an arm ⇒ conservatively bails ⇒ still correct via the VM).
+function signfold(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) {
+    let v = (i % 3 === 0) ? i : -i
+    s = s + v + (i < n / 2 ? 1 : 2)
+  }
+  return s
+}
+console.log("signfold", signfold(1000))
+
+// abs-via-ternary + clamp-via-ternary in a loop
+function absclamp(n) {
+  let s = 0
+  for (let i = -n; i < n; i++) {
+    let a = i < 0 ? -i : i
+    let c = a > 100 ? 100 : a
+    s = s + c
+  }
+  return s
+}
+console.log("absclamp", absclamp(300))
+
+// ternary result compared / used as a condition
+function pick(n) {
+  let t = 0
+  for (let i = 0; i < n; i++) { if ((i % 2 === 0 ? 10 : 20) > 15) { t = t + 1 } }
+  return t
+}
+console.log("pick", pick(500))
+
+// nested ternary (arm is itself a ternary) — must still be correct (bails to VM)
+function nested(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) { s = s + (i % 3 === 0 ? 1 : (i % 3 === 1 ? 2 : 3)) }
+  return s
+}
+console.log("nested", nested(600))

--- a/tests/core/ternary_in_loop.tish.expected
+++ b/tests/core/ternary_in_loop.tish.expected
@@ -1,0 +1,4 @@
+signfold -164334
+absclamp 50000
+pick 250
+nested 1200

--- a/tests/main.js
+++ b/tests/main.js
@@ -5011,6 +5011,51 @@ console.log(`Joined: ${words.join(" ").toUpperCase()}`);
 }
 
 {
+// #203: a ternary `cond ? a : b` inside a hot loop lowers to a branch-free `select` (like the
+// straight-line path already does), instead of bailing the whole function to the interpreter.
+// Byte-identical across all backends + node. Covers: simple ternary, comparison/logical conds,
+// multiple ternaries per iteration, the result assigned/added/compared, and a nested ternary
+// (control flow in an arm ⇒ conservatively bails ⇒ still correct via the VM).
+function signfold(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) {
+    let v = (i % 3 === 0) ? i : -i
+    s = s + v + (i < n / 2 ? 1 : 2)
+  }
+  return s
+}
+console.log("signfold", signfold(1000))
+
+// abs-via-ternary + clamp-via-ternary in a loop
+function absclamp(n) {
+  let s = 0
+  for (let i = -n; i < n; i++) {
+    let a = i < 0 ? -i : i
+    let c = a > 100 ? 100 : a
+    s = s + c
+  }
+  return s
+}
+console.log("absclamp", absclamp(300))
+
+// ternary result compared / used as a condition
+function pick(n) {
+  let t = 0
+  for (let i = 0; i < n; i++) { if ((i % 2 === 0 ? 10 : 20) > 15) { t = t + 1 } }
+  return t
+}
+console.log("pick", pick(500))
+
+// nested ternary (arm is itself a ternary) — must still be correct (bails to VM)
+function nested(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) { s = s + (i % 3 === 0 ? 1 : (i % 3 === 1 ? 2 : 3)) }
+  return s
+}
+console.log("nested", nested(600))
+}
+
+{
 // MVP test: try/catch and throw (JS equivalent of try_catch.tish)
 try {
   console.log("in try");

--- a/tests/main.tish
+++ b/tests/main.tish
@@ -5128,6 +5128,52 @@ console.log(`Joined: ${words.join(" ").toUpperCase()}`)
 }
 __perf_run_core_template_literals()
 
+fn __perf_run_core_ternary_in_loop() {
+// #203: a ternary `cond ? a : b` inside a hot loop lowers to a branch-free `select` (like the
+// straight-line path already does), instead of bailing the whole function to the interpreter.
+// Byte-identical across all backends + node. Covers: simple ternary, comparison/logical conds,
+// multiple ternaries per iteration, the result assigned/added/compared, and a nested ternary
+// (control flow in an arm ⇒ conservatively bails ⇒ still correct via the VM).
+function signfold(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) {
+    let v = (i % 3 === 0) ? i : -i
+    s = s + v + (i < n / 2 ? 1 : 2)
+  }
+  return s
+}
+console.log("signfold", signfold(1000))
+
+// abs-via-ternary + clamp-via-ternary in a loop
+function absclamp(n) {
+  let s = 0
+  for (let i = -n; i < n; i++) {
+    let a = i < 0 ? -i : i
+    let c = a > 100 ? 100 : a
+    s = s + c
+  }
+  return s
+}
+console.log("absclamp", absclamp(300))
+
+// ternary result compared / used as a condition
+function pick(n) {
+  let t = 0
+  for (let i = 0; i < n; i++) { if ((i % 2 === 0 ? 10 : 20) > 15) { t = t + 1 } }
+  return t
+}
+console.log("pick", pick(500))
+
+// nested ternary (arm is itself a ternary) — must still be correct (bails to VM)
+function nested(n) {
+  let s = 0
+  for (let i = 0; i < n; i++) { s = s + (i % 3 === 0 ? 1 : (i % 3 === 1 ? 2 : 3)) }
+  return s
+}
+console.log("nested", nested(600))
+}
+__perf_run_core_ternary_in_loop()
+
 fn __perf_run_core_try_catch() {
 // MVP test: try/catch and throw
 try {


### PR DESCRIPTION
Regression lock for the **ternary-in-a-hot-loop** JIT lever (the highest-value remaining #203 perf target, ~173×). Ternaries inside loops run correctly today but bail the numeric JIT to the interpreter.

This fixture pins the correct results — simple ternary, comparison/logical conds, multiple ternaries per iteration, result assigned/added/compared, and a **nested ternary** (an arm with control flow, which any JIT lowering must conservatively bail) — **byte-identical across interp/vm/native/cranelift/wasi/js/node**, so the eventual JIT lowering can't regress them.

Landing the contract first (as with the #180 JSON contract), so the perf feature has its gate in place.