### PR TITLE
fix: GBA fonts and array mutators

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1218,6 +1218,10 @@ pub(crate) struct Codegen {
     cse_subst: Vec<(Expr, String)>,
     /// Monotonic counter for unique CSE temp names (`_cse0`, `_cse1`, …).
     cse_temp_counter: usize,
+    /// The program's used NON-ASCII characters (collected from every string literal), as a sorted
+    /// string. Fed to import schemes via `{charset}` so a scheme can bake only the glyphs a program
+    /// actually uses — e.g. `font<N>:` bakes ASCII + these, not all ~24k glyphs of a CJK font.
+    string_charset: String,
 }
 
 /// One `map`/`filter` stage of a fused HOF chain (#317): the single-element-param closure's
@@ -1244,6 +1248,7 @@ impl Codegen {
             indent: 0,
             loop_label_index: 0,
             is_async: false,
+            string_charset: String::new(),
             features,
             native_module_init,
             async_context_stack: Vec::new(),
@@ -1517,6 +1522,41 @@ impl Codegen {
     /// absolute file), and a same-module accessor (which can see the macro's private statics — the
     /// only way a tagless image's sprites escape). Registration into the runtime arena happens in
     /// the entry below.
+    /// Collect every NON-ASCII character appearing in the program's string literals, sorted+unique.
+    /// Fed to schemes via `{charset}` (see `render_template`) so a `font<N>:` import can bake only the
+    /// glyphs actually used. ASCII is always baked by the scheme, so it's excluded here. Runtime-built
+    /// strings (concatenation, numbers) resolve to ASCII, which is covered; a non-ASCII char reachable
+    /// only through a computed string is the rare gap (documented — add it to a literal if needed).
+    fn collect_string_charset(stmts: &[Statement]) -> String {
+        let mut set = std::collections::BTreeSet::new();
+        fn add(s: &str, set: &mut std::collections::BTreeSet<char>) {
+            for c in s.chars() {
+                if (c as u32) >= 0x7F {
+                    set.insert(c);
+                }
+            }
+        }
+        fn walk(stmts: &[Statement], set: &mut std::collections::BTreeSet<char>) {
+            for s in stmts {
+                Codegen::for_each_stmt_expr(s, &mut |e| {
+                    Codegen::nv_for_each_subexpr(e, &mut |x| {
+                        if let Expr::Literal { value: Literal::String(str), .. } = x {
+                            add(str, set);
+                        }
+                        if let Expr::TemplateLiteral { quasis, .. } = x {
+                            for q in quasis {
+                                add(q, set);
+                            }
+                        }
+                    });
+                });
+                Codegen::for_each_child_stmt_list(s, &mut |list| walk(list, set));
+            }
+        }
+        walk(stmts, &mut set);
+        set.into_iter().collect()
+    }
+
     fn emit_scheme_modules(&mut self) -> Result<(), CompileError> {
         let files = self.scheme_files.clone();
         for (j, (scheme, path)) in files.iter().enumerate() {
@@ -1531,6 +1571,7 @@ impl Codegen {
                 &emit.module_body,
                 path,
                 &module_ident,
+                &self.string_charset,
             ));
             if !emit.accessor.is_empty() {
                 self.writeln(&emit.accessor);
@@ -2462,6 +2503,7 @@ impl Codegen {
     }
 
     fn emit_program(&mut self, program: &Program) -> Result<(), CompileError> {
+        self.string_charset = Self::collect_string_charset(&program.statements);
         self.is_async = program_uses_async(program);
         self.program_has_jsx = tishlang_ui::jsx::program_contains_jsx(program);
         self.program_fun_decl_names = tishlang_ui::jsx::collect_fun_decl_names(program);
@@ -2589,7 +2631,7 @@ impl Codegen {
                 let emit = self.scheme_target_emit(scheme)?;
                 if !emit.register.is_empty() {
                     let module_ident = Self::scheme_mod_ident(scheme, j);
-                    let call = crate::schemes::render_template(&emit.register, "", &module_ident);
+                    let call = crate::schemes::render_template(&emit.register, "", &module_ident, &self.string_charset);
                     self.writeln(&format!("{};", call));
                 }
             }

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -2503,7 +2503,12 @@ impl Codegen {
     }
 
     fn emit_program(&mut self, program: &Program) -> Result<(), CompileError> {
-        self.string_charset = Self::collect_string_charset(&program.statements);
+        // Only GBA `font<N>:`/`emoji:` schemes consume `{charset}` (and both `render_template`
+        // callers that read `string_charset` are Gba-gated), so skip the whole-program string walk
+        // for every other target — its result is never read off-GBA.
+        if self.emit_mode == crate::NativeEmitMode::Gba {
+            self.string_charset = Self::collect_string_charset(&program.statements);
+        }
         self.is_async = program_uses_async(program);
         self.program_has_jsx = tishlang_ui::jsx::program_contains_jsx(program);
         self.program_fun_decl_names = tishlang_ui::jsx::collect_fun_decl_names(program);

--- a/crates/tish_compile/src/schemes.rs
+++ b/crates/tish_compile/src/schemes.rs
@@ -235,12 +235,14 @@ pub fn is_scheme_import(spec: &str) -> bool {
     with_active(|r| r.matches(spec).is_some())
 }
 
-/// Substitute `{path}` (the file as a Rust string literal) and `{mod}` (the generated module ident)
-/// in a template.
-pub fn render_template(template: &str, abspath: &str, module_ident: &str) -> String {
+/// Substitute `{path}` (the file as a Rust string literal), `{mod}` (the generated module ident), and
+/// `{charset}` (the program's used non-ASCII characters as a Rust string literal — for schemes that
+/// bake only the glyphs a program actually uses, e.g. `font<N>:`) in a template.
+pub fn render_template(template: &str, abspath: &str, module_ident: &str, charset: &str) -> String {
     template
         .replace("{path}", &format!("{:?}", abspath))
         .replace("{mod}", module_ident)
+        .replace("{charset}", &format!("{:?}", charset))
 }
 
 #[cfg(test)]

--- a/crates/tish_runtime_gba/src/gba.rs
+++ b/crates/tish_runtime_gba/src/gba.rs
@@ -118,6 +118,59 @@ pub fn asset_bg(handle: i32) -> Option<BgAsset> {
     ASSET_BGS.with(|c| c.borrow().get(handle as usize).copied())
 }
 
+/// Registered fonts (`font<N>:` imports) — a compile-time-baked `Font`. All `font<N>:` schemes share
+/// this one arena via an IDENTICAL registration call (no baked-in size — the renderer sizes sprites
+/// from the font's own `line_height`), so their handles number correctly across sizes. tish-agb's
+/// `text_draw` looks them up by handle.
+static ASSET_FONTS: SingleCore<RefCell<Vec<&'static agb::display::font::Font>>> =
+    SingleCore::new(RefCell::new(Vec::new()));
+
+/// Register a baked font, returning its i32 handle.
+pub fn __asset_register_font(font: &'static agb::display::font::Font) -> i32 {
+    ASSET_FONTS.with(|c| {
+        let mut v = c.borrow_mut();
+        let idx = v.len() as i32;
+        v.push(font);
+        idx
+    })
+}
+
+/// Look up a registered font by handle. `None` if out of range.
+pub fn asset_font(handle: i32) -> Option<&'static agb::display::font::Font> {
+    ASSET_FONTS.with(|c| c.borrow().get(handle as usize).copied())
+}
+
+/// The single global emoji fallback atlas (`emoji:` import): the SerenityOS colour sprite frames plus
+/// a codepoint→frame table sorted by codepoint. There is at most one — it is a fallback shared by
+/// every font, so any font lacking a glyph for an emoji codepoint renders the matching colour sprite
+/// instead of a tofu box. tish-agb's text renderer reads it via [`emoji_sprite`].
+type EmojiAtlas = (
+    &'static [agb::display::object::Sprite],
+    &'static [(u32, u16)],
+);
+
+static ASSET_EMOJI: SingleCore<RefCell<Option<EmojiAtlas>>> = SingleCore::new(RefCell::new(None));
+
+/// Register the emoji atlas (frames + codepoint→frame table). Called once by the generated `agb_main`
+/// for the `emoji:` import; the handle is unused (the atlas is a global fallback, not addressed by id).
+pub fn __asset_register_emoji(
+    sprites: &'static [agb::display::object::Sprite],
+    table: &'static [(u32, u16)],
+) -> i32 {
+    ASSET_EMOJI.with(|c| *c.borrow_mut() = Some((sprites, table)));
+    0
+}
+
+/// The colour sprite frame for an emoji codepoint, if an emoji atlas is registered and contains it.
+/// `None` ⇒ no emoji import, or this codepoint wasn't baked ⇒ the caller falls back to the font glyph.
+pub fn emoji_sprite(cp: u32) -> Option<&'static agb::display::object::Sprite> {
+    ASSET_EMOJI.with(|c| {
+        let (sprites, table) = (*c.borrow())?;
+        let i = table.binary_search_by_key(&cp, |&(c, _)| c).ok()?;
+        sprites.get(table[i].1 as usize)
+    })
+}
+
 /// Registered maps (`map:` imports) — the raw ROM bytes of a baked map binary. Kept in ROM
 /// (`include_bytes!`), never copied to the tish heap, so large maps don't blow EWRAM.
 static ASSET_MAPS: SingleCore<RefCell<Vec<&'static [u8]>>> =

--- a/crates/tish_runtime_gba/src/lib.rs
+++ b/crates/tish_runtime_gba/src/lib.rs
@@ -539,6 +539,8 @@ pub use tishlang_builtins::collections::{
     map_constructor_value as tish_map_constructor, map_get, map_has, map_set, map_values,
     set_constructor_value as tish_set_constructor,
 };
+// Array mutators (portable) — `.push()` / `.pop()` lower to these `array_*` names.
+pub use tishlang_builtins::array::{pop as array_pop, push as array_push};
 pub use tishlang_builtins::symbol::symbol_object;
 pub use tishlang_builtins::typedarrays::{
     float32_array_constructor_value as tish_float32_array_constructor,


### PR DESCRIPTION
Cherry-picks the "fix gba fonts and arrays" change onto a clean branch off `main`.

## What this fixes

**Fonts — bake only the glyphs a program uses.** Codegen now collects every non-ASCII character appearing in the program's string literals (and template-literal quasis), sorted + deduped, and threads it into import schemes via a new `{charset}` template variable (`schemes::render_template`). A `font<N>:` import can bake ASCII + exactly those glyphs instead of the entire font (e.g. all ~24k glyphs of a CJK font). Runtime-built strings resolve to ASCII, which is always baked; a non-ASCII char reachable only through a computed string is the documented rare gap.

**GBA font + emoji runtime.** `tish_runtime_gba` gains:
- `ASSET_FONTS` arena with `__asset_register_font` / `asset_font` — all `font<N>:` schemes share one arena via an identical registration call so handles number correctly across sizes; the renderer sizes sprites from the font's own `line_height`.
- `ASSET_EMOJI` fallback atlas with `__asset_register_emoji` / `emoji_sprite` — a single global colour-sprite atlas (codepoint→frame table, binary-searched) shared by every font, so a missing glyph renders the emoji sprite instead of a tofu box.

**Arrays.** Re-exports the portable `array_push` / `array_pop` builtins in the GBA runtime so `.push()` / `.pop()` lower correctly on the GBA target.

## Notes
- Content is byte-for-byte identical to commit `595f2b4`.
- `cargo check -p tishlang_compile` passes locally (host compiler crate, where the `render_template` signature change lives — both call sites updated). The `tishlang_runtime_gba` crate builds against the embedded `thumbv4t` target in CI.