### PR TITLE
fix(native): clone a bare-ident `&&`/`||` right operand instead of moving it

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -6963,6 +6963,23 @@ impl Codegen {
         Ok(())
     }
 
+    /// `.clone()` an emitted operand that is a bare Rust identifier, leave anything else alone.
+    ///
+    /// Used where an operand is yielded as the value of an expression that does not consume it
+    /// exclusively (`&&` / `||`): moving a non-`Copy` `Value` local out of such a position makes
+    /// every later read a use-after-move. A parenthesised expression, call, field access, or an
+    /// already-`.clone()`d ident is a temporary, so it needs nothing.
+    fn clone_if_bare_ident(s: &str) -> String {
+        let bare = !s.is_empty()
+            && !s.starts_with(|c: char| c.is_ascii_digit())
+            && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
+        if bare {
+            format!("{}.clone()", s)
+        } else {
+            s.to_string()
+        }
+    }
+
     fn emit_call_arg(&mut self, arg: &CallArg) -> Result<String, CompileError> {
         let e = match arg {
             CallArg::Expr(e) | CallArg::Spread(e) => e,
@@ -25014,8 +25031,21 @@ impl Codegen {
             // the same local (`aid && out.indexOf(aid)`), and a bare `let __l = aid;` moves the non-`Copy`
             // `Value` so the reuse is a borrow-after-move (E0382). The left operand is still evaluated
             // exactly once (its side effects don't double-run); only its value is cloned for the test.
-            BinOp::And => format!("{{ let __l = ({}).clone(); if __l.is_truthy() {{ {} }} else {{ __l }} }}", l, r),
-            BinOp::Or => format!("{{ let __l = ({}).clone(); if __l.is_truthy() {{ __l }} else {{ {} }} }}", l, r),
+            //
+            // The RESULT operand has the same hazard: when it lowers to a bare local (`inGenBlock &&
+            // currentTrack`), yielding it moves that local out, so a later read — the next iteration
+            // of the enclosing loop, or any subsequent use — is E0382. Clone it in that case only;
+            // anything else is already a temporary (or already cloned), so the fast path is unchanged.
+            BinOp::And => format!(
+                "{{ let __l = ({}).clone(); if __l.is_truthy() {{ {} }} else {{ __l }} }}",
+                l,
+                Self::clone_if_bare_ident(r)
+            ),
+            BinOp::Or => format!(
+                "{{ let __l = ({}).clone(); if __l.is_truthy() {{ __l }} else {{ {} }} }}",
+                l,
+                Self::clone_if_bare_ident(r)
+            ),
             BinOp::BitAnd => Self::emit_bitwise_binop(l, r, "&"),
             BinOp::BitOr => Self::emit_bitwise_binop(l, r, "|"),
             BinOp::BitXor => Self::emit_bitwise_binop(l, r, "^"),

--- a/crates/tish_compile/tests/regr_andor_rhs_move.rs
+++ b/crates/tish_compile/tests/regr_andor_rhs_move.rs
@@ -1,0 +1,85 @@
+//! Regression: `&&` / `||` yield the deciding OPERAND (JS semantics, #240). #328 fixed the left
+//! operand to bind by `.clone()` rather than by move; the right operand had the identical hazard.
+//!
+//! When the right operand lowers to a bare local — `inGenBlock && currentTrack` — yielding it moved
+//! that local out of scope, so any later read was `E0382: use of moved value`. It only bites when
+//! the operand is a plain non-`Copy` `Value` local that is read again (typically the next iteration
+//! of the enclosing loop), which is why it survived: the common right operand is a call or an
+//! already-cloned expression, which are temporaries.
+//!
+//! Found compiling `@spacedevin/deck`'s `Parser.tish`, whose statement loop does exactly this. The
+//! source runs fine under `--target js` and the interpreter, so the divergence was Rust-backend-only.
+use tishlang_compile::compile;
+use tishlang_parser::parse;
+
+fn rust_for(src: &str) -> String {
+    compile(&parse(src).unwrap()).unwrap()
+}
+
+#[test]
+fn bare_ident_right_operand_is_cloned_not_moved() {
+    let rust = rust_for(
+        r#"
+fn f() {
+  let cur = null
+  let flag = true
+  let i = 0
+  while (i < 3) {
+    if (flag && cur) { return 1 }
+    if (flag && cur) { return 2 }
+    i = i + 1
+  }
+  return 0
+}
+"#,
+    );
+    assert!(
+        rust.contains("if __l.is_truthy() { cur.clone() }"),
+        "a bare-ident right operand must be cloned out, not moved:\n{rust}"
+    );
+    assert!(
+        !rust.contains("if __l.is_truthy() { cur }"),
+        "found the moving form, which is E0382 on the second read:\n{rust}"
+    );
+}
+
+#[test]
+fn or_right_operand_gets_the_same_treatment() {
+    let rust = rust_for(
+        r#"
+fn f() {
+  let a = null
+  let b = null
+  let i = 0
+  while (i < 3) {
+    let x = a || b
+    let y = a || b
+    i = i + 1
+  }
+  return 0
+}
+"#,
+    );
+    assert!(
+        rust.contains("else { b.clone() }"),
+        "`||` must clone a bare-ident right operand too:\n{rust}"
+    );
+}
+
+#[test]
+fn non_ident_right_operands_are_not_given_a_redundant_clone() {
+    // A call result is already a temporary — cloning it would be pure overhead on a hot path.
+    let rust = rust_for(
+        r#"
+fn g() { return 1 }
+fn f() {
+  let flag = true
+  return flag && g()
+}
+"#,
+    );
+    assert!(
+        !rust.contains("))).clone().clone()"),
+        "an already-temporary right operand must not gain a second clone:\n{rust}"
+    );
+}


### PR DESCRIPTION
## Problem

`&&` / `||` yield the deciding **operand**, not a coerced boolean (JS semantics, #240). #328 fixed the **left** operand to bind by `.clone()` rather than by move. The **right** operand has the identical hazard and was missed.

When the right operand lowers to a bare local, yielding it moves that local out of scope, so any later read is `E0382: use of moved value`.

Repro — runs fine under `--target js` and the interpreter (prints `0`), `E0382` on `--target native` before this change:

```tish
fn f() {
  let cur = null
  let flag = true
  let i = 0
  while (i < 3) {
    if (flag && cur) { return 1 }
    if (flag && cur) { return 2 }
    i = i + 1
  }
  return 0
}
console.log(f())
```

```
error[E0382]: use of moved value: `cur`
 ...
 | if { let __l = (Value::Bool(flag)).clone(); if __l.is_truthy() { cur } else { __l } }.is_truthy() {
 |                                                                  ---  value moved here
 ...
 | if { let __l = (Value::Bool(flag)).clone(); if __l.is_truthy() { cur } else { __l } }.is_truthy() {
 |                                                                  ^^^  value used here after move
```

It only bites when the operand is a plain non-`Copy` `Value` local that is read again — typically on the next iteration of the enclosing loop. The common right operand is a call or an already-cloned expression (a temporary), which is why this survived this long.

## Fix

Clone the right operand **only when the emitted text is a bare identifier**. Anything else is already a temporary or already `.clone()`d, so the existing fast path is untouched and no redundant clone lands on a hot path.

## How it was found

Compiling `@spacedevin/deck`'s `Parser.tish`, whose statement loop contains `inGenBlock && currentTrack` and then reads `currentTrack` again on the following iteration. That package is only ever compiled to JS today, so the divergence had never been exercised.

## Tests

`crates/tish_compile/tests/regr_andor_rhs_move.rs` — the `&&` and `||` bare-ident cases both clone, and a call-valued right operand does **not** gain a second clone.

`cargo test -p tishlang_compile`: 153 passed, 0 failed. The repro above now builds and prints `0`, matching the interpreter.