### PR TITLE
ci: honor the conventional-commit "!" breaking shorthand in release config

### DIFF
--- a/release.config.cjs
+++ b/release.config.cjs
@@ -6,6 +6,13 @@
  *
  * - TISH_SEMANTIC_RELEASE_CI=1: file:// repo + analyzer only (CI dry-runs, no git push / NPM_TOKEN).
  * - Otherwise: full config (npm + GitHub plugins, real remote).
+ *
+ * The commit-analyzer + release-notes-generator entries in release.full.config.json carry
+ * a `parserOpts` that extends the bundled "angular" preset with the Conventional-Commits
+ * `!` breaking shorthand (feat!:, fix(scope)!:). The stock angular header regex has no `!`,
+ * so `feat!:` parsed as no-type -> no release. This is two regexes, not a whole preset
+ * package. The dry-run (readOnlyCi) path REUSES those exact JSON entries so the version it
+ * computes matches the real config — parserOpts lives in ONE place (the JSON).
  */
 const path = require("path");
 const { execSync } = require("child_process");
@@ -15,12 +22,15 @@ const full = require(path.join(__dirname, "release.full.config.json"));
 function readOnlyCi() {
   const root = execSync("git rev-parse --show-toplevel", { encoding: "utf8" }).trim();
   const fileUrl = "file://" + root.replace(/\\/g, "/") + "/.git";
+  // Reuse the analyzer + notes entries (with their parserOpts) straight from the full
+  // config, so the dry-run version decision can't drift from the real one.
+  const pick = (name) => full.plugins.find((p) => Array.isArray(p) && p[0] === name);
   return {
     branches: full.branches,
     repositoryUrl: fileUrl,
     plugins: [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
+      pick("@semantic-release/commit-analyzer"),
+      pick("@semantic-release/release-notes-generator"),
     ],
   };
 }

--- a/release.full.config.json
+++ b/release.full.config.json
@@ -1,8 +1,16 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    ["@semantic-release/commit-analyzer", { "parserOpts": {
+      "headerPattern": "^(\\w*)(?:\\((.*)\\))?!?: (.*)$",
+      "headerCorrespondence": ["type", "scope", "subject"],
+      "breakingHeaderPattern": "^(\\w*)(?:\\((.*)\\))?!: (.*)$"
+    } }],
+    ["@semantic-release/release-notes-generator", { "parserOpts": {
+      "headerPattern": "^(\\w*)(?:\\((.*)\\))?!?: (.*)$",
+      "headerCorrespondence": ["type", "scope", "subject"],
+      "breakingHeaderPattern": "^(\\w*)(?:\\((.*)\\))?!: (.*)$"
+    } }],
     ["@semantic-release/npm", { "npmPublish": false }],
     [
       "@semantic-release/github",


### PR DESCRIPTION
## Problem

The merge of #554 (`feat!: Game Boy Advance target …`) **did not trigger a release** — [run 30142643271](https://github.com/tishlang/tish/actions/runs/30142643271) reported *"No version bump in these commits."* No tag, no prerelease, so nothing to promote to npm/crates.

## Root cause

semantic-release runs `@semantic-release/commit-analyzer` with its **default `angular` preset**, whose header regex is:

```
/^(\w*)(?:\((.*)\))?: (.*)$/
```

There's no `!` in it. So `feat!:` fails to parse as a conventional commit at all → type dropped → no release (a bare `feat` would have at least been a minor). On top of that, the `---------` rule GitHub's squash-merge inserts before the footer hid the commit's `BREAKING CHANGE:` note from the angular parser, so the belt-and-suspenders footer didn't save it either.

Reproduced against the real `@semantic-release/commit-analyzer@13`: the exact #554 squash message → `null`.

## Fix

Extend the analyzer + release-notes-generator `parserOpts` to accept the optional `!` — **two regexes, not a new preset package** (no `conventional-changelog-conventionalcommits` dependency, no workflow change):

- `headerPattern`: `^(\w*)(?:\((.*)\))?!?: (.*)$`
- `breakingHeaderPattern`: `^(\w*)(?:\((.*)\))?!: (.*)$`

`parserOpts` lives once in `release.full.config.json`; the dry-run (`readOnlyCi`) path in `release.config.cjs` now reuses those exact plugin entries, so the CI version decision can't drift from the real config.

## Verification

Ran the real analyzer with the config as written:

| commit | result |
|---|---|
| `feat!: …` | major |
| `fix(scope)!: …` | major |
| #554 squash message, unchanged | major |
| `feat:` / `fix:` / `docs:` | minor / patch / none |

## Note

This commit is `ci:`-typed, so it does **not** cut a release itself. Once merged, a `feat!:` (or `BREAKING CHANGE:` footer) commit on `main` will resolve to **v3.0.0** and create the prerelease to promote.