### PR TITLE
fix(gba): add missing `str_index` to the GBA runtime facade

### DIFF
--- a/crates/tish_runtime_gba/src/lib.rs
+++ b/crates/tish_runtime_gba/src/lib.rs
@@ -266,6 +266,23 @@ pub fn get_index(obj: &Value, index: &Value) -> Value {
     }
 }
 
+/// `&str` `s[i]` — char at a non-negative integer `idx`; non-int / negative / OOB → null.
+///
+/// Mirrors `tish_runtime::str_index`, and exists here because codegen emits a call to it whenever
+/// the indexed expression is statically a `&str` rather than a `Value` — which is what a module
+/// `const` string lowers to. Without it, `const D = "0123456789"` followed by `D[i]` is a hard
+/// E0425 on the GBA target only, while the identical code compiles and runs everywhere else.
+#[inline]
+pub fn str_index(s: &str, idx: &Value) -> Value {
+    match idx {
+        Value::Number(n) if *n >= 0.0 && n.fract() == 0.0 => match s.chars().nth(*n as usize) {
+            Some(c) => Value::String(c.to_string().into()),
+            None => Value::Null,
+        },
+        _ => Value::Null,
+    }
+}
+
 pub fn delete_property(obj: &Value, key: &Value) -> Value {
     match obj {
         Value::Object(m) => {


### PR DESCRIPTION
## Problem

Codegen emits `tishlang_runtime::str_index(s, &idx)` whenever the indexed expression is statically a `&str` rather than a `Value` (`crates/tish_compile/src/codegen.rs:23772`) — which is what a module-level `const` string lowers to.

On the GBA target, `tishlang_runtime` is a Cargo package rename of `tishlang_runtime_gba` (`crates/tish_native/src/build.rs:434`), and the facade neither defined nor re-exported `str_index`.

So this:

```tish
const D = "0123456789"
// …
D[i]
```

is a hard `E0425: cannot find function 'str_index'` on the GBA target **only**, while the identical source compiles and runs on every other target.

## Fix

Define `str_index` on the facade, with a body identical to `tish_runtime::str_index` (`crates/tish_runtime/src/lib.rs:366`).

It uses only constructs already present in the file — `Value::String(c.to_string().into())` is the same char-at expression `get_index` uses a few lines above, and `alloc::string::{String, ToString}` is already imported — so it adds no new dependency on the portable prelude surface.

## Verification

`portable-gba.yml` already covers `crates/tish_runtime_gba/**` in its `paths:` filter, so both tiers run on this PR: the host `no_std` type-check and the real `thumbv4t-none-eabi` build-std build of the facade.

Not compile-verified locally — `thumbv4t-none-eabi` isn't installed on this machine and the crate is excluded from the workspace (`Cargo.toml:42`), so CI is the check here.