### PR TITLE
fix(ci): look release assets up via the API, not the frozen event payload

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -137,9 +137,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ASSET_URL=$(echo '${{ toJSON(github.event.release.assets) }}' | jq -r --arg n "${{ matrix.asset }}" '.[] | select(.name == $n) | .url')
+          # Look the asset up through the API, NOT `github.event.release.assets`.
+          #
+          # The event payload is a snapshot frozen when the release event fired, and ci.yml creates
+          # the release BEFORE it finishes uploading the tarballs — so a package whose tarball lands
+          # a few seconds later is simply absent from the payload and the job fails with
+          # "Release has no asset". Re-running does not help: a re-run replays the SAME frozen
+          # payload, so it fails identically forever. That is what happened to v3.2.1 — the payload
+          # carried 14 assets, the release has 21, and the 7 it never saw included the tarballs for
+          # @tishlang/tish, tish-lsp, tish-lint, tish-format and cargo-bindgen.
+          #
+          # Querying live also lets a re-run recover a release whose uploads have since completed,
+          # and the retry below covers the first run still racing them.
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            ASSET_URL=$(curl -sL -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?per_page=100" \
+              | jq -r --arg n "${{ matrix.asset }}" '.[] | select(.name == $n and .state == "uploaded") | .url')
+            [ -n "$ASSET_URL" ] && [ "$ASSET_URL" != "null" ] && break
+            echo "asset ${{ matrix.asset }} not uploaded yet (attempt $attempt/10) — waiting 30s"
+            sleep 30
+          done
           if [ -z "$ASSET_URL" ] || [ "$ASSET_URL" = "null" ]; then
-            echo "Release has no asset ${{ matrix.asset }}"
+            echo "Release ${{ github.event.release.tag_name }} has no uploaded asset ${{ matrix.asset }} after 5 minutes"
             exit 1
           fi
           curl -sL -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/octet-stream" "$ASSET_URL" -o "${{ matrix.asset }}"


### PR DESCRIPTION
## Why v3.2.1 never reached npm — and why re-running can't fix it

The tarball download reads the asset list from the **event payload**:

```yaml
ASSET_URL=$(echo '${{ toJSON(github.event.release.assets) }}' | jq -r …)
```

That payload is a snapshot frozen when the release event fired. `ci.yml` creates the release **before** it finishes uploading the tarballs, so any package whose asset lands a few seconds later is absent from the snapshot and the job dies with `Release has no asset …`.

The trap is that **re-running replays the same frozen payload**, so it fails identically however many times you try — even though the asset is plainly visible on the release page.

## Evidence from v3.2.1

| | count |
|---|---|
| assets in the frozen event payload | **14** |
| assets actually on the release | **21** |

The 7 the payload never saw:

```
cargo-bindgen-npm-package.tgz   tish-lsp-darwin-x64
tish-format-npm-package.tgz     tish-lsp-npm-package.tgz
tish-lint-npm-package.tgz       tish-lsp-win32-x64.exe
tish-npm-package.tgz
```

Those tarballs are exactly the five jobs that failed — `@tishlang/tish`, `tish-lsp`, `tish-lint`, `tish-format`, `cargo-bindgen`. The three that succeeded (`pg`, `create-tish-app`, `vite-plugin-tish`) are the ones whose tarballs happened to be uploaded before the event fired. npm is still on **3.1.0** because of this.

## Fix

Query the assets endpoint at run time, filtering on `state == "uploaded"` so a half-written asset isn't picked up:

```bash
curl -sL -H "Authorization: Bearer $GITHUB_TOKEN" \
  "https://api.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?per_page=100" \
  | jq -r --arg n "${{ matrix.asset }}" '.[] | select(.name == $n and .state == "uploaded") | .url'
```

Two things this buys:

- **A re-run now recovers** a release whose uploads have since completed — which is the case for v3.2.1 right now.
- A short retry (10 × 30s) covers a *first* run still racing the upload, so the next release doesn't need a manual re-run at all.

Verified against the live v3.2.1 release: the API returns all 21 assets and resolves every one of the five tarballs the payload was missing.

## After this merges

Re-running the v3.2.1 npm-release job should publish the five stuck packages, since all its assets are now uploaded.