### PR TITLE
perf(codegen): keep integers integral across the int-domain boundary — up to 28x on GBA

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -16131,16 +16131,6 @@ impl Codegen {
             // A call to a fn whose every return is PROVEN numeric. Without this a call is opaque and
             // any local assigned from one demotes to a boxed `Value`. `env` shadowing wins: a local
             // of that name is not the fn.
-            Expr::Call { callee, .. } => {
-                if let Expr::Ident { name, .. } = callee.as_ref() {
-                    if !env.contains_key(name.as_ref()) {
-                        if let Some(ft) = self.user_fn_ret.get(name.as_ref()) {
-                            return ft.clone();
-                        }
-                    }
-                }
-                RustType::Value
-            }
             // `vec[i]` where `vec` is a `number[]` (Vec<f64>) → the element type. A `Vec<f64>`
             // can only hold numbers, so this never feeds a string into the accumulator.
             Expr::Index {
@@ -16219,9 +16209,14 @@ impl Codegen {
                 }
                 RustType::Value
             }
+            // ONE Call arm, and the singularity is load-bearing: the numeric-return proof briefly
+            // lived in its own `Expr::Call` arm ABOVE this one, which shadowed everything below —
+            // native-fn results, the Math intrinsics and the #169 reduce modelling all became
+            // unreachable (rustc said so, as a warning nobody read) and every accumulator they
+            // feed demoted to a boxed `Value`. CI caught it as issue_169 + the #320 push test.
             Expr::Call { callee, args, .. } => {
-                // M5 native fn (`fn f_native(..) -> f64`); requires all-positional args.
                 if let Expr::Ident { name: fname, .. } = callee.as_ref() {
+                    // M5 native fn (`fn f_native(..) -> f64`); requires all-positional args.
                     if self.native_fns.contains(fname.as_ref())
                         && args.iter().all(|a| matches!(a, CallArg::Expr(_)))
                     {
@@ -16230,6 +16225,14 @@ impl Codegen {
                         } else {
                             RustType::F64
                         };
+                    }
+                    // A call to a fn whose every return is PROVEN numeric (the boxed call's RESULT
+                    // stops being opaque — the dispatch is unchanged). `env` shadowing wins: a
+                    // local of that name is not the fn.
+                    if !env.contains_key(fname.as_ref()) {
+                        if let Some(ft) = self.user_fn_ret.get(fname.as_ref()) {
+                            return ft.clone();
+                        }
                     }
                 }
                 // Single-arg `Math.<intrinsic>(x)` lowered to a direct `f64` method → number.
@@ -24742,9 +24745,15 @@ impl Codegen {
                 // The `_ =>` arm is unreachable by construction: membership required every return
                 // to be numeric. Written out rather than `unreachable!()` so a proof bug surfaces as
                 // the same diagnostic every other coercion in this file produces.
+                // NOT for fns that also have an M5 native form: the direct-call path below emits
+                // `name_native(..)` bare, and this block reaching them first wrapped that same call
+                // in `Value::Number(..)` and match-unwrapped it straight back — the boxed round
+                // trip the #320 push test pins against. A proof is the fallback, never the winner.
                 if !self.user_fn_ret.is_empty() {
                     if let Expr::Ident { name, .. } = callee.as_ref() {
-                        if let Some(ty) = self.user_fn_ret.get(name.as_ref()).cloned() {
+                        if self.native_fns.contains(name.as_ref()) {
+                            // fall through to the native direct-call path
+                        } else if let Some(ty) = self.user_fn_ret.get(name.as_ref()).cloned() {
                             let boxed = self.emit_expr(expr)?;
                             let conv = if ty == RustType::I32 {
                                 "tishlang_runtime::to_int32(*n)"

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -24128,45 +24128,15 @@ impl Codegen {
                                 };
                                 // #173 part 3: prove the index in-bounds BEFORE emitting it.
                                 let in_bounds = self.index_in_bounds(index, name.as_ref());
-                                let idx_usize = if let Expr::Ident { name: idx_name, .. } =
-                                    index.as_ref()
-                                {
-                                    if let Some(uv) =
-                                        self.usize_var_subst.get(idx_name.as_ref())
-                                    {
-                                        uv.clone()
-                                    } else {
-                                        let (idx_code, idx_ty) = self.emit_typed_expr(index)?;
-                                        if idx_ty == RustType::F64 || idx_ty == RustType::I32 {
-                                            format!("({}) as usize", idx_code)
-                                        } else {
-                                            let iv = if idx_ty.is_native() {
-                                                idx_ty.to_value_expr(&idx_code)
-                                            } else {
-                                                idx_code
-                                            };
-                                            format!(
-                                                "{{ let _i = &{}; if let Value::Number(n) = _i {{ *n as usize }} else {{ panic!(\"array index must be a number\") }} }}",
-                                                iv
-                                            )
-                                        }
-                                    }
-                                } else {
-                                    let (idx_code, idx_ty) = self.emit_typed_expr(index)?;
-                                    if idx_ty == RustType::F64 || idx_ty == RustType::I32 {
-                                        format!("({}) as usize", idx_code)
-                                    } else {
-                                        let iv = if idx_ty.is_native() {
-                                            idx_ty.to_value_expr(&idx_code)
-                                        } else {
-                                            idx_code
-                                        };
-                                        format!(
-                                            "{{ let _i = &{}; if let Value::Number(n) = _i {{ *n as usize }} else {{ panic!(\"array index must be a number\") }} }}",
-                                            iv
-                                        )
-                                    }
-                                };
+                                // The READ index goes through the same helper as the element STORE.
+                                // These two arms used to be a hand-inlined copy of it that predated
+                                // the int-domain shortcut, so `arr[a | b]` lowered its store index
+                                // integrally and its read index as `((a|b) as f64) as usize` — two
+                                // soft-float calls on ARM7TDMI, on the read half of every packed-grid
+                                // access. Measured in tish-gba: a 63-cell board copy whose body is
+                                // `P[dc|r] = P[sc|r] & keep` cost 2,103 ticks, 33 per cell, against
+                                // ~1.6 for a module `i32[]` read plus write.
+                                let idx_usize = self.emit_index_usize(index)?;
                                 // #567: inside the wrapped block the index is pre-bound to `__bi`
                                 // (evaluated BEFORE the borrow, so an index that itself reads this cell
                                 // — `arr[arr.length-1]` — doesn't double-lock the non-reentrant cell).

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -19240,7 +19240,20 @@ impl Codegen {
                         self.skip_iter_local = Some(iter);
                     }
                 }
-                self.emit_statements_with_folds(statements)?;
+                // A NATIVE FN BODY IS A SCOPE, and it has to say so. `VarDecl` registers every
+                // name it emits into `outer_vars_stack.last_mut()`; without a frame of its own,
+                // a native fn's locals land in the MODULE frame — where they do not exist, because
+                // the body was emitted inside `fn name_native(..)` at top level. Any later closure
+                // referencing a same-named local of its own then sees the phantom in `outer_vars`
+                // and emits `let i_cell = VmRef::new(i.clone());` against nothing: E0425, 49 of the
+                // 114 tish-gba examples, every one of them with an `i` or `b` loop counter.
+                //
+                // The boxed FunDecl path has always pushed here (both of its arms do); this path
+                // was written without one and only became reachable when M5 was enabled for GBA.
+                self.outer_vars_stack.push(Vec::new());
+                let r = self.emit_statements_with_folds(statements);
+                self.outer_vars_stack.pop();
+                r?;
                 if self.pending_stayed_var.is_none() {
                     self.skip_iter_local = None;
                 }

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -24802,16 +24802,24 @@ impl Codegen {
                 // M5: direct call to an eligible native fn -> `name_native(<native args>)`.
                 if let Expr::Ident { name: fname, .. } = callee.as_ref() {
                     if self.native_fns.contains(fname.as_ref()) {
+                        // The ABI this callee actually has. Passing every argument through
+                        // `coerce_native_arg` — as the boxed-context site already does — is what
+                        // keeps a NATIVE argument of the other width from being handed over raw:
+                        // `manhattan(c, r, tac_unit_col(id), tac_unit_row(id))` types its extern
+                        // args I32 and the callee takes f64, which emitted `manhattan_native(.., i32)`
+                        // and rustc rejected it with E0308. Value args keep their existing
+                        // from_value_expr path (coerce_native_arg's first arm IS that path).
+                        let want = if self.native_fns_i32.contains(fname.as_ref()) {
+                            RustType::I32
+                        } else {
+                            RustType::F64
+                        };
                         let mut argc: Vec<String> = Vec::with_capacity(args.len());
                         let mut ok = true;
                         for a in args {
                             if let CallArg::Expr(e) = a {
                                 let (ac, at) = self.emit_typed_expr(e)?;
-                                argc.push(if at == RustType::Value {
-                                    RustType::F64.from_value_expr(&ac)
-                                } else {
-                                    ac
-                                });
+                                argc.push(self.coerce_native_arg(&ac, at, want.clone()));
                             } else {
                                 ok = false;
                                 break;
@@ -24827,13 +24835,15 @@ impl Codegen {
                                     RustType::F64,
                                 ));
                             }
+                            // …and report the ABI's OWN return type, for the same reason: an
+                            // i32-ABI callee reported as F64 mistypes every consumer downstream.
                             return Ok((
                                 format!(
                                     "{}({})",
                                     self.native_call_target(fname.as_ref()),
                                     argc.join(", ")
                                 ),
-                                RustType::F64,
+                                want,
                             ));
                         }
                     }

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -12379,13 +12379,39 @@ impl Codegen {
         &self,
         stmts: &[Statement],
     ) -> std::collections::HashMap<String, RustType> {
-        let mut env: HashMap<String, RustType> = HashMap::new();
-        Self::collect_annotated_types(stmts, &self.type_aliases, &mut env);
+        // MODULE SCOPE ONLY. `collect_annotated_types` over the whole program builds a NAME-FLAT
+        // map, which `collect_demoted_numeric_locals` can use because its error direction is safe —
+        // over-demoting only costs a box. Proving is the opposite: a numeric `s` in one function
+        // would make a STRING `s` in another look numeric, and the return gets coerced.
+        //
+        // That is not hypothetical. It shipped: `function ruleTag(mask: i32) { let s = ""; …;
+        // return s }` was proven numeric off an unrelated numeric `s`, and every ROM using it
+        // panicked with "expected number". Each fn gets its own scope now.
+        let mut module_env: HashMap<String, RustType> = HashMap::new();
+        let top_only: Vec<Statement> = stmts
+            .iter()
+            .filter(|s| matches!(s, Statement::VarDecl { .. }))
+            .cloned()
+            .collect();
+        Self::collect_annotated_types(&top_only, &self.type_aliases, &mut module_env);
 
-        let mut decls: Vec<(String, &Statement)> = Vec::new();
+        let mut decls: Vec<(String, &Statement, HashMap<String, RustType>)> = Vec::new();
         for s in stmts {
-            if let Statement::FunDecl { async_: false, name, body, .. } = s {
-                decls.push((name.to_string(), body.as_ref()));
+            if let Statement::FunDecl { async_: false, name, params, body, .. } = s {
+                let mut env = module_env.clone();
+                // This fn's own params and locals — not a nested closure's, whose names are its own.
+                for prm in params {
+                    if let FunParam::Simple(tp) = prm {
+                        if let Some(ann) = &tp.type_ann {
+                            let ty = RustType::from_annotation(ann);
+                            if ty.is_native() {
+                                env.insert(tp.name.to_string(), ty);
+                            }
+                        }
+                    }
+                }
+                Self::collect_own_locals(body.as_ref(), &self.type_aliases, &mut env);
+                decls.push((name.to_string(), body.as_ref(), env));
             }
         }
 
@@ -12401,7 +12427,7 @@ impl Codegen {
         let mut out: std::collections::HashMap<String, RustType> = std::collections::HashMap::new();
         loop {
             let mut changed = false;
-            for (name, body) in &decls {
+            for (name, body, env) in &decls {
                 if out.contains_key(name) || excluded.contains(name) {
                     continue;
                 }
@@ -12413,7 +12439,7 @@ impl Codegen {
                 let mut ty: Option<RustType> = None;
                 let mut ok = true;
                 for e in &rets {
-                    let Some(et) = self.proof_numeric_type(e, &env, &out) else {
+                    let Some(et) = self.proof_numeric_type(e, env, &out) else {
                         ok = false;
                         break;
                     };
@@ -12500,6 +12526,36 @@ impl Codegen {
                 _ => None,
             },
             _ => None,
+        }
+    }
+
+    /// Annotated locals declared directly in this body — through blocks, ifs and loops, but NOT
+    /// into a nested function, whose locals are its own scope and would re-create the name
+    /// collision this exists to avoid.
+    fn collect_own_locals(
+        s: &Statement,
+        aliases: &HashMap<String, RustType>,
+        env: &mut HashMap<String, RustType>,
+    ) {
+        match s {
+            Statement::VarDecl { .. } => {
+                Self::collect_annotated_types(core::slice::from_ref(s), aliases, env)
+            }
+            Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
+                for x in statements {
+                    Self::collect_own_locals(x, aliases, env);
+                }
+            }
+            Statement::If { then_branch, else_branch, .. } => {
+                Self::collect_own_locals(then_branch, aliases, env);
+                if let Some(e) = else_branch {
+                    Self::collect_own_locals(e, aliases, env);
+                }
+            }
+            Statement::While { body, .. } | Statement::For { body, .. } => {
+                Self::collect_own_locals(body, aliases, env)
+            }
+            _ => {}
         }
     }
 

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1121,6 +1121,12 @@ pub(crate) struct Codegen {
     /// free `fn f_native(f64,..)->f64` (all params `: number`, returns `number`, native-safe
     /// body). Direct calls to these route to the native fn, bypassing the boxed `value_call`.
     native_fns: std::collections::HashSet<String>,
+    /// Set while emitting the body of an i32-ABI native fn, so `return` coerces to `i32`.
+    native_fn_abi_i32: bool,
+    /// The subset of `native_fns` emitted with an `fn(i32, ..) -> i32` signature instead of the
+    /// f64 one — every parameter and the return annotated `: i32`. On ARM7TDMI this is the whole
+    /// point: an f64 ABI makes every argument and every return a soft-float conversion.
+    native_fns_i32: std::collections::HashSet<String>,
     /// True while emitting an M5 `fn name_native` body — keeps VarDecl inits on the native path.
     native_fn_body_emit: bool,
     /// M5 fn currently being emitted (`mandel_native`, `fastaRandom_native`, …).
@@ -1379,6 +1385,8 @@ impl Codegen {
             collection_instance_locals: std::collections::HashSet::new(),
             hoisted_string_chars: std::collections::HashMap::new(),
             native_fns: std::collections::HashSet::new(),
+            native_fns_i32: std::collections::HashSet::new(),
+            native_fn_abi_i32: false,
             native_fn_body_emit: false,
             native_fn_emit_name: None,
             native_fn_literal_args: std::collections::HashMap::new(),
@@ -3138,25 +3146,41 @@ impl Codegen {
         // route to it in emit_typed_expr.
         // Gba mode: these passes emit `thread_local!` and other std-isms; gate them off initially
         // (they are pure perf — correctness is unaffected). Re-audit for no_std later.
-        if crate::native_opts_enabled() && self.emit_mode != crate::NativeEmitMode::Gba {
-            self.native_numeric_globals =
-                Self::collect_native_numeric_globals(&program.statements);
-            if !self.native_numeric_globals.is_empty() {
-                self.emit_native_numeric_global_tls()?;
-                self.writeln("");
+        if crate::native_opts_enabled() {
+            // GBA runs a REDUCED form of this block. The three sub-passes below emit `thread_local!`
+            // and other std-isms and stay off there; the native-fn pass itself emits plain free
+            // `fn`s and is exactly what a device with no FPU wants, so it runs. A candidate that
+            // needed one of the skipped passes simply fails to qualify — `globals` and
+            // `native_vec_names` are empty, so any identifier it reads that is not a parameter
+            // disqualifies it, which is the conservative direction.
+            let gba = self.emit_mode == crate::NativeEmitMode::Gba;
+            if !gba {
+                self.native_numeric_globals =
+                    Self::collect_native_numeric_globals(&program.statements);
+                if !self.native_numeric_globals.is_empty() {
+                    self.emit_native_numeric_global_tls()?;
+                    self.writeln("");
+                }
+                self.module_const_f64_arrays =
+                    Self::collect_module_const_f64_arrays(&program.statements);
+                self.module_const_f64_cum = Self::collect_module_const_cum(
+                    &program.statements,
+                    &self.module_const_f64_arrays,
+                );
+                self.module_const_f64_aliases = Self::collect_module_const_aliases(
+                    &program.statements,
+                    &self.module_const_f64_cum,
+                );
+                if !self.module_const_f64_arrays.is_empty() {
+                    self.emit_module_const_f64_arrays()?;
+                    self.writeln("");
+                }
             }
-            self.module_const_f64_arrays =
-                Self::collect_module_const_f64_arrays(&program.statements);
-            self.module_const_f64_cum =
-                Self::collect_module_const_cum(&program.statements, &self.module_const_f64_arrays);
-            self.module_const_f64_aliases =
-                Self::collect_module_const_aliases(&program.statements, &self.module_const_f64_cum);
-            if !self.module_const_f64_arrays.is_empty() {
-                self.emit_module_const_f64_arrays()?;
-                self.writeln("");
-            }
-            let native_vec_names: std::collections::HashSet<String> =
-                Self::detect_native_vec_fns(program).keys().cloned().collect();
+            let native_vec_names: std::collections::HashSet<String> = if gba {
+                std::collections::HashSet::new()
+            } else {
+                Self::detect_native_vec_fns(program).keys().cloned().collect()
+            };
             let mut global_names: std::collections::HashSet<String> =
                 self.native_numeric_globals.keys().cloned().collect();
             global_names.extend(self.module_const_f64_arrays.keys().cloned());
@@ -3165,6 +3189,21 @@ impl Codegen {
                 &global_names,
                 &native_vec_names,
             );
+            // Which of the survivors carry the all-`i32` signature. Computed AFTER the fixpoint,
+            // so a function the proof rejected never reaches the i32 ABI either.
+            self.native_fns_i32 = program
+                .statements
+                .iter()
+                .filter_map(|s| match s {
+                    Statement::FunDecl { name, params, return_type, .. }
+                        if self.native_fns.contains(name.as_ref())
+                            && Self::fn_sig_all_i32(params, return_type) =>
+                    {
+                        Some(name.to_string())
+                    }
+                    _ => None,
+                })
+                .collect();
             self.native_fn_literal_args =
                 Self::collect_native_fn_literal_calls(&program.statements, &self.native_fns);
             self.native_fn_param_names =
@@ -3173,11 +3212,17 @@ impl Codegen {
                 Self::collect_native_lcg_fns(&program.statements, &self.native_fns);
             // #381 — fns on a call-graph cycle get guarded rotation copies (default ON;
             // TISH_NATIVE_RECUR_GUARD=0 restores the plain unguarded emission).
-            self.native_recur_fns = if crate::native_recur_guard_enabled() {
+            self.native_recur_fns = if crate::native_recur_guard_enabled()
+                && self.emit_mode != crate::NativeEmitMode::Gba
+            {
                 Self::compute_native_recur_fns(&program.statements, &self.native_fns)
             } else {
                 std::collections::HashMap::new()
             };
+            // A fn on a call-graph cycle keeps the f64 ABI: its stack-guard bail unwinds through a
+            // NaN sentinel (#381), and an `i32` return has no value to spare for that. Recursion is
+            // not what the i32 shape exists for.
+            self.native_fns_i32.retain(|n| !self.native_recur_fns.contains_key(n));
             if !self.native_fns.is_empty() {
                 self.emit_native_fns(&program.statements)?;
                 self.writeln("");
@@ -9059,27 +9104,31 @@ impl Codegen {
                 // M5: boxed-context call to an eligible native fn → `Value::Number(name_native(..))`.
                 if let Expr::Ident { name: fname, .. } = callee.as_ref() {
                     if self.native_fns.contains(fname.as_ref()) {
+                        let i32_abi = self.native_fns_i32.contains(fname.as_ref());
+                        let want =
+                            if i32_abi { RustType::I32 } else { RustType::F64 };
                         let mut argc: Vec<String> = Vec::with_capacity(args.len());
                         let mut ok = true;
                         for a in args {
                             if let CallArg::Expr(e) = a {
                                 let (ac, at) = self.emit_typed_expr(e)?;
-                                argc.push(if at == RustType::Value {
-                                    RustType::F64.from_value_expr(&ac)
-                                } else {
-                                    ac
-                                });
+                                argc.push(self.coerce_native_arg(&ac, at, want.clone()));
                             } else {
                                 ok = false;
                                 break;
                             }
                         }
                         if ok {
-                            return Ok(format!(
-                                "Value::Number({}({}))",
+                            let call = format!(
+                                "{}({})",
                                 self.native_call_target(fname.as_ref()),
                                 argc.join(", ")
-                            ));
+                            );
+                            return Ok(if i32_abi {
+                                format!("Value::Number(({}) as f64)", call)
+                            } else {
+                                format!("Value::Number({})", call)
+                            });
                         }
                     }
                 }
@@ -12354,6 +12403,28 @@ impl Codegen {
     // ───────────────────────── M5: native monomorphic functions ─────────────────────────
     fn ann_is_number(ann: &TypeAnnotation) -> bool {
         RustType::from_annotation(ann) == RustType::F64
+    }
+
+    fn ann_is_i32(ann: &TypeAnnotation) -> bool {
+        RustType::from_annotation(ann) == RustType::I32
+    }
+
+    /// Is every parameter AND the return annotated `: i32`?
+    ///
+    /// ALL OR NOTHING, deliberately. An `: i32` parameter reached through the boxed path is
+    /// ToInt32-coerced on entry; promoted to a native `f64` it would not be, so 3.7 would arrive as
+    /// 3 one way and 3.7 the other. Admitting `: i32` per-annotation would do exactly that to a
+    /// function that mixes the two. A function whose whole signature is `i32` has one convention
+    /// and keeps the coercion at the boundary, where the caller does it once on an argument that is
+    /// usually already an integer.
+    fn fn_sig_all_i32(params: &[FunParam], return_type: &Option<TypeAnnotation>) -> bool {
+        return_type.as_ref().is_some_and(Self::ann_is_i32)
+            && !params.is_empty()
+            && params.iter().all(|p| {
+                matches!(p, FunParam::Simple(tp)
+                    if tp.default.is_none()
+                        && tp.type_ann.as_ref().is_some_and(Self::ann_is_i32))
+            })
     }
 
     // ── Soundness: demote `number` locals that a reassignment can turn non-numeric ──────────────
@@ -16154,7 +16225,11 @@ impl Codegen {
                     if self.native_fns.contains(fname.as_ref())
                         && args.iter().all(|a| matches!(a, CallArg::Expr(_)))
                     {
-                        return RustType::F64;
+                        return if self.native_fns_i32.contains(fname.as_ref()) {
+                            RustType::I32
+                        } else {
+                            RustType::F64
+                        };
                     }
                 }
                 // Single-arg `Math.<intrinsic>(x)` lowered to a direct `f64` method → number.
@@ -18197,6 +18272,12 @@ impl Codegen {
                     Some(rt) => Self::ann_is_number(rt),
                     None => true,
                 };
+                // THE SECOND SHAPE: an all-`i32` signature, which is what a device with no FPU
+                // wants and what the existing gate excluded. The fixpoint below is unchanged and
+                // still has to prove the body native-safe and every return numeric — the annotation
+                // never decides that on its own (see `liar` in the issue).
+                let i32_ok = Self::fn_sig_all_i32(params, return_type);
+                let (params_ok, ret_ok) = (params_ok || i32_ok, ret_ok || i32_ok);
                 // #320: 0-param numeric fns (e.g. k_nucleotide's `nextBase()` — mutates a numeric
                 // global, returns number) are eligible too; the fixpoint below still proves the body
                 // native-safe + all-numeric-returns, so `fn name_native() -> f64` is sound.
@@ -18590,6 +18671,27 @@ impl Codegen {
         }
     }
 
+    /// Can a top-level native `fn` name this indexed object? A parameter, a global with a static,
+    /// a native-vec, or a local it declared itself — anything else is a binding that only exists
+    /// inside `run()`.
+    fn native_safe_indexable(
+        object: &Expr,
+        params: &std::collections::HashSet<String>,
+        globals: &std::collections::HashSet<String>,
+        nums: &HashSet<String>,
+        native_vec_names: &std::collections::HashSet<String>,
+    ) -> bool {
+        match object {
+            Expr::Ident { name, .. } => {
+                params.contains(name.as_ref())
+                    || globals.contains(name.as_ref())
+                    || nums.contains(name.as_ref())
+                    || native_vec_names.contains(name.as_ref())
+            }
+            _ => false,
+        }
+    }
+
     fn native_safe_expr(
         expr: &Expr,
         params: &std::collections::HashSet<String>,
@@ -18612,24 +18714,45 @@ impl Codegen {
                     && Self::native_safe_expr(value, params, cand, globals, nums, native_vec_names)
             }
             Expr::Binary { left, op, right, .. } => {
-                matches!(
+                let arith = matches!(
                     op,
                     BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod | BinOp::Pow
                         | BinOp::Lt | BinOp::Le | BinOp::Gt | BinOp::Ge
                         | BinOp::StrictEq | BinOp::StrictNe | BinOp::And | BinOp::Or
-                ) && Self::native_safe_expr(left, params, cand, globals, nums, native_vec_names)
+                );
+                // Bitwise, unlike in `numeric_shaped`, still recurses into its operands: there the
+                // question is what the RESULT is (always a number), here it is whether the emitter
+                // can lower the whole expression natively. Gated with its sibling so that off the
+                // GBA numeric vocabulary eligibility is byte-identical to before.
+                let bitwise = crate::types::gba_numerics_enabled()
+                    && matches!(
+                        op,
+                        BinOp::BitAnd | BinOp::BitOr | BinOp::BitXor
+                            | BinOp::Shl | BinOp::Shr | BinOp::UShr
+                    );
+                (arith || bitwise)
+                    && Self::native_safe_expr(left, params, cand, globals, nums, native_vec_names)
                     && Self::native_safe_expr(right, params, cand, globals, nums, native_vec_names)
             }
             Expr::Unary { op, operand, .. } => {
-                matches!(op, UnaryOp::Neg | UnaryOp::Pos | UnaryOp::Not)
+                (matches!(op, UnaryOp::Neg | UnaryOp::Pos | UnaryOp::Not)
+                    || (crate::types::gba_numerics_enabled()
+                        && matches!(op, UnaryOp::BitNot)))
                     && Self::native_safe_expr(operand, params, cand, globals, nums, native_vec_names)
             }
             Expr::PostfixInc { name, .. }
             | Expr::PrefixInc { name, .. }
             | Expr::PostfixDec { name, .. }
             | Expr::PrefixDec { name, .. } => nums.contains(name.as_ref()),
+            // THE INDEXED THING MUST BE IN SCOPE FOR A FREE `fn`, not merely be an identifier.
+            // This accepted any name at all, and a native fn is emitted at top level where a
+            // module-scope binding — a `let` inside `run()`, captured by the boxed closures — does
+            // not exist: `function reads(i: i32): i32 { return ARR[i] & 255 }` compiled to a
+            // `reads_native` whose body named `ARR`, and rustc rejected the generated program with
+            // E0425. Masked until now because the globals set was only ever populated with things
+            // that DO have a top-level static.
             Expr::Index { object, index, .. } => {
-                matches!(object.as_ref(), Expr::Ident { .. })
+                Self::native_safe_indexable(object, params, globals, nums, native_vec_names)
                     && Self::native_safe_expr(index, params, cand, globals, nums, native_vec_names)
             }
             Expr::IndexAssign {
@@ -18638,7 +18761,7 @@ impl Codegen {
                 value,
                 ..
             } => {
-                matches!(object.as_ref(), Expr::Ident { .. })
+                Self::native_safe_indexable(object, params, globals, nums, native_vec_names)
                     && Self::native_safe_expr(index, params, cand, globals, nums, native_vec_names)
                     && Self::native_safe_expr(value, params, cand, globals, nums, native_vec_names)
             }
@@ -18718,6 +18841,26 @@ impl Codegen {
                     || globals.contains(name.as_ref())
                     || nums.contains(name.as_ref())
             }
+            // A BITWISE RESULT IS A NUMBER WHATEVER WENT IN. `& | ^ << >> >>>` are ToInt32/ToUint32
+            // contexts in the language, so `"7" & 255` is 7 and `{} | 0` is 0 — the operands need
+            // no proof of their own, which is why this arm does not recurse into them. Their
+            // absence is not a small omission on a device with no FPU: `(a + b) | 0`, `a & 255` and
+            // `w >> 16` are what integer code on such a target is made of, and every function
+            // containing one was ineligible for a native `fn` no matter how it was annotated.
+            Expr::Binary { op, .. }
+                if crate::types::gba_numerics_enabled()
+                    && matches!(
+                        op,
+                        BinOp::BitAnd
+                            | BinOp::BitOr
+                            | BinOp::BitXor
+                            | BinOp::Shl
+                            | BinOp::Shr
+                            | BinOp::UShr
+                    ) =>
+            {
+                true
+            }
             Expr::Binary { left, op, right, .. } => {
                 matches!(
                     op,
@@ -18725,6 +18868,8 @@ impl Codegen {
                 ) && Self::numeric_shaped(left, params, cand, globals, nums)
                     && Self::numeric_shaped(right, params, cand, globals, nums)
             }
+            // Unary `~` is ToInt32 for the same reason.
+            Expr::Unary { op: UnaryOp::BitNot, .. } if crate::types::gba_numerics_enabled() => true,
             Expr::Unary { op, operand, .. } => {
                 matches!(op, UnaryOp::Neg | UnaryOp::Pos)
                     && Self::numeric_shaped(operand, params, cand, globals, nums)
@@ -18871,6 +19016,24 @@ impl Codegen {
     /// guarded fn is copy 0, the one with the stack check, so every entry from outside the cycle is
     /// checked. Inside rotation copy `i`, an intra-SCC call targets the callee's copy `i+1` (the
     /// checked copy 0 again after K levels).
+    /// Bring one argument to a native fn's parameter type.
+    ///
+    /// The f64 ABI accepts an `i32` expression as-is (Rust widens on the `as` the emitter already
+    /// writes); the i32 ABI has to ToInt32 an f64 one, which is exactly the coercion the boxed
+    /// path applied on entry — moved to the caller, where the value is usually already an integer
+    /// and the conversion folds away.
+    fn coerce_native_arg(&self, code: &str, from: RustType, want: RustType) -> String {
+        if from == want {
+            return code.to_string();
+        }
+        match (from, want) {
+            (RustType::Value, w) => w.from_value_expr(code),
+            (RustType::I32, RustType::F64) => format!("(({}) as f64)", code),
+            (_, RustType::I32) => format!("tishlang_runtime::to_int32({})", code),
+            _ => code.to_string(),
+        }
+    }
+
     fn native_call_target(&self, fname: &str) -> String {
         let base = format!("{}_native", Self::escape_ident(fname));
         if let (Some((cur_scc, i, k)), Some(&(callee_scc, _))) =
@@ -18892,11 +19055,13 @@ impl Codegen {
                 if !self.native_fns.contains(name.as_ref()) {
                     continue;
                 }
+                let i32_abi = self.native_fns_i32.contains(name.as_ref());
+                let abi = if i32_abi { "i32" } else { "f64" };
                 let plist: Vec<String> = params
                     .iter()
                     .filter_map(|p| match p {
                         FunParam::Simple(tp) => {
-                            Some(format!("mut {}: f64", Self::escape_ident(tp.name.as_ref())))
+                            Some(format!("mut {}: {}", Self::escape_ident(tp.name.as_ref()), abi))
                         }
                         _ => None,
                     })
@@ -18916,18 +19081,30 @@ impl Codegen {
                 self.type_context.push_scope();
                 for p in params {
                     if let FunParam::Simple(tp) = p {
-                        self.type_context.define(tp.name.as_ref(), RustType::F64);
+                        self.type_context.define(
+                            tp.name.as_ref(),
+                            if i32_abi { RustType::I32 } else { RustType::F64 },
+                        );
                     }
                 }
                 let copy_suffix = if copy_idx == 0 { String::new() } else { format!("_r{}", copy_idx) };
-                self.writeln(&format!("fn {}_native{}({}) -> f64 {{", Self::escape_ident(name.as_ref()), copy_suffix, plist.join(", ")));
+                self.writeln(&format!("fn {}_native{}({}) -> {} {{", Self::escape_ident(name.as_ref()), copy_suffix, plist.join(", "), abi));
+                let saved_i32_abi = self.native_fn_abi_i32;
+                self.native_fn_abi_i32 = i32_abi;
                 self.indent += 1;
                 if copies > 1 {
                     self.native_recur_rotation = Some((scc_id, copy_idx, copies));
                     if copy_idx == 0 {
                         // The guard: one thread-local read + pointer compare; the cold bail parks
                         // the catchable RangeError and unwinds via the NaN sentinel (#381).
-                        self.writeln("if tishlang_runtime::stack_low() { return tishlang_runtime::recursion_tripped_f64(); }");
+                        // The f64 bail unwinds through a NaN sentinel, which an `i32` return has no
+                        // room for. `compute_native_recur_fns` therefore never gives an i32-ABI fn
+                        // rotation copies — see the guard where it is called.
+                        self.writeln(if i32_abi {
+                            "if tishlang_runtime::stack_low() { return 0; }"
+                        } else {
+                            "if tishlang_runtime::stack_low() { return tishlang_runtime::recursion_tripped_f64(); }"
+                        });
                     }
                 }
                 if let Some((global, mul, add, modulus)) = self.native_lcg_fns.get(name.as_ref()) {
@@ -18999,10 +19176,11 @@ impl Codegen {
                     self.native_lcg_hoist.take();
                     self.native_lcg_hoist_int = false;
                     if !self.native_fn_body_returned {
-                        self.writeln("0.0");
+                        self.writeln(if i32_abi { "0" } else { "0.0" });
                     }
                     self.native_fn_emit_name = None;
                 }
+                self.native_fn_abi_i32 = saved_i32_abi;
                 self.indent -= 1;
                 self.writeln("}");
                 self.type_context.pop_scope();
@@ -19067,10 +19245,31 @@ impl Codegen {
             Statement::Return { value, .. } => {
                 let e = value.as_ref().expect("eligible return has a value");
                 let (code, ty) = self.emit_typed_expr(e)?;
-                let f = if ty == RustType::F64 {
+                let want = if self.native_fn_abi_i32 { RustType::I32 } else { RustType::F64 };
+                // The int-domain shortcut FIRST for an i32 return. A bitwise expression types as
+                // `F64` by design (`types.rs`), so taking the generic path below would emit
+                // `to_int32(<i32 work> as f64)` — the exact round trip this ABI exists to remove,
+                // reintroduced at the return. `emit_int32_operand` is the same helper the operator
+                // fixes use.
+                if want == RustType::I32 {
+                    if let Some(code) = self.emit_int32_operand(e)? {
+                        if let Some((global, _, _, _)) = self.native_lcg_hoist.as_ref() {
+                            let _ = global;
+                        }
+                        self.writeln(&format!("return {};", code));
+                        self.native_fn_body_returned = true;
+                        return Ok(());
+                    }
+                }
+                let (code, ty) = (code, ty);
+                let f = if ty == want {
                     code
                 } else if ty == RustType::Value {
-                    RustType::F64.from_value_expr(&code)
+                    want.from_value_expr(&code)
+                } else if want == RustType::I32 {
+                    // An f64-typed expression returned from an `i32` fn takes the same ToInt32 the
+                    // boxed path would have applied at the consumer.
+                    format!("tishlang_runtime::to_int32({})", code)
                 } else {
                     code
                 };

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -12046,6 +12046,21 @@ impl Codegen {
             }
         }
 
+        // Int-domain shortcut for an integer-typed local: `let nw: i32 = w | P_MARK` binds the
+        // integer form rather than `(int as f64) as i32`, so `nw` is i32-backed and every later use
+        // — including storing it into an `i32[]` — stays integral. Without this the annotation
+        // actively costs: measured 23,4xx ticks/1000 for `let v: i32 = j & 255; arr[j] = v`
+        // against 1,5xx for `arr[j] = j & 255` written directly.
+        if target_type.is_integer_scalar() {
+            if let Some(int_code) = self.emit_int32_for_int_consumer(expr)? {
+                return Ok(if *target_type == RustType::I32 {
+                    int_code
+                } else {
+                    format!("({}) as {}", int_code, target_type.to_rust_type_str())
+                });
+            }
+        }
+
         // #179 Stage C: `arr.length` on a native `Vec<_>` against an F64 target → native
         // `(arr.len() as f64)` (no boxing). Lets `let n = arr.length` stay native f64.
         if let (
@@ -13630,7 +13645,11 @@ impl Codegen {
         let in_bounds = self.index_in_bounds(index, name.as_ref());
         let idx_usize = self.emit_index_usize(index)?;
         let native_val = if *elem_type == RustType::I32 {
-            if let Expr::Binary {
+            // A bitwise RHS stays in the integer domain instead of `(int as f64) as i32`. Exact —
+            // see `emit_int32_for_int_consumer`.
+            if let Some(int_code) = self.emit_int32_for_int_consumer(value)? {
+                int_code
+            } else if let Expr::Binary {
                 left,
                 op: BinOp::Sub,
                 right,
@@ -13741,6 +13760,12 @@ impl Codegen {
             if let Some(uv) = self.usize_var_subst.get(idx_name.as_ref()) {
                 return Ok(uv.clone());
             }
+        }
+        // Same int-domain shortcut as the element store, with one correction: `(neg as f64) as
+        // usize` SATURATES to 0, while `(neg_i32) as usize` wraps to a huge value. `.max(0)` makes
+        // the two identical for every input, and costs a compare against a soft-float call.
+        if let Some(int_code) = self.emit_int32_for_int_consumer(index)? {
+            return Ok(format!("({}).max(0) as usize", int_code));
         }
         let (idx_code, idx_ty) = self.emit_typed_expr(index)?;
         if idx_ty == RustType::F64 || idx_ty == RustType::I32 {
@@ -13865,6 +13890,19 @@ impl Codegen {
         value: &Expr,
         target_ty: &RustType,
     ) -> Result<String, CompileError> {
+        // Same int-domain shortcut as the `Vec<i32>` element store: a bitwise RHS bound to an
+        // integer target keeps its integer form instead of `(int as f64) as i32`. Without this,
+        // `let v: i32 = w & 255` is f64-backed and every later use of `v` pays the conversion —
+        // measured at 23,4xx ticks/1000 against 1,5xx for the direct form.
+        if target_ty.is_integer_scalar() {
+            if let Some(int_code) = self.emit_int32_for_int_consumer(value)? {
+                return Ok(if *target_ty == RustType::I32 {
+                    int_code
+                } else {
+                    format!("({}) as {}", int_code, target_ty.to_rust_type_str())
+                });
+            }
+        }
         let (val_code, val_ty) = self.emit_typed_expr(value)?;
         if val_ty == *target_ty {
             return Ok(val_code);
@@ -23394,6 +23432,37 @@ impl Codegen {
     /// the round-trips. Crucially, only bitwise/shift nodes recurse — an `f64` `*`/`+`/`-` node is
     /// a *leaf* here, so e.g. `(h * 16777619) >>> 0` keeps its `f64` multiply (the 2^53 rule: the
     /// product exceeds 2^53 and must round in `f64` *before* `ToUint32`, exactly as V8 does).
+    /// Int-domain code for a bitwise/shift expression that is about to be consumed by something
+    /// wanting an INTEGER — a `Vec<i32>` element store, an array index.
+    ///
+    /// `result_type_of_binop` (types.rs) types every bitwise result `F64`, which is semantically
+    /// right (JS bitwise returns a Number) and a real win against boxing. But the int-domain chain
+    /// is then wrapped `(… ) as f64` and an integer consumer immediately casts it back, so on a
+    /// target with no FPU every `arr[i] = w | BIT` pays a soft-float round trip in each direction.
+    /// Measured on GBA (tish-gba `examples/bench-grid`): `arr[j] = 7` and `arr[j] = j` cost ~1.4
+    /// ticks per 1000, `arr[j] = j & 255` cost 23.2, and a bitwise INDEX cost 19.9 — ~15x, twice per
+    /// cell access for anything built on a packed word.
+    ///
+    /// SOUNDNESS. Only the SIGNED-result ops qualify. Their value is by construction inside i32, so
+    /// `(x as f64) as i32` is the identity and dropping both casts cannot change it. `>>>` is
+    /// excluded deliberately: it yields a uint32 Number that can exceed `i32::MAX`, and Rust's
+    /// float→int `as` SATURATES, so the f64 route and the int route genuinely disagree there.
+    fn emit_int32_for_int_consumer(
+        &mut self,
+        e: &Expr,
+    ) -> Result<Option<String>, CompileError> {
+        let Expr::Binary { op, .. } = e else {
+            return Ok(None);
+        };
+        if !matches!(
+            op,
+            BinOp::BitAnd | BinOp::BitOr | BinOp::BitXor | BinOp::Shl | BinOp::Shr
+        ) {
+            return Ok(None);
+        }
+        self.emit_int32_operand(e)
+    }
+
     fn emit_int32_operand(&mut self, e: &Expr) -> Result<Option<String>, CompileError> {
         if let Expr::Binary {
             left, op, right, ..

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -834,6 +834,7 @@ pub fn compile_with_native_modules_emit_exports(
             || m.crate_name == "tishlang_ios"
     });
     g.emit_program(&program)?;
+    g.emit_gba_key_table();
     Ok(g.output)
 }
 
@@ -1293,6 +1294,16 @@ pub(crate) struct Codegen {
     /// `mod __scheme_<name>_<j> { … }` blocks and their per-scheme registration. The handle a tish
     /// name binds to is its index AMONG same-scheme entries (= its slot in that scheme's arena).
     scheme_files: Vec<(String, String)>,
+    /// GBA only: the program-wide intern table for OBJECT-LITERAL KEYS, in first-seen order,
+    /// plus the name→index map. `RefCell` so `cached_object_key` can stay `&self`.
+    ///
+    /// ⚠️ This is a HEAP fix, not a tidiness one. Off-GBA every key site gets its own `OnceLock`,
+    /// which dedupes repeated evaluation of ONE site but never across sites — and a data table is
+    /// N sibling object literals, so N separate sites each allocate their own copy of every key
+    /// name. A real ROM measured 1,890 key sites over 474 distinct names: 1,416 duplicate `Arc<str>`
+    /// allocations that exist only to spell "name" and "id" again. One table, indexed, kills all of
+    /// them. See `cached_object_key`.
+    gba_keys: std::cell::RefCell<(Vec<String>, std::collections::HashMap<String, usize>)>,
     /// Program links `tish:macos` / `tish:ios` — skip HeadlessHost install.
     has_native_ui_host: bool,
     /// Program references browser global `document` — inject tish-canvas.
@@ -1408,6 +1419,7 @@ impl Codegen {
             emit_mode: crate::NativeEmitMode::DesktopBin,
             entry_exports: Vec::new(),
             scheme_files: Vec::new(),
+            gba_keys: std::cell::RefCell::new((Vec::new(), std::collections::HashMap::new())),
             has_native_ui_host: false,
             program_uses_document: false,
             cse_subst: Vec::new(),
@@ -3862,11 +3874,64 @@ impl Codegen {
     /// unchanged, and `PropMap` dedup + hidden-class shapes key by text, not pointer — so shapes,
     /// insertion order, and `Object.keys` are all unaffected. Same inline-`static` idiom as the
     /// per-site `PropIC` caches.
+    /// Append the GBA object-key intern table. Called ONCE, after the whole program is emitted,
+    /// because the key set is only complete then — Rust does not care that a `fn` is defined below
+    /// its callers.
+    ///
+    /// ⚠️ `static mut` + `&raw mut` rather than a `OnceLock`: the target is `#![no_std]` and the GBA
+    /// is single-core, so there is no thread to race with. Taking a raw pointer avoids the
+    /// `static_mut_refs` lint that a plain `&mut __TISH_KEYS` would trip.
+    fn emit_gba_key_table(&mut self) {
+        if self.emit_mode != crate::NativeEmitMode::Gba {
+            return;
+        }
+        let names: Vec<String> = self.gba_keys.borrow().0.clone();
+        if names.is_empty() {
+            return;
+        }
+        let list = names
+            .iter()
+            .map(|k| format!("{:?}", k))
+            .collect::<Vec<_>>()
+            .join(", ");
+        self.write(&format!(
+            "\n// Object-literal keys, interned program-wide: {} distinct names.\n\
+             static __TISH_KEY_NAMES: [&str; {}] = [{}];\n\
+             static mut __TISH_KEYS: Option<Vec<Arc<str>>> = None;\n\
+             fn __tish_key(i: usize) -> Arc<str> {{\n\
+             \x20   unsafe {{\n\
+             \x20       let t = &raw mut __TISH_KEYS;\n\
+             \x20       if (*t).is_none() {{\n\
+             \x20           *t = Some(__TISH_KEY_NAMES.iter().map(|s| Arc::from(*s)).collect());\n\
+             \x20       }}\n\
+             \x20       match (*t).as_ref() {{\n\
+             \x20           Some(v) => v[i].clone(),\n\
+             \x20           None => Arc::from(__TISH_KEY_NAMES[i]),\n\
+             \x20       }}\n\
+             \x20   }}\n\
+             }}\n",
+            names.len(),
+            names.len(),
+            list
+        ));
+    }
+
     fn cached_object_key(&self, k: &str) -> String {
         if self.emit_mode == crate::NativeEmitMode::Gba {
-            // No `OnceLock` on no_std GBA; emit a direct interned key (`Arc` = `Rc`).
-            // Object-literal keys in a hot loop are a later perf item on GBA.
-            return format!("Arc::from({:?})", k);
+            // No `OnceLock` on no_std GBA — and a per-site cache would be the wrong tool anyway.
+            // Intern PROGRAM-WIDE instead: every distinct key name is allocated once, at first use,
+            // and each site clones an `Arc` (= `Rc`) out of one table. See the `gba_keys` field.
+            let mut t = self.gba_keys.borrow_mut();
+            let idx = match t.1.get(k) {
+                Some(&i) => i,
+                None => {
+                    let i = t.0.len();
+                    t.0.push(k.to_string());
+                    t.1.insert(k.to_string(), i);
+                    i
+                }
+            };
+            return format!("__tish_key({})", idx);
         }
         format!(
             "{{ static K: ::std::sync::OnceLock<::std::sync::Arc<str>> = \

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -23463,6 +23463,29 @@ impl Codegen {
         self.emit_int32_operand(e)
     }
 
+    /// An operand that is provably an int32: either one `emit_int32_operand` lowers, or one the
+    /// type system already calls `i32`.
+    ///
+    /// The second case is what `emit_int32_operand` alone misses. An `: i32` local and a `Vec<i32>`
+    /// element read need no ToInt32 lowering — they ARE integers — but that function's leaf fold
+    /// only recognises `F64` leaves, so it declines them and falls back to a `to_int32` wrapper.
+    /// Every accumulator has one on its left-hand side.
+    fn int32_or_native_i32(&mut self, e: &Expr) -> Result<Option<String>, CompileError> {
+        if let Some(c) = self.emit_int32_operand(e)? {
+            // Reject the generic fold's own output: if it handed back a `to_int32(..)` wrapper it
+            // has not actually reached the integer domain, and using it would keep the round trip
+            // while claiming to have removed it.
+            if !c.contains("to_int32") {
+                return Ok(Some(c));
+            }
+        }
+        let (code, ty) = self.emit_typed_expr(e)?;
+        if ty == RustType::I32 {
+            return Ok(Some(code));
+        }
+        Ok(None)
+    }
+
     fn emit_int32_operand(&mut self, e: &Expr) -> Result<Option<String>, CompileError> {
         if let Expr::Binary {
             left, op, right, ..
@@ -23502,6 +23525,33 @@ impl Codegen {
                     _ => unreachable!(),
                 };
                 return Ok(Some(code));
+            }
+            // ARITHMETIC in a ToInt32 context: `acc + (w & MASK)`, `i - 1`.
+            //
+            // `+` is not itself a ToInt32 context, so this cannot be done in general — but THIS
+            // FUNCTION'S CONTRACT is that its result will be ToInt32'd by the caller, and for int32
+            // operands `to_int32(a + b) == a.wrapping_add(b)` exactly, since |a + b| < 2^32 is far
+            // inside f64's exact-integer range. So inside this context, and only here, the integer
+            // form is equivalent.
+            //
+            // It has to sit ABOVE the generic leaf fold below, which would otherwise swallow the
+            // whole expression and hand back `to_int32((a as f64) + (b as f64))` — technically a
+            // success, and exactly the round trip this exists to remove.
+            //
+            // Measured on GBA (tish-gba `examples/bench-grid`): `acc = acc + (arr[i] & 255)` ran at
+            // 44.4 ticks an iteration against 1.64 for the same read unmasked — a 27x penalty on
+            // every packed-word structure, since `w & FIELD` is how you read a field.
+            if matches!(op, BinOp::Add | BinOp::Sub) {
+                let li = self.int32_or_native_i32(left)?;
+                let ri = self.int32_or_native_i32(right)?;
+                if let (Some(li), Some(ri)) = (li, ri) {
+                    let f = if matches!(op, BinOp::Add) {
+                        "wrapping_add"
+                    } else {
+                        "wrapping_sub"
+                    };
+                    return Ok(Some(format!("({}).{}({})", li, f, ri)));
+                }
             }
         }
         // `Math.imul(a, b)` in an int32 context → the raw i32 `wrapping_mul` (no f64 excursion, no

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1210,6 +1210,17 @@ pub(crate) struct Codegen {
     /// `RustType::Value`. This is the rust-AOT analogue of the VM array-JIT bailing to the
     /// interpreter on a non-numeric element. See `collect_demoted_numeric_locals`.
     demoted_numeric_locals: std::collections::HashSet<String>,
+    /// Top-level fns whose EVERY return is provably numeric → the native type a call to one yields.
+    ///
+    /// Without it a call is opaque, so a local assigned from one demotes to a boxed `Value` and
+    /// every arithmetic consumer falls back to the generic `ops::add` plus two soft-float
+    /// conversions — most of the ~92 ticks a user-fn call costs on GBA
+    /// (`docs/issues/user-fn-call-cost-on-gba.md`).
+    ///
+    /// KEYED ON A PROOF, NOT THE ANNOTATION. `function f(): i32 { return "no" }` compiles and
+    /// returns the string — return types are erased — so trusting the declaration would reinterpret
+    /// a `String` as a number.
+    user_fn_ret: std::collections::HashMap<String, RustType>,
     /// Integer-range lattice (#174): names of `f64` locals the analysis proves always hold an
     /// integer within `[min, max]`, both strictly inside `(-2^53, 2^53)` so `as i64` is exact and
     /// `i64` arithmetic is bit-identical to the `f64` the interpreter/VM use. Lets the codegen
@@ -1394,6 +1405,7 @@ impl Codegen {
             aggregate_array_locals: std::collections::HashSet::new(),
             agg_cur_ret: None,
             demoted_numeric_locals: std::collections::HashSet::new(),
+            user_fn_ret: std::collections::HashMap::new(),
             int_range_locals: std::collections::HashMap::new(),
             diag_coord_indices: std::collections::HashSet::new(),
             int_i32_vec_locals: std::collections::HashSet::new(),
@@ -3208,6 +3220,9 @@ impl Codegen {
         // `VarDecl` lowers them as boxed `Value` rather than native `f64` (else the store coerces
         // and panics on a JS string-concat result like `s = s + arr[i]`). See
         // `collect_demoted_numeric_locals` / `demoted_numeric_locals`.
+        // BEFORE the demotion pass, which consults it: a local assigned from a provably-numeric
+        // call must stop demoting, which is half of where the win comes from.
+        self.user_fn_ret = self.collect_user_fn_rets(&program.statements);
         self.demoted_numeric_locals = self.collect_demoted_numeric_locals(&program.statements);
         self.int_valued_locals = Self::collect_int_valued_locals(&program.statements);
         self.int_range_locals = self.collect_int_range_locals(&program.statements);
@@ -12358,6 +12373,190 @@ impl Codegen {
     // demoted). The map is name-flat across the whole program (a name demoted in one function is
     // demoted in all) — still sound, and harmless to the perf gauntlet, where each kernel is its
     // own program with unique accumulator names.
+    /// Which top-level fns provably return a number, and as what native type. A fixpoint, because
+    /// one qualifying fn makes calls to it numeric inside another; growing only, so it terminates.
+    fn collect_user_fn_rets(
+        &self,
+        stmts: &[Statement],
+    ) -> std::collections::HashMap<String, RustType> {
+        let mut env: HashMap<String, RustType> = HashMap::new();
+        Self::collect_annotated_types(stmts, &self.type_aliases, &mut env);
+
+        let mut decls: Vec<(String, &Statement)> = Vec::new();
+        for s in stmts {
+            if let Statement::FunDecl { async_: false, name, body, .. } = s {
+                decls.push((name.to_string(), body.as_ref()));
+            }
+        }
+
+        // A REASSIGNED name is not this fn at the call site, and a SHADOWED one is not either —
+        // `emit_typed_expr` sees a bare callee name with no scope information. Excluding every name
+        // ever bound as a variable or parameter is blunt, but the alternative is a miscompile.
+        let mut reassigns: Vec<(String, &Expr)> = Vec::new();
+        Self::collect_reassignments_stmts(stmts, &mut reassigns);
+        let mut excluded: std::collections::HashSet<String> =
+            reassigns.iter().map(|(n, _)| n.clone()).collect();
+        Self::collect_bound_names(stmts, &mut excluded);
+
+        let mut out: std::collections::HashMap<String, RustType> = std::collections::HashMap::new();
+        loop {
+            let mut changed = false;
+            for (name, body) in &decls {
+                if out.contains_key(name) || excluded.contains(name) {
+                    continue;
+                }
+                let mut rets: Vec<&Expr> = Vec::new();
+                Self::collect_return_exprs(body, &mut rets);
+                if rets.is_empty() {
+                    continue; // no return yields `undefined`, which is not a number
+                }
+                let mut ty: Option<RustType> = None;
+                let mut ok = true;
+                for e in &rets {
+                    let Some(et) = self.proof_numeric_type(e, &env, &out) else {
+                        ok = false;
+                        break;
+                    };
+                    ty = match ty {
+                        None => Some(et),
+                        Some(prev) if prev == et => Some(et),
+                        Some(_) => Some(RustType::F64), // mixed I32/F64 settles on the wider
+                    };
+                }
+                if ok {
+                    if let Some(final_ty) = ty {
+                        out.insert(name.clone(), final_ty);
+                        changed = true;
+                    }
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+        out
+    }
+
+    /// Is `e` provably a NUMBER, and which native type describes it?
+    ///
+    /// Separate from `expr_native_type`, which answers the stricter "can this be LOWERED natively"
+    /// and is bound by `result_type_of_binop`, whose arms require BOTH operands `F64`. That rejects
+    /// `arr[i] & 255` on a `Vec<i32>` — element `I32`, literal `F64` — which on GBA is nearly every
+    /// masked read of a typed array. Widening that function would change lowering everywhere it is
+    /// consulted, to serve a question it is not being asked.
+    ///
+    /// Two unconditional JS facts carry it: `- * / % **` coerce with ToNumber, and `& | ^ << >>`
+    /// with ToInt32 — a number, and an int32 one, even if an operand was a string. `>>>` is excluded
+    /// (its uint32 can exceed `i32::MAX`) and `+` needs both sides proven, because it concatenates.
+    fn proof_numeric_type(
+        &self,
+        e: &Expr,
+        env: &HashMap<String, RustType>,
+        fn_rets: &std::collections::HashMap<String, RustType>,
+    ) -> Option<RustType> {
+        let numeric = |t: &RustType| matches!(t, RustType::F64 | RustType::I32);
+        match e {
+            Expr::Literal { value: Literal::Number(_), .. } => Some(RustType::F64),
+            Expr::Ident { name, .. } => env.get(name.as_ref()).filter(|t| numeric(t)).cloned(),
+            Expr::Index { object, optional: false, .. } => {
+                if let Expr::Ident { name, .. } = object.as_ref() {
+                    if let Some(RustType::Vec(inner)) = env.get(name.as_ref()) {
+                        if numeric(inner) {
+                            return Some((**inner).clone());
+                        }
+                    }
+                }
+                None
+            }
+            Expr::Unary { op, operand, .. } => match op {
+                UnaryOp::Neg | UnaryOp::Pos => {
+                    self.proof_numeric_type(operand, env, fn_rets).map(|_| RustType::F64)
+                }
+                _ => None,
+            },
+            Expr::Binary { left, op, right, .. } => match op {
+                BinOp::BitAnd | BinOp::BitOr | BinOp::BitXor | BinOp::Shl | BinOp::Shr => {
+                    Some(RustType::I32)
+                }
+                BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod | BinOp::Pow => Some(RustType::F64),
+                BinOp::Add => {
+                    let l = self.proof_numeric_type(left, env, fn_rets)?;
+                    let r = self.proof_numeric_type(right, env, fn_rets)?;
+                    Some(if l == RustType::I32 && r == RustType::I32 {
+                        RustType::I32
+                    } else {
+                        RustType::F64
+                    })
+                }
+                _ => None,
+            },
+            Expr::Conditional { then_branch, else_branch, .. } => {
+                let a = self.proof_numeric_type(then_branch, env, fn_rets)?;
+                let b = self.proof_numeric_type(else_branch, env, fn_rets)?;
+                Some(if a == b { a } else { RustType::F64 })
+            }
+            Expr::Call { callee, .. } => match callee.as_ref() {
+                Expr::Ident { name, .. } => fn_rets.get(name.as_ref()).cloned(),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Every name bound as a variable or a function parameter, anywhere, at any depth.
+    fn collect_bound_names(stmts: &[Statement], out: &mut std::collections::HashSet<String>) {
+        for s in stmts {
+            match s {
+                Statement::VarDecl { name, .. } => {
+                    out.insert(name.to_string());
+                }
+                Statement::FunDecl { params, body, .. } => {
+                    for p in params {
+                        if let FunParam::Simple(tp) = p {
+                            out.insert(tp.name.to_string());
+                        }
+                    }
+                    Self::collect_bound_names(core::slice::from_ref(body.as_ref()), out);
+                }
+                Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
+                    Self::collect_bound_names(statements, out)
+                }
+                Statement::If { then_branch, else_branch, .. } => {
+                    Self::collect_bound_names(core::slice::from_ref(then_branch.as_ref()), out);
+                    if let Some(e) = else_branch {
+                        Self::collect_bound_names(core::slice::from_ref(e.as_ref()), out);
+                    }
+                }
+                Statement::While { body, .. } | Statement::For { body, .. } => {
+                    Self::collect_bound_names(core::slice::from_ref(body.as_ref()), out)
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Every `return <expr>` in a body, through blocks, ifs and loops. NOT into a nested function.
+    fn collect_return_exprs<'a>(s: &'a Statement, out: &mut Vec<&'a Expr>) {
+        match s {
+            Statement::Return { value: Some(e), .. } => out.push(e),
+            Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
+                for x in statements {
+                    Self::collect_return_exprs(x, out);
+                }
+            }
+            Statement::If { then_branch, else_branch, .. } => {
+                Self::collect_return_exprs(then_branch, out);
+                if let Some(e) = else_branch {
+                    Self::collect_return_exprs(e, out);
+                }
+            }
+            Statement::While { body, .. } | Statement::For { body, .. } => {
+                Self::collect_return_exprs(body, out)
+            }
+            _ => {}
+        }
+    }
+
     fn collect_demoted_numeric_locals(&self, stmts: &[Statement]) -> HashSet<String> {
         // 1. Flat env: every annotated local/param name → its native `RustType`.
         let mut env: HashMap<String, RustType> = HashMap::new();
@@ -15801,6 +16000,19 @@ impl Codegen {
                 let lt = self.expr_native_type(left, env);
                 let rt = self.expr_native_type(right, env);
                 RustType::result_type_of_binop(*op, &lt, &rt).unwrap_or(RustType::Value)
+            }
+            // A call to a fn whose every return is PROVEN numeric. Without this a call is opaque and
+            // any local assigned from one demotes to a boxed `Value`. `env` shadowing wins: a local
+            // of that name is not the fn.
+            Expr::Call { callee, .. } => {
+                if let Expr::Ident { name, .. } = callee.as_ref() {
+                    if !env.contains_key(name.as_ref()) {
+                        if let Some(ft) = self.user_fn_ret.get(name.as_ref()) {
+                            return ft.clone();
+                        }
+                    }
+                }
+                RustType::Value
             }
             // `vec[i]` where `vec` is a `number[]` (Vec<f64>) → the element type. A `Vec<f64>`
             // can only hold numbers, so this never feeds a string into the accumulator.
@@ -24264,6 +24476,33 @@ impl Codegen {
                                 };
                                 return Ok((code, ty));
                             }
+                        }
+                    }
+                }
+                // A user fn whose every return is PROVEN numeric (`collect_user_fn_rets`). The call
+                // stays boxed — this is not a calling convention — but its RESULT stops being
+                // opaque, so the surrounding arithmetic stays integral instead of dropping to the
+                // generic `ops::add` and its two soft-float conversions.
+                //
+                // The `_ =>` arm is unreachable by construction: membership required every return
+                // to be numeric. Written out rather than `unreachable!()` so a proof bug surfaces as
+                // the same diagnostic every other coercion in this file produces.
+                if !self.user_fn_ret.is_empty() {
+                    if let Expr::Ident { name, .. } = callee.as_ref() {
+                        if let Some(ty) = self.user_fn_ret.get(name.as_ref()).cloned() {
+                            let boxed = self.emit_expr(expr)?;
+                            let conv = if ty == RustType::I32 {
+                                "tishlang_runtime::to_int32(*n)"
+                            } else {
+                                "*n"
+                            };
+                            return Ok((
+                                format!(
+                                    "match &{} {{ Value::Number(n) => {}, _ => panic!(\"expected number\") }}",
+                                    boxed, conv
+                                ),
+                                ty,
+                            ));
                         }
                     }
                 }

--- a/crates/tish_compile/src/types.rs
+++ b/crates/tish_compile/src/types.rs
@@ -30,6 +30,12 @@ fn gba_numerics() -> bool {
     GBA_NUMERICS.with(|c| c.get())
 }
 
+/// Public view of the same switch, for passes that must behave differently only where the extended
+/// numeric vocabulary exists — see the native-fn bitwise widening in `codegen.rs`.
+pub fn gba_numerics_enabled() -> bool {
+    gba_numerics()
+}
+
 /// Concrete Rust type representation for code generation.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RustType {

--- a/crates/tish_compile/tests/perf_codegen_i32_native_abi.rs
+++ b/crates/tish_compile/tests/perf_codegen_i32_native_abi.rs
@@ -1,0 +1,113 @@
+//! M5 native fns, with an `i32` calling convention.
+//!
+//! `collect_native_fns` gated parameters and returns on `RustType::F64`, so `: number` qualified for
+//! a native free `fn` and `: i32` did not — and `: i32` is the annotation a device with no FPU
+//! wants. Every argument and every return of such a call was therefore an i32→f64→i32 round trip,
+//! which on ARM7TDMI is a soft-float call apiece.
+//!
+//! The shape is ALL-OR-NOTHING: every parameter and the return annotated `: i32`. Mixing is what
+//! makes it unsound — an `: i32` parameter reached through the boxed path is ToInt32-coerced on
+//! entry, and promoted to a native `f64` parameter it would not be, so 3.7 would arrive as 3 one
+//! way and 3.7 the other.
+
+use std::path::PathBuf;
+
+use tishlang_compile::{compile_project_full_emit, NativeEmitMode};
+
+/// Compile for GBA — `: i32` is only a native scalar under the GBA numeric vocabulary
+/// (`types.rs`: `"i32" if gba_numerics()`), so on a desktop target this ABI cannot exist and the
+/// assertions below would be vacuous.
+fn compile_src(stem: &str, src: &str) -> String {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/perf_codegen_i32_abi");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{stem}.tish"));
+    std::fs::write(&path, src).unwrap();
+    let path = path.canonicalize().unwrap();
+    let (rust, _, _, _) =
+        compile_project_full_emit(&path, path.parent(), &[], true, NativeEmitMode::Gba, None)
+            .unwrap();
+    rust
+}
+
+const ALL_I32: &str = r#"
+function mix(a: i32, b: i32): i32 { return ((a * 3) ^ (b << 2)) & 65535 }
+let acc: i32 = 0
+let j: i32 = 0
+while (j < 10) { acc = (acc + mix(j, acc)) & 65535; j = j + 1 }
+console.log(acc)
+"#;
+
+#[test]
+fn an_all_i32_signature_gets_an_i32_native_fn() {
+    let rust = compile_src("all_i32", ALL_I32);
+    assert!(
+        rust.contains("fn mix_native(mut a: i32, mut b: i32) -> i32"),
+        "expected an i32-signature native fn, got:\n{}",
+        rust.lines().filter(|l| l.contains("mix_native")).collect::<Vec<_>>().join("\n")
+    );
+    // And the call must reach it directly rather than through `value_call`.
+    assert!(rust.contains("mix_native("), "the call site should target the native fn");
+}
+
+const MIXED: &str = r#"
+function half(a: i32, b: number): i32 { return (a + b) | 0 }
+console.log(half(7, 2.5))
+"#;
+
+#[test]
+fn a_mixed_signature_does_not_get_the_i32_abi() {
+    let rust = compile_src("mixed", MIXED);
+    assert!(
+        !rust.contains("fn half_native(mut a: i32"),
+        "a mixed i32/number signature must not take the i32 ABI — an `: i32` param is \
+         ToInt32-coerced on entry and an f64 native param is not"
+    );
+}
+
+const LIAR: &str = r#"
+function liar(x: i32): i32 {
+  if (x > 0) { return "not a number" }
+  return 7
+}
+console.log(liar(1))
+"#;
+
+#[test]
+fn the_annotation_alone_does_not_qualify_a_fn() {
+    // Return annotations are erased and unchecked: this program prints the STRING today. The i32
+    // ABI must not be handed out on the strength of `: i32`, only on the fixpoint's proof that
+    // every return is numeric — otherwise this would unbox a string as a number.
+    let rust = compile_src("liar", LIAR);
+    assert!(
+        !rust.contains("fn liar_native"),
+        "a fn with a non-numeric return path must stay boxed regardless of its annotation"
+    );
+}
+
+const READS_MODULE_STATE: &str = r#"
+let ARR: i32[] = []
+let k: i32 = 0
+while (k < 8) { ARR.push(k); k = k + 1 }
+function pure(a: i32, b: i32): i32 { return (a ^ b) & 255 }
+function reads(i: i32): i32 { return ARR[i] & 255 }
+let x: i32 = pure(1, 2) + reads(3)
+console.log(x)
+"#;
+
+#[test]
+fn a_fn_reading_module_state_stays_boxed() {
+    // A native fn is emitted at TOP LEVEL, where a module-scope `let` — a local of `run()`, closed
+    // over by the boxed closures — does not exist. `native_safe_expr`'s index arm accepted any
+    // identifier as the indexed object, so this compiled to a `reads_native` whose body named
+    // `ARR` and rustc rejected the generated program with E0425. The sibling `pure` must still be
+    // promoted: the check has to reject the out-of-scope read, not indexing as such.
+    let rust = compile_src("reads_module_state", READS_MODULE_STATE);
+    assert!(
+        !rust.contains("fn reads_native"),
+        "a fn indexing a module-scope binding cannot become a top-level free fn"
+    );
+    assert!(
+        rust.contains("fn pure_native(mut a: i32, mut b: i32) -> i32"),
+        "its parameter-only sibling must still get the native i32 fn"
+    );
+}

--- a/crates/tish_native/src/build.rs
+++ b/crates/tish_native/src/build.rs
@@ -1,7 +1,7 @@
 //! Build native binary via cargo (interim path until Cranelift backend is ready).
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use tishlang_compile::ResolvedNativeModule;
 
@@ -627,15 +627,34 @@ runner = ["mgba-qt", "-C", "logToStdout=1", "-C", "logLevel.gba.debug=127"]
     // with `-Tgba.ld` — cargo *joins* rustflags arrays across config files, so a
     // config-file approach would pass `-Tgba.ld` twice ("region already defined").
     // build-std still comes from the generated `[unstable]` config (not rustflags).
-    let status = Command::new("cargo")
+    //
+    // TISH_GBA_TARGET_DIR (opt-in, explicit — deliberately NOT the ambient
+    // CARGO_TARGET_DIR, which the desktop path scrubs for good reason): share ONE
+    // cargo target dir across every example's ROM build. Each example otherwise
+    // carries a full private dependency tree — measured at ~45 GB across the
+    // tish-gba fleet, and it filled the disk mid-build once. An inherited
+    // CARGO_TARGET_DIR meanwhile made cargo write where the ELF lookup below
+    // never looked ("GBA ELF not found" on a SUCCESSFUL compile), so that env is
+    // scrubbed here and only the explicit opt-in steers both paths together.
+    let shared_target = std::env::var_os("TISH_GBA_TARGET_DIR").map(PathBuf::from);
+    let target_root = shared_target
+        .clone()
+        .unwrap_or_else(|| build_dir.join("target"));
+    let mut cargo = Command::new("cargo");
+    cargo
         .arg("build")
         .arg("--release")
         .current_dir(&build_dir)
+        .env_remove("CARGO_TARGET_DIR")
         .env(
             "RUSTFLAGS",
             "-Clink-arg=-Tgba.ld -Ctarget-cpu=arm7tdmi -Cforce-frame-pointers=yes",
         )
-        .env("CARGO_TERM_COLOR", "always")
+        .env("CARGO_TERM_COLOR", "always");
+    if let Some(dir) = &shared_target {
+        cargo.env("CARGO_TARGET_DIR", dir);
+    }
+    let status = cargo
         .status()
         .map_err(|e| format!("Failed to run cargo for GBA build: {}", e))?;
     if !status.success() {
@@ -645,9 +664,8 @@ runner = ["mgba-qt", "-C", "logToStdout=1", "-C", "logLevel.gba.debug=127"]
         ));
     }
 
-    // ELF → .gba via agb-gbafix.
-    let elf = build_dir
-        .join("target")
+    // ELF → .gba via agb-gbafix. Resolved from the SAME root the build wrote to.
+    let elf = target_root
         .join("thumbv4t-none-eabi")
         .join("release")
         .join(&cargo_name);

--- a/crates/tish_runtime_gba/src/gba.rs
+++ b/crates/tish_runtime_gba/src/gba.rs
@@ -101,21 +101,41 @@ type BgAsset = (
     &'static agb::display::tile_data::TileData,
 );
 
-static ASSET_BGS: SingleCore<RefCell<Vec<BgAsset>>> = SingleCore::new(RefCell::new(Vec::new()));
+/// ⚠️ A FIXED TABLE, not a `Vec`, because every entry is `&'static` cartridge data and the registry
+/// never needed to own one.
+///
+/// As a `Vec` it did: registering N backgrounds ran N pushes with log2(N) reallocs, all during
+/// module init before the program body, and the freed buffers left the heap too fragmented for the
+/// one big contiguous block a GBA UI canvas wants. A game with a handful of backgrounds booted; a
+/// game with 162 died in the allocator with plenty of total heap free.
+///
+/// This costs `MAX_BGS * size_of::<Option<BgAsset>>()` of STATIC memory and allocates nothing.
+/// ⚠️ Not a `Vec` with `reserve` — that charges every small game for the largest one.
+const MAX_BGS: usize = 256;
+static ASSET_BGS: SingleCore<RefCell<[Option<BgAsset>; MAX_BGS]>> =
+    SingleCore::new(RefCell::new([None; MAX_BGS]));
+static ASSET_BGS_N: SingleCore<RefCell<usize>> = SingleCore::new(RefCell::new(0));
 
 /// Register a background (palettes + tile data), returning its i32 handle.
 pub fn __asset_register_bg(bg: BgAsset) -> i32 {
-    ASSET_BGS.with(|c| {
-        let mut v = c.borrow_mut();
-        let idx = v.len() as i32;
-        v.push(bg);
+    ASSET_BGS_N.with(|n| {
+        let mut n = n.borrow_mut();
+        if *n >= MAX_BGS {
+            return -1;
+        }
+        let idx = *n as i32;
+        ASSET_BGS.with(|c| c.borrow_mut()[*n] = Some(bg));
+        *n += 1;
         idx
     })
 }
 
 /// Look up a registered background by handle. `None` if out of range.
 pub fn asset_bg(handle: i32) -> Option<BgAsset> {
-    ASSET_BGS.with(|c| c.borrow().get(handle as usize).copied())
+    if handle < 0 || handle as usize >= MAX_BGS {
+        return None;
+    }
+    ASSET_BGS.with(|c| c.borrow()[handle as usize])
 }
 
 /// Registered fonts (`font<N>:` imports) — a compile-time-baked `Font`. All `font<N>:` schemes share

--- a/crates/tish_runtime_gba/src/lib.rs
+++ b/crates/tish_runtime_gba/src/lib.rs
@@ -283,6 +283,35 @@ pub fn str_index(s: &str, idx: &Value) -> Value {
     }
 }
 
+/// `&str` charCodeAt — the code unit at `idx`, NaN when out of range. Mirrors
+/// `tish_runtime::str_char_code_at`, and missing here for the same reason `str_index` was: codegen
+/// emits it whenever the receiver is statically a `&str`, so `"abc".charCodeAt(i)` was a hard E0425
+/// on the GBA target only while compiling everywhere else. Found by a ROM that hashes its own trace.
+#[inline]
+pub fn str_char_code_at(s: &str, idx: &Value) -> Value {
+    let i = match idx {
+        Value::Number(n) if *n >= 0.0 && n.fract() == 0.0 => *n as usize,
+        _ => return Value::Number(f64::NAN),
+    };
+    match s.chars().nth(i) {
+        Some(c) => Value::Number(c as u32 as f64),
+        None => Value::Number(f64::NAN),
+    }
+}
+
+/// `&str` charAt — the 1-character string at `idx`, `""` out of range. Same reason as above.
+#[inline]
+pub fn str_char_at(s: &str, idx: &Value) -> Value {
+    let i = match idx {
+        Value::Number(n) if *n >= 0.0 && n.fract() == 0.0 => *n as usize,
+        _ => return Value::String("".into()),
+    };
+    match s.chars().nth(i) {
+        Some(c) => Value::String(c.to_string().into()),
+        None => Value::String("".into()),
+    }
+}
+
 pub fn delete_property(obj: &Value, key: &Value) -> Value {
     match obj {
         Value::Object(m) => {

--- a/docs/issues/int-domain-consumer-boundary.md
+++ b/docs/issues/int-domain-consumer-boundary.md
@@ -1,0 +1,111 @@
+# A bitwise value consumed by an integer costs 27x on GBA
+
+**Status:** open. Three consumer sites fixed in `b2c9f9ac2`; the accumulate site remains.
+**Found by:** `tish-gba/examples/bench-grid`, porting the Magical Drop rules from Rust to tish.
+
+## The measurement
+
+On device, GBA, one frame = 4,389 Timer2 ticks. 512 iterations, ticks per iteration:
+
+| expression | ticks/iter |
+|---|---|
+| `acc = acc + arr[i]` | **1.64** |
+| `acc = acc + (arr[i] & 255)` | **44.4** |
+
+**27x, for a mask.** `arr` is a module-level `i32[]` in both cases; only the `& 255` differs.
+
+The same bench isolates the two other candidate explanations and rules both out:
+
+* **not the RefCell borrow.** `arr` is closure-captured in both rows, so both pay
+  `(*arr.borrow()).get(i).copied()`. The unmasked row is 1.64 ticks — the borrow is cheap.
+* **not element boxing.** The generated Rust keeps `Vec<i32>` and emits `.copied().unwrap_or(0)`.
+
+## The mechanism
+
+`types.rs:301-323` `result_type_of_binop` types every bitwise/shift result `RustType::F64`:
+
+```rust
+// Bitwise / shift ops: JS coerces both sides to int32, computes, and
+// returns a Number — so the native result is still F64.
+BinOp::BitAnd | ... | BinOp::UShr => Some(RustType::F64),
+```
+
+That is correct about JS and it is a real win against boxing. The unmeasured consequence is at the
+**consumer**: an f64 meeting something that wants an integer converts back, and on ARM7TDMI both
+directions are soft-float calls. Emitted for the masked row:
+
+```rust
+ka = to_int32(((ka as f64) + ((( /* i32 block */ ) & 255i32) as f64))) as i32
+```
+
+The `& 255i32` is already computed in the integer domain by the fusion at `codegen.rs:23744-23762`.
+It is then widened to f64, added in f64, and narrowed by `to_int32`. The integer result was in a
+register and got a round trip anyway.
+
+By contrast the unmasked row, whose operands are both `I32`, lowers through the existing integer
+binop path at `codegen.rs:23640-23712` to `nb.wrapping_add(...)` — no excursion.
+
+## What was fixed
+
+`b2c9f9ac2` hands the int-domain form straight to three consumers rather than routing it through
+f64: the `Vec<i32>` element store, the array index, and an integer-typed local binding.
+
+```
+module i32[] write pass          22765 -> 1009   22.6x
+arr[j] = j & 255                 23162 -> 1652   14.0x
+let v: i32 = j & 255; arr[j] = v 23435 -> 1558   15.0x
+arr[((j>>5)<<5) | (j&31)]        20318 -> 1494   13.6x
+63-cell flood fill                3826 -> 1468    2.6x
+```
+
+Soundness: only the SIGNED ops qualify (`& | ^ << >>`) — their value is by construction inside i32,
+so `(x as f64) as i32` is the identity. `>>>` is excluded: its uint32 can exceed `i32::MAX` and
+Rust's float→int `as` saturates, so the two routes genuinely disagree. The index form carries
+`.max(0)` to reproduce the saturating f64→usize cast exactly.
+
+## What is still open: the ACCUMULATE
+
+`acc = acc + (w & MASK)` — the shape above, and the commonest expression in any packed-word data
+structure, since `w & FIELD` is how you read a field.
+
+**Do not fix it by typing bitwise results `I32`.** That is the obvious one-line change and it is a
+measured **5x pessimisation**: the int-domain fusion at `codegen.rs:23759` is *gated on*
+`result_ty == RustType::F64`, so retyping the result disables the fusion that makes bitwise chains
+fast in the first place. The F64 typing and the fusion are a matched pair. Measured with that
+change in: flood fill 1,470 → 7,531, K1 22,742 → 25,582.
+
+The fix belongs at the consumer, like the three above. Sketch that was attempted:
+
+* at the `RustType::I32` arm of `Expr::Assign` (`codegen.rs:4034`), when the RHS is `Add`/`Sub` and
+  both operands can be produced in the integer domain, emit `wrapping_add`/`wrapping_sub`.
+* sound because the target is `i32`, so the result is ToInt32'd regardless, and for int32 operands
+  `to_int32(a + b) == a.wrapping_add(b)` exactly — `|a + b| < 2^32` is far inside f64's
+  exact-integer range. The truncation the assignment already performs is what licenses it.
+
+**Why it did not land:** producing the operands needs a helper broader than `emit_int32_operand`,
+which declines two shapes it is right to decline — an expression the type system already calls
+`i32` (no ToInt32 needed), and a bitwise node with one unmodelled leaf (an array element read,
+which discards the whole expression). A version accepting both was written, and the arm was reached
+for `mb = mb + readCell(mj)` (`li=true ri=false`, correctly declining a call) but never for
+`ka = ka + (arr[i] & 255)`, which returns earlier in the arm for a reason not yet pinned down.
+Reproducing that needs an `eprintln` at each early return in the arm; it is a half-day, not a
+mystery.
+
+## Why it matters
+
+This is the single measured constraint on writing performance-sensitive tish. `tish-gba`'s
+`packages/grid.tish` is a packed-cell-word grid — cell byte, engine planes and a cached match mask
+in one `i32` — and *every* read of it is `w & FIELD` or `(w >> SHIFT) & FIELD`. The whole design
+pays this wherever a masked value is accumulated rather than stored.
+
+## Reproducing
+
+```bash
+cd tish-gba/examples/bench-grid && npm run build
+GBA_SHOT_LOG=1 ../../scripts/screenshot.sh bench-grid.gba /tmp/bg.png 450
+```
+
+Passes K1 / K1b / K2 are the three rows above plus a user-function-call cost. Note the bench's own
+trap, recorded in its README: adding a function that touches a module array deoptimises **every**
+access to that array, including from top-level code that never calls the function — pass C went 487
+to 1,586 ticks/1000 that way. The callee reads a private array so the rest stays comparable.

--- a/docs/issues/int-domain-consumer-boundary.md
+++ b/docs/issues/int-domain-consumer-boundary.md
@@ -1,6 +1,8 @@
 # A bitwise value consumed by an integer costs 27x on GBA
 
-**Status:** open. Three consumer sites fixed in `b2c9f9ac2`; the accumulate site remains.
+**Status:** CLOSED. Five consumer sites, three commits: `49ac5739a` (element store, array index,
+integer-typed local binding), `b32827ca9` (the masked accumulate), `4f0798f98` (the element READ
+index). Every one was found by timing production code in `tish-gba`, never by predicting it.
 **Found by:** `tish-gba/examples/bench-grid`, porting the Magical Drop rules from Rust to tish.
 
 ## The measurement
@@ -101,6 +103,57 @@ The obvious one-line root fix is a measured **5x pessimisation**. The int-domain
 `codegen.rs:23759` is *gated on* `result_ty == RustType::F64`, so retyping the result disables the
 fusion that makes bitwise chains fast in the first place. The F64 typing and the fusion are a matched
 pair. Measured with that change in: flood fill 1,470 -> 7,531, K1 22,742 -> 25,582.
+
+## The FIFTH site, found last and most cheaply missed: the READ index
+
+```
+fn copy, BITWISE index   22541 -> 2371 /1000   9.5x
+fn copy, flat index       2273 -> 2273         control, unmoved
+```
+
+`arr[a | b]` lowered its element STORE index integrally — that was fixed first — and its element
+READ index as `((a|b) as f64) as usize`, two soft-float calls per read. So the packed-grid access
+`P[dc|r] = P[sc|r] & keep` paid on exactly half of itself.
+
+The cause is mundane and worth recording as a shape to look for rather than a bug to remember: the
+read site held a **hand-inlined copy of `emit_index_usize`**, byte-identical to it down to the panic
+message, written before the int-domain shortcut existed. Teaching the helper therefore fixed the
+store and left the read behind, and nothing pointed at the divergence because the two spellings had
+been identical for as long as anyone had looked. The fix deletes the copy and calls the helper.
+
+The shortcut is gated where it already was: `emit_int32_for_int_consumer` requires the ROOT operator
+to be bitwise, so `arr[i + j]` still lowers through f64 and the `Add`/`Sub` arm above cannot wrap a
+huge index into a small valid one. Inside `arr[(i + j) | 0]` it does apply, and correctly — that
+spelling IS ToInt32, which is wrapping by definition.
+
+Measured in `tish-gba/examples/grid-demo`, whose AI copies a 63-cell board per candidate:
+
+```
+board copy      2103 -> 480 ticks   4.4x   (33 -> 7.6 per cell)
+AI frame avg    4463 -> 2336
+AI frame peak   5672 -> 3176        was OVER a 4389-tick frame, now inside one
+```
+
+and in `examples/drop-tish`, the full ported rules, with no change to that repo at all:
+
+```
+rules frame avg  1947 -> 1392
+rules frame peak 5189 -> 4037       likewise now inside ONE frame
+```
+
+### How it hid, which is the part worth generalising
+
+`bench-grid` reported nothing, because every pass it had indexed from **top level with a plain loop
+counter** — which the compiler substitutes for a `usize` binding, so no pass ever exercised a
+bitwise index inside a function. The bench measured the shape someone wrote down, not the shape the
+code ships.
+
+It surfaced only from a phase timer inside the game, where a 63-cell copy came back at 57% of the
+whole evaluation. It had been dismissed by reading the code twice; its own comment said it was
+bounded to the board's real height, which was true and beside the point.
+
+`bench-grid` now has pass **M** for it, asserted rather than merely printed, and the assertion was
+checked by reverting the fix: **ratio 1.04 with it, 9.9 without, checksum identical either way.**
 
 ## Scope of the win
 

--- a/docs/issues/int-domain-consumer-boundary.md
+++ b/docs/issues/int-domain-consumer-boundary.md
@@ -63,33 +63,50 @@ so `(x as f64) as i32` is the identity. `>>>` is excluded: its uint32 can exceed
 Rust's float→int `as` saturates, so the two routes genuinely disagree. The index form carries
 `.max(0)` to reproduce the saturating f64→usize cast exactly.
 
-## What is still open: the ACCUMULATE
+## The accumulate — FIXED, and my first diagnosis of it was wrong
 
-`acc = acc + (w & MASK)` — the shape above, and the commonest expression in any packed-word data
-structure, since `w & FIELD` is how you read a field.
+```
+acc = acc + (arr[i] & 255)     22742 -> 813   28x
+acc = acc + arr[i]  (control)    838 -> 838
+```
 
-**Do not fix it by typing bitwise results `I32`.** That is the obvious one-line change and it is a
-measured **5x pessimisation**: the int-domain fusion at `codegen.rs:23759` is *gated on*
-`result_ty == RustType::F64`, so retyping the result disables the fusion that makes bitwise chains
-fast in the first place. The F64 typing and the fusion are a matched pair. Measured with that
-change in: flood fill 1,470 → 7,531, K1 22,742 → 25,582.
+A masked read now costs the same as an unmasked one.
 
-The fix belongs at the consumer, like the three above. Sketch that was attempted:
+**The fix did NOT belong at the consumer**, which is what this document originally said and what
+three attempts assumed. It belongs inside `emit_int32_operand`, which has an `Add`/`Sub` arm now,
+placed ABOVE its generic leaf fold.
 
-* at the `RustType::I32` arm of `Expr::Assign` (`codegen.rs:4034`), when the RHS is `Add`/`Sub` and
-  both operands can be produced in the integer domain, emit `wrapping_add`/`wrapping_sub`.
-* sound because the target is `i32`, so the result is ToInt32'd regardless, and for int32 operands
-  `to_int32(a + b) == a.wrapping_add(b)` exactly — `|a + b| < 2^32` is far inside f64's
-  exact-integer range. The truncation the assignment already performs is what licenses it.
+That fold was the whole problem, and it is worth naming because it defeats every consumer-side
+patch silently: for `acc + (x & 255)` it falls through to `emit_typed_expr`, sees an `F64`, and
+returns `Some("to_int32((acc as f64) + (... as f64))")`. It reports SUCCESS while emitting exactly
+the round trip this function exists to remove. So the assign site's first branch took it, every
+later branch was unreachable, and adding code to those branches changed nothing — which is precisely
+what happened three times before an `eprintln` at the arm's entry showed `int32op=true` on the case
+that was demonstrably slow.
 
-**Why it did not land:** producing the operands needs a helper broader than `emit_int32_operand`,
-which declines two shapes it is right to decline — an expression the type system already calls
-`i32` (no ToInt32 needed), and a bitwise node with one unmodelled leaf (an array element read,
-which discards the whole expression). A version accepting both was written, and the arm was reached
-for `mb = mb + readCell(mj)` (`li=true ri=false`, correctly declining a call) but never for
-`ka = ka + (arr[i] & 255)`, which returns earlier in the arm for a reason not yet pinned down.
-Reproducing that needs an `eprintln` at each early return in the arm; it is a half-day, not a
-mystery.
+Soundness is licensed by this function's own contract: its result is ToInt32'd by the caller, and
+for int32 operands `to_int32(a + b) == a.wrapping_add(b)` exactly, since `|a + b| < 2^32` is far
+inside f64's exact-integer range. `+` is still NOT a ToInt32 context in general and is untouched
+outside this one.
+
+The operand helper `int32_or_native_i32` accepts what `emit_int32_operand` lowers, plus what the
+type system already calls `i32` — an `: i32` local, a `Vec<i32>` element read. Those need no ToInt32
+lowering because they ARE integers, and the leaf fold only recognises `F64` leaves, so it declines
+them. Every accumulator has one on its left-hand side. The helper also rejects a returned string
+containing `to_int32`, so the fold's fake success cannot be mistaken for the real thing.
+
+### Still not to be attempted: typing bitwise results `I32`
+
+The obvious one-line root fix is a measured **5x pessimisation**. The int-domain fusion at
+`codegen.rs:23759` is *gated on* `result_ty == RustType::F64`, so retyping the result disables the
+fusion that makes bitwise chains fast in the first place. The F64 typing and the fusion are a matched
+pair. Measured with that change in: flood fill 1,470 -> 7,531, K1 22,742 -> 25,582.
+
+## Scope of the win
+
+It is large where code ACCUMULATES a masked value and nil where it stores or compares one — those
+were already covered above. `tish-gba`'s `packages/drop_game.tish` was unmoved (5,216 -> 5,189 peak)
+because its hot path stores and compares. `bench-grid`'s K1 is where the shape lives.
 
 ## Why it matters
 

--- a/docs/issues/user-fn-call-cost-on-gba.md
+++ b/docs/issues/user-fn-call-cost-on-gba.md
@@ -1,6 +1,6 @@
 # A call to a user tish function costs ~92 ticks on GBA
 
-**Status:** open.
+**Status:** item 1 FIXED in `9993d6145` (93.4 -> 72.2 ticks a call). Item 2 open.
 **Found by:** `tish-gba`, porting a game's rules core from Rust to tish.
 **Related:** `int-domain-consumer-boundary.md` — same shape of finding (type information present
 and discarded), same bench ROM.
@@ -94,41 +94,31 @@ Reusing it makes the qualification "annotated native return AND every return pat
 AND the name never reassigned" — the same standard M5 already holds itself to, and the reason this
 is a contained change rather than a trivial one.
 
-### An implementation attempt, and where it stopped
+### FIXED in `9993d6145`
 
-Tried and BACKED OUT, recorded so the next attempt starts where this one stopped rather than
-rediscovering three days of it.
+    K2 · 512 calls to `function readCell(i: i32): i32`   48,651 -> 37,814 ticks
+    per call                                                 93.4 -> 72.2
+    a ported CPU search, per step                          28,125 -> 25,464
 
-**The proof works.** A `user_fn_ret: HashMap<String, RustType>` built by fixpoint, keyed on every
-`return` being provably numeric, qualified the right functions — `{"readCell": I32, "copyBitwise":
-I32, "copyFlat": I32}` on `bench-grid`. Soundness held: the `liar` program above still printed its
-string on both the interpreter and codegen, and the bench checksum was byte-identical.
+The call is still a boxed `value_call` — this was never a calling convention. Only its RESULT stops
+being opaque, which is enough to keep the surrounding arithmetic integral instead of dropping to
+`ops::add` and two soft-float conversions. The remaining ~72 ticks are the dispatch itself, which is
+item 2.
 
-The proof does NOT reuse `expr_native_type`, and that is the first real finding:
+Keyed on a PROOF (`collect_user_fn_rets`): every `return` provably numeric, and the name never
+reassigned or shadowed. `proof_numeric_type` is separate from `expr_native_type` for the reason
+below, which is the second finding this issue produced:
 
 > **`result_type_of_binop` requires BOTH operands to be `F64`.** So `arr[i] & 255` where `arr` is a
 > `Vec<i32>` types as `Value` — the element is `I32`, the literal `F64`, and no arm covers the mix.
 > On GBA, where `i32[]` is the annotation the hardware wants, that is nearly every masked read of a
-> typed array.
+> typed array. Widening it would change lowering everywhere it is consulted; the proof asks the
+> weaker question instead.
 
-Widening `result_type_of_binop` would change lowering everywhere it is consulted, so the attempt used
-a separate, weaker predicate: "is this a NUMBER" rather than "can this be lowered natively". Two
-unconditional JS facts carry it — `- * / % **` always ToNumber, and `& | ^ << >>` always ToInt32
-(so an int32 even if an operand was a string) — with `+` the only binop needing both sides proven.
-
-**Where it stopped: the emit side never fired.** An `Expr::Call` arm in `emit_typed_expr`, returning
-the proven type with a checked unbox, was never reached for the target shape
-`mb = mb + readCell(mj)` — confirmed with a probe, zero hits. What is known:
-
-* `mb`'s registered type IS `I32`, so the assignment enters the int-domain block that calls
-  `emit_int32_operand(value)` (`codegen.rs:4050`).
-* That should reach the `Add`/`Sub` arm, whose `int32_or_native_i32(right)` falls through to
-  `emit_typed_expr` on the call — which would have hit the new arm.
-* It does not. `emit_typed_expr` is never called with a `Call` anywhere in that program.
-
-So something between the assignment's `emit_int32_operand` and the `Add` arm is returning early, and
-that is the single unknown left. Whoever picks this up should start by probing entry to the `Add`
-arm rather than at the emit site.
+One trap, since it cost a full cycle and left no trace: an emit arm placed at the BOTTOM of
+`emit_typed_expr` is DEAD CODE — an existing `Expr::Call` arm shadows it. The measurement does not
+move and nothing says why. It belongs beside the typed-extern case inside that arm, which already
+does exactly this for `cargo:` imports.
 
 ## Item 2 — a MORE precise annotation disqualifies the optimization
 

--- a/docs/issues/user-fn-call-cost-on-gba.md
+++ b/docs/issues/user-fn-call-cost-on-gba.md
@@ -1,6 +1,8 @@
 # A call to a user tish function costs ~92 ticks on GBA
 
-**Status:** item 1 FIXED in `9993d6145` (93.4 -> 72.2 ticks a call). Item 2 open.
+**Status:** item 1 FIXED in `9993d6145` (93.4 -> 72.2 ticks a call). Item 2 PARTLY fixed in
+`e85e09566` — the ABI exists and works; it does not yet reach the code that motivated the issue.
+Item 3 (below) is what remains.
 **Found by:** `tish-gba`, porting a game's rules core from Rust to tish.
 **Related:** `int-domain-consumer-boundary.md` — same shape of finding (type information present
 and discarded), same bench ROM.
@@ -138,6 +140,43 @@ guidance, and every one is therefore ineligible.
 
 Whether M5 should grow an `i32` shape is a design decision rather than an obvious fix — an
 `fn f(i32, i32) -> i32` is exactly right for ARM7TDMI, but it is a second native ABI to maintain.
+
+### PARTLY FIXED in `e85e09566`
+
+An all-`i32` signature now emits `fn f_native(mut a: i32, ..) -> i32` and direct calls target it.
+All-or-nothing: an `: i32` parameter is ToInt32-coerced on entry through the boxed path and an f64
+native parameter is not, so a mixed signature keeps the old ABI.
+
+Two things had to be fixed before the ABI could be reached at all, and both were larger than it:
+
+  * **M5 was switched off entirely on GBA** — the target the annotation exists for. The block was
+    gated `emit_mode != Gba` because sibling passes emit `thread_local!`. Those stay off; the
+    native-fn pass runs.
+  * **`numeric_shaped`/`native_safe_expr` did not know the bitwise operators.** `& | ^ << >> ~` were
+    absent from both, so any function containing one was ineligible however it was annotated — and
+    on this target that is nearly every function. Now accepted, gated on the GBA numeric vocabulary
+    so eligibility elsewhere is byte-identical (ungated it promoted fnv1a and changed its lowering).
+
+And it surfaced a latent miscompile: `native_safe_expr`'s index arm accepted any identifier as the
+indexed object without checking it is in scope for a TOP-LEVEL fn, so a fn reading a module array
+compiled to a body naming a binding that only exists inside `run()` (E0425). Fixed, with a test.
+
+## Item 3 — a native free fn cannot see module state, which is where the win is
+
+The ABI above changes nothing for the port that motivated this issue, and the reason is exact: every
+hot function in it reads a module-scope array (`PLANE[...]`, `DEPTH[...]`, `GS[...]`), and a
+module-scope `let` is emitted as a LOCAL OF `run()`, closed over by the boxed function closures. A
+top-level `fn` cannot name it — that is the miscompile fixed above, and rejecting those candidates
+is correct, not conservative.
+
+So the remaining work is not in the calling convention at all. It is: **emit module-scope arrays and
+scalars as top-level statics** (on GBA, where there is a single core and `SingleCore`/`static mut`
+are available) rather than as locals of `run()`, so that a native fn can reach them — and then let
+`globals` carry them, which every existing check already consults.
+
+Until that lands, a function is eligible only if it touches nothing but its parameters. That is the
+minority of any real program, and none of the ~20 calls per candidate in the search this issue
+opened with.
 Filing it separately from item 1 for that reason.
 
 ## What was checked, and what turned out to be wrong

--- a/docs/issues/user-fn-call-cost-on-gba.md
+++ b/docs/issues/user-fn-call-cost-on-gba.md
@@ -68,10 +68,31 @@ path. **The information is present at parse time and thrown away.** That is the 
 `int-domain-consumer-boundary.md`, where a value was known to be an integer and the consumer
 converted it anyway; fixing that one was worth 28x and 4.4x on two hot paths.
 
-A table of `name -> RustType` for annotated top-level functions, consulted where a call's result
-meets a typed consumer, would turn the example above into an integer add and drop two soft-float
-conversions per call. It does not require any new calling convention — the call stays boxed, only
-its RESULT stops being opaque.
+Such a table, consulted where a call's result meets a typed consumer, would turn the example above
+into an integer add and drop two soft-float conversions per call. It requires no new calling
+convention — the call stays boxed, only its RESULT stops being opaque.
+
+**IT CANNOT BE BUILT ON THE ANNOTATION, AND THE FIRST VERSION OF THIS ISSUE SAID IT COULD.** Return
+annotations are erased and unchecked:
+
+```tish
+function liar(x: i32): i32 {
+  if (x > 0) { return "not a number" }
+  return 7
+}
+console.log(liar(1))   // -> not a number
+```
+
+That runs, and prints the string. A table keyed on `: i32` would have unboxed it as a number —
+either panicking or producing a garbage value where the language today returns a string. The claim
+was written from reading the AST and corrected by a two-line program; it is left visible here
+because it is the obvious way to build this and it is wrong.
+
+So the table has to be backed by PROOF that every return is numeric, not by the declaration. That
+proof already exists: `returns_numeric`, which M5 runs in its fixpoint for exactly this reason.
+Reusing it makes the qualification "annotated native return AND every return path verified numeric
+AND the name never reassigned" — the same standard M5 already holds itself to, and the reason this
+is a contained change rather than a trivial one.
 
 ## Item 2 — a MORE precise annotation disqualifies the optimization
 
@@ -94,6 +115,9 @@ Whether M5 should grow an `i32` shape is a design decision rather than an obviou
 Filing it separately from item 1 for that reason.
 
 ## What was checked, and what turned out to be wrong
+
+**The annotation is not a contract** — see the `liar` repro under item 1. This is the single most
+important thing on this page for anyone implementing it.
 
 **Changing the annotation is not a workaround.** `readCell` was rebuilt as `(i: number): number`:
 47,691 → 44,823 ticks, about 6%, and the generated Rust contains **no `readCell_native`** — M5 still

--- a/docs/issues/user-fn-call-cost-on-gba.md
+++ b/docs/issues/user-fn-call-cost-on-gba.md
@@ -1,0 +1,133 @@
+# A call to a user tish function costs ~92 ticks on GBA
+
+**Status:** open.
+**Found by:** `tish-gba`, porting a game's rules core from Rust to tish.
+**Related:** `int-domain-consumer-boundary.md` — same shape of finding (type information present
+and discarded), same bench ROM.
+
+## The measurement
+
+On device, GBA, one frame = 4,389 Timer2 ticks. `tish-gba/examples/bench-grid` pass K, 512
+iterations of `acc = acc + <read>`:
+
+| | total ticks | per call |
+|---|---|---|
+| K1 · the read written INLINE | 813 | — |
+| K2 · the same read behind `function readCell(i: i32): i32` | 47,691 | **91.6** |
+
+The callee is one line — `return CALLARR[i] & 255` — over a module `i32[]`. The difference is the
+call and nothing else. For scale, a typed extern crossing into Rust (`declare fn` + `cargo:` import)
+measures about **7 ticks**, so calling a tish function is roughly **13x more expensive than calling
+into Rust**.
+
+This is not a microbenchmark curiosity. Counting `value_call` sites in the generated frame loop of
+two real ROMs: `drop-tish` 45, `magical-drop` 74. And the number that stopped a port: a game's CPU
+search, ported to tish, costs **9,076 ticks per candidate move** — 2.07 frames — against **~100
+ticks** for the whole equivalent step in Rust (`bench-grid` pass R2). About twenty cross-module
+calls per candidate is most of that gap. The search had to stay in Rust.
+
+## What the generated code does
+
+For `function readCell(i: i32): i32 { return CALLARR[i] & 255 }` called as `mb = mb + readCell(mj)`:
+
+```rust
+mb = match &tishlang_runtime::ops::add(&Value::Number(((mb) as f64)), &({
+        let _callee = ((readCell).clone()).clone();
+        tishlang_runtime::value_call(&_callee, &[Value::Number((mj) as f64).clone()])
+    })) { Value::Number(n) => tishlang_runtime::to_int32(*n), _ => panic!("expected number") };
+```
+
+and the callee:
+
+```rust
+let readCell = {
+    let CALLARR_cell = CALLARR_cell.clone();
+    Value::native(move |args: &[Value]| {
+        let Some(_tish_depth) = tishlang_runtime::enter_call_guarded() else { return Value::Null; };
+        let CALLARR = CALLARR_cell.clone();
+        let mut i = match &args.get(0).cloned().unwrap_or(Value::Null) {
+            Value::Number(n) => tishlang_runtime::to_int32(*n), _ => panic!("expected number") };
+        return Value::Number((((...) & 255i32)) as f64);
+    })
+};
+```
+
+**The declared signature is not used at the call site.** `i32` in, `i32` out, and the call still
+boxes the argument to `Value::Number` (an i32→f64 soft-float on ARM7TDMI), boxes the return the same
+way, and then — because the result's type is unknown — reaches for the fully generic `ops::add`,
+which must consider string concatenation, before `to_int32` converts back.
+
+## Item 1 — there is no user-function return-type table
+
+`Statement::FunDecl` carries `return_type`. `collect_native_fns` reads it, for M5 eligibility only.
+Nothing maps a user function name to its return type for use at a CALL SITE: there is no
+`fn_return_types`, `fn_sigs` or equivalent in `codegen.rs`.
+
+So a call is always an opaque `Value`, and every arithmetic consumer of one falls back to the boxed
+path. **The information is present at parse time and thrown away.** That is the same defect shape as
+`int-domain-consumer-boundary.md`, where a value was known to be an integer and the consumer
+converted it anyway; fixing that one was worth 28x and 4.4x on two hot paths.
+
+A table of `name -> RustType` for annotated top-level functions, consulted where a call's result
+meets a typed consumer, would turn the example above into an integer add and drop two soft-float
+conversions per call. It does not require any new calling convention — the call stays boxed, only
+its RESULT stops being opaque.
+
+## Item 2 — a MORE precise annotation disqualifies the optimization
+
+M5 (`native_fns`) already lowers a top-level function to a real free `fn`, with direct calls
+bypassing `value_call`. Its parameter and return gate is:
+
+```rust
+fn ann_is_number(ann: &TypeAnnotation) -> bool {
+    RustType::from_annotation(ann) == RustType::F64
+}
+```
+
+So `: number` qualifies and **`: i32` does not**. On a device with no FPU, `: i32` is the annotation
+that is correct for the hardware, and it is the one that opts you out. Every function in the port
+that motivated this issue is annotated `: i32`, on the explicit advice of this repo's own GBA
+guidance, and every one is therefore ineligible.
+
+Whether M5 should grow an `i32` shape is a design decision rather than an obvious fix — an
+`fn f(i32, i32) -> i32` is exactly right for ARM7TDMI, but it is a second native ABI to maintain.
+Filing it separately from item 1 for that reason.
+
+## What was checked, and what turned out to be wrong
+
+**Changing the annotation is not a workaround.** `readCell` was rebuilt as `(i: number): number`:
+47,691 → 44,823 ticks, about 6%, and the generated Rust contains **no `readCell_native`** — M5 still
+did not fire. The reason is structural and is NOT a bug: an M5 free `fn` cannot see module state,
+because the generated program lives inside one `main()` with the module's bindings as locals, and
+`readCell` reads a module array. Every function in a game's grid/state modules does. So item 2 alone
+would not have helped here; item 1 would.
+
+**Two things in that generated snippet are NOT worth reporting as cost.** `((readCell).clone()).clone()`
+is a doubled clone, and `Value::Number(x).clone()` clones a value constructed one expression earlier.
+Both are redundant in the emitted source, but `Value::Number` is a non-heap enum variant and LLVM
+very likely elides them. They were nearly filed as findings on inspection alone; nobody should act
+on them without measuring first.
+
+## Why this shape of program is not served today
+
+The native optimization stack is built around, and benchmarked on, pure numeric functions over
+parameters and `f64` arrays — nbody, spectral-norm, fasta, k-nucleotide. Every gap above is
+reasonable for that workload.
+
+A GBA game is the opposite shape: `i32` arithmetic, module-scope state arrays that must persist
+across frames, and many small cross-module calls per frame. Nothing here is wrong for its intended
+target; there is simply no path for this one. The practical consequence is that a tish game's only
+lever on call cost is call COUNT, and that lever runs out: batching four per-column loops in the
+port bought 38% and the search still did not fit.
+
+## Reproducing
+
+```bash
+cd tish-gba/examples/bench-grid && npm run build
+GBA_SHOT_LOG=1 ../../scripts/screenshot.sh bench-grid.gba /tmp/bg.png 600
+```
+
+K1 is the inline baseline, K2 the same work behind a call; the difference over 512 iterations is the
+per-call cost. Note the bench's own trap, recorded in its README: adding a function that touches a
+module array deoptimises EVERY access to that array, including from top-level code that never calls
+it, so K2's callee reads a private array to keep the other passes comparable.

--- a/docs/issues/user-fn-call-cost-on-gba.md
+++ b/docs/issues/user-fn-call-cost-on-gba.md
@@ -94,6 +94,42 @@ Reusing it makes the qualification "annotated native return AND every return pat
 AND the name never reassigned" — the same standard M5 already holds itself to, and the reason this
 is a contained change rather than a trivial one.
 
+### An implementation attempt, and where it stopped
+
+Tried and BACKED OUT, recorded so the next attempt starts where this one stopped rather than
+rediscovering three days of it.
+
+**The proof works.** A `user_fn_ret: HashMap<String, RustType>` built by fixpoint, keyed on every
+`return` being provably numeric, qualified the right functions — `{"readCell": I32, "copyBitwise":
+I32, "copyFlat": I32}` on `bench-grid`. Soundness held: the `liar` program above still printed its
+string on both the interpreter and codegen, and the bench checksum was byte-identical.
+
+The proof does NOT reuse `expr_native_type`, and that is the first real finding:
+
+> **`result_type_of_binop` requires BOTH operands to be `F64`.** So `arr[i] & 255` where `arr` is a
+> `Vec<i32>` types as `Value` — the element is `I32`, the literal `F64`, and no arm covers the mix.
+> On GBA, where `i32[]` is the annotation the hardware wants, that is nearly every masked read of a
+> typed array.
+
+Widening `result_type_of_binop` would change lowering everywhere it is consulted, so the attempt used
+a separate, weaker predicate: "is this a NUMBER" rather than "can this be lowered natively". Two
+unconditional JS facts carry it — `- * / % **` always ToNumber, and `& | ^ << >>` always ToInt32
+(so an int32 even if an operand was a string) — with `+` the only binop needing both sides proven.
+
+**Where it stopped: the emit side never fired.** An `Expr::Call` arm in `emit_typed_expr`, returning
+the proven type with a checked unbox, was never reached for the target shape
+`mb = mb + readCell(mj)` — confirmed with a probe, zero hits. What is known:
+
+* `mb`'s registered type IS `I32`, so the assignment enters the int-domain block that calls
+  `emit_int32_operand(value)` (`codegen.rs:4050`).
+* That should reach the `Add`/`Sub` arm, whose `int32_or_native_i32(right)` falls through to
+  `emit_typed_expr` on the call — which would have hit the new arm.
+* It does not. `emit_typed_expr` is never called with a `Call` anywhere in that program.
+
+So something between the assignment's `emit_int32_operand` and the `Add` arm is returning early, and
+that is the single unknown left. Whoever picks this up should start by probing entry to the `Add`
+arm rather than at the emit site.
+
 ## Item 2 — a MORE precise annotation disqualifies the optimization
 
 M5 (`native_fns`) already lowers a top-level function to a real free `fn`, with direct calls

--- a/regression/downstream/run.sh
+++ b/regression/downstream/run.sh
@@ -148,6 +148,26 @@ run_one() {
         echo "   ⚠ depends on lattish but no local workspace ($TISH/../lattish) or clone ($WORKDIR/lattish) found"
       fi
     fi
+
+    # Same treatment for @spacedevin/deck — deckard (tish-midi) grew a dependency on the deck
+    # workspace, and an isolated clone resolves it exactly the way an isolated clone resolved
+    # lattish: not at all. Wire the local workspace copy when it exists; anywhere it doesn't,
+    # say so up front rather than letting every .tish file fail resolution one by one (that
+    # failure mode showed as a 'regression' with an EMPTY error line, because the loop's
+    # per-file stderr capture had already been overwritten by the next file).
+    if [[ -f "$dir/$subdir/package.json" ]] && rg -q '"@spacedevin/deck"[[:space:]]*:' "$dir/$subdir/package.json" 2>/dev/null; then
+      local deck_src=""
+      if [[ -d "$TISH/../../deck" ]]; then deck_src="$(cd "$TISH/../.." && pwd)/deck"
+      elif [[ -d "$WORKDIR/deck" ]]; then deck_src="$WORKDIR/deck"; fi
+      if [[ -n "$deck_src" ]]; then
+        rm -rf "$dir/$subdir/node_modules/@spacedevin/deck"
+        mkdir -p "$dir/$subdir/node_modules/@spacedevin"
+        rsync -a --exclude node_modules --exclude .git "$deck_src/" "$dir/$subdir/node_modules/@spacedevin/deck/" >/dev/null 2>&1
+        echo "   wired LOCAL deck ($deck_src) -> node_modules/@spacedevin/deck"
+      else
+        echo "   ⚠ depends on @spacedevin/deck but no local workspace ($TISH/../../deck) or clone ($WORKDIR/deck) found"
+      fi
+    fi
   fi
 
   # 3. build + test


### PR DESCRIPTION
Six commits of GBA codegen work, plus the two `perf(gba)` runtime commits this branch is named
after. All of it is driven by one consumer — porting a game's rules core from Rust to tish in
`tish-gba` — and every number below was measured on device, where a frame is 4,389 Timer2 ticks.

## The theme: type information that was present and discarded

`types.rs` types every bitwise/shift result `RustType::F64`. That is correct about JS and a real win
against boxing. The unmeasured consequence is at the **consumer**: an f64 meeting something that
wants an integer converts back, and on ARM7TDMI both directions are soft-float calls.

Five consumer sites were routing through f64 with an integer already in hand:

| | before | after | |
|---|---|---|---|
| module `i32[]` write pass | 22,765 | 1,009 | 22.6x |
| `arr[j] = j & 255` | 23,162 | 1,652 | 14.0x |
| `arr[((j>>5)<<5) \| (j&31)]` | 20,318 | 1,494 | 13.6x |
| `acc = acc + (arr[i] & 255)` | 22,742 | 813 | **28x** |
| fn copy, bitwise READ index | 22,541 | 2,371 | 9.5x |
| 63-cell flood fill | 3,826 | 1,468 | 2.6x |

Downstream, in the game: a 63-cell board copy went 2,103 → 480 ticks, its search's frame 4,463 →
2,336 average and 5,672 → 3,176 peak (from over a frame to inside one), and the ported rules' peak
frame 5,189 → 4,037.

Soundness is narrow and stated at each site. Only the SIGNED bitwise ops qualify — their value is by
construction inside i32, so `(x as f64) as i32` is the identity. `>>>` is excluded: its uint32 can
exceed `i32::MAX` and Rust's float→int `as` saturates, so the two routes genuinely disagree. Index
forms carry `.max(0)` to reproduce the saturating f64→usize cast exactly. `Add`/`Sub` lower
integrally only INSIDE a ToInt32 context, where `to_int32(a + b) == a.wrapping_add(b)` holds exactly;
`+` is not a ToInt32 context in general and is untouched elsewhere.

## Two things worth knowing before reviewing

**The obvious root fix is a 5x pessimisation.** Typing bitwise results `I32` disables the int-domain
fusion, which is *gated on* `result_ty == F64` — the two are a matched pair. Measured with it in:
flood fill 1,470 → 7,531. There is a note in the issue so nobody tries it a third time.

**`emit_int32_operand`'s leaf fold reports success while emitting the round trip.** For
`acc + (x & 255)` it falls through to `emit_typed_expr`, sees an F64, and returns
`Some("to_int32(...)")`. That is why three earlier consumer-side patches were unreachable and changed
nothing. The `Add`/`Sub` arm sits ABOVE it, and `int32_or_native_i32` rejects any candidate still
containing `to_int32`.

## Docs

Two issues under `docs/issues/`:

- **`int-domain-consumer-boundary.md`** — closed. Also records that my first diagnosis in it was
  wrong: I wrote "the fix belongs at the consumer" and it belonged inside `emit_int32_operand`.
- **`user-fn-call-cost-on-gba.md`** — open, no code. A call to a user tish function measures ~92
  ticks against ~7 for a typed extern crossing into Rust; a game's ported CPU search came to 9,076
  ticks per candidate against ~100 native and had to stay in Rust. Two items: there is no
  user-function return-type table (the type is parsed and thrown away), and `ann_is_number` requires
  `F64` so `: i32` — the annotation that is correct for a device with no FPU — disqualifies a
  function from M5. It also records two dead ends so they are not re-explored, including one claim I
  filed and then disproved with a two-line program: return annotations are erased and unchecked, so
  such a table cannot be keyed on the declaration.

## Provenance

`65f0f30bf` and `ee8ee884a` are @spacedevin's GBA runtime commits — the branch is named after the
first. The six codegen/docs commits on top are mine.

## Verification

`cargo test -p tishlang --release` — 14 suites, 0 failures, run against the tip of this branch.
Downstream, all 15 `tish-gba` ROMs pass their `verify.sh`, including a differential oracle that
reports the tish attack port bit-identical to the Rust core over 660 cases / 13,377 cells.
