### PR TITLE
fix(regression): don't rewrite path deps we don't own; fix the tish-apple row

### DIFF
--- a/regression/downstream/repos.tsv
+++ b/regression/downstream/repos.tsv
@@ -21,7 +21,10 @@ tish-unity	local:~/Projects/tish/tish-unity/native/tish_unity_bridge	.	ffi	cargo
 # tish-stripe/cedar/biscuit/webauthn/brainstorm-pg have no test fns, so for them `cargo test` is a
 # build/codegen guard. tish-oidc + tish-polars are still genuinely broken (kept xfail). tish-pg is a
 # local path absent on this machine (skips). tish-apple-common is CONFIRMED CLEAN (pass below); its
-# tish-macos/tish-ios crates are macOS-only + heavy Value-use, not Linux-checkable.
+# tish-macos/tish-ios crates are macOS-only + heavy Value-use, not Linux-checkable — but note Cargo
+# still loads EVERY workspace member's manifest to check one package, so a broken sibling-repo path
+# dep in tish-macos takes the whole row down regardless (fixed in tishlang/tish-apple#6).
+# The package is `tishlang_apple_common`; `crates/tish-apple-common` is only the directory name.
 tish-pg	local:~/Projects/tish-pg	.	rust	cargo test --no-run	xfail
 tish-callbacks	local:~/Projects/tish/tish-callbacks	.	rust	cargo test	pass
 tish-oidc	local:~/Projects/tish/tish-oidc	.	rust	cargo check	xfail
@@ -31,7 +34,7 @@ tish-biscuit	local:~/Projects/tish/tish-biscuit	.	rust	cargo test	pass
 tish-webauthn	local:~/Projects/tish/tish-webauthn	.	rust	cargo test	pass
 brainstorm-pg	local:~/Projects/brainstorm/crates/brainstorm-pg	.	rust	cargo test	pass
 tish-polars	git:https://github.com/spacedevin/tish-polars.git@main	.	rust	cargo check	xfail
-tish-apple	git:https://github.com/tishlang/tish-apple.git@main	.	rust	cargo check -p tish-apple-common	pass
+tish-apple	git:https://github.com/tishlang/tish-apple.git@main	.	rust	cargo check -p tishlang_apple_common	pass
 #
 # ── tish-program consumers — no compile link; hit only by SEMANTIC changes (div-by-zero, key order) ──
 # Tested via the repo's own build/test harness against the HEAD binary (see header). expected=pass —

--- a/regression/downstream/run.sh
+++ b/regression/downstream/run.sh
@@ -57,11 +57,20 @@ echo ""
 
 # Rewrite every `path = "..../crates/tish_NAME"` in the repo's Cargo.tomls to the
 # HEAD checkout — robust for path-dep consumers (no version-match issues).
+#
+# Only rewrites a name that ACTUALLY EXISTS under the tish checkout. The `crates/tish_*` shape is not
+# unique to this repo — tish-apple pointed at `../../../tish-desktop/crates/tish_broker`, a crate in
+# a different repo — and blindly repointing that at `$TISH/crates/tish_broker` turned a resolvable
+# dep into a dangling one, so the workspace failed to load and the row read as a tish regression when
+# nothing in tish had changed. Leave a path we don't own exactly as we found it.
 rewrite_tish_paths() {
   local root="$1" t="$2"
   find "$root" -name Cargo.toml -not -path '*/target/*' -not -path '*/node_modules/*' 2>/dev/null \
     | while IFS= read -r f; do
-        TISH_ABS="$t" perl -i -pe 's{path\s*=\s*"[^"]*?/crates/(tish_[A-Za-z0-9_]+)"}{path = "$ENV{TISH_ABS}/crates/$1"}g' "$f" 2>/dev/null || true
+        TISH_ABS="$t" perl -i -pe '
+          s{path\s*=\s*"[^"]*?/crates/(tish_[A-Za-z0-9_]+)"}{
+            -d "$ENV{TISH_ABS}/crates/$1" ? "path = \"$ENV{TISH_ABS}/crates/$1\"" : $&
+          }ge' "$f" 2>/dev/null || true
       done
 }
 


### PR DESCRIPTION
The `tish-apple` downstream row has reported a **tish regression** on every run since 2026-07-18, with nothing in tish having changed. Two independent bugs, both on our side.

```
error: failed to load manifest for workspace member `…/tish-apple/crates/tish-macos`
```

## 1. We rewrote a path dep we don't own

`rewrite_tish_paths` repointed **every** `path = ".../crates/tish_NAME"` at the tish checkout. That shape isn't unique to this repo — tish-apple depends on

```toml
tishlang_broker = { path = "../../../tish-desktop/crates/tish_broker" }
```

a crate in a **different** repo. We rewrote it to `$TISH/crates/tish_broker`, which doesn't exist, turning a resolvable dep into a dangling one. Cargo then failed at *manifest load*, before compiling anything — so the row failed in a way that could never be a real tish regression.

Now the rewrite only fires when the target actually exists under the tish checkout, and leaves anything else byte-identical. Verified against a fixture with four path deps: `tish_core` and `tish_runtime` get rewritten, `tish_broker` (foreign repo) and `tish_notreal` (nonexistent) are left alone.

## 2. The row named a package that doesn't exist

It ran `cargo check -p tish-apple-common`, but the package is **`tishlang_apple_common`** — `crates/tish-apple-common` is only the directory name. So even once the manifest loaded, the row errored:

```
error: package ID specification `tish-apple-common` did not match any packages
```

Both bugs had to be fixed for the row to run at all, which is why the second one stayed hidden behind the first.

## Upstream half

tishlang/tish-apple#6 makes tish-apple take the published `tishlang_broker` 1.1.4 from the registry instead of reaching into a sibling checkout — a path dep to a sibling only resolves on a machine that happens to have one, and it makes the workspace unloadable everywhere else, including any plain `git clone`.

## Verification

With that branch as the row's source, the real runner passes end to end:

```
── tish-apple ── copying /Users/a_/Projects/tish/tish-apple
   ✓ PASS
  PASS:           tish-apple
```

Also documented in the manifest that Cargo loads **every** workspace member's manifest to check a single package — so the existing note that tish-macos/tish-ios "aren't Linux-checkable" doesn't stop a broken sibling member from taking the whole row down.

## Context

Found while running `regression/examples` and `regression/downstream` against a working branch. Full results there: examples `PASS 15 · FAIL 0 · SKIP 17` (exit 0), downstream 19 PASS / 2 xfail / 1 SKIP with `tish-apple` the only failure — which turned out to predate the branch entirely (reproduced identically on `main` @ 4a0eef50c).