### PR TITLE
fix(codegen): module-const-array hoist admission was permissive by default — broke 4 ROMs on 3.3.0

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -3201,7 +3201,12 @@ impl Codegen {
             // #597: which annotated arrays escape into a call, and so must stay boxed to preserve
             // aliasing. Collected once over the whole program — an array declared here can be
             // passed to a fn declared anywhere.
-            {
+            //
+            // GATED ON GBA, and not only because the RESULT is GBA-only: this scan runs
+            // `scan_param_use` over the whole program once per annotated array, so it is
+            // O(arrays x program). Off-target that is pure waste — the set is never read — and it
+            // would be a silent compile-time tax on every host build.
+            if self.emit_mode == crate::NativeEmitMode::Gba {
                 let mut array_names: Vec<String> = Vec::new();
                 Self::collect_annotated_array_names(&program.statements, &mut array_names);
                 self.arrays_passed_to_calls =
@@ -3718,7 +3723,25 @@ impl Codegen {
         if self.is_async {
             self.async_context_stack.push(true); // run() body is async Rust context
         }
-        self.emit_statements_with_folds(&program.statements)?;
+        // #629: A FUNCTION MAY REFERENCE A MODULE BINDING DECLARED BELOW IT. Module bindings are
+        // emitted into `run()` in source order, but a function VALUE is emitted where it appears and
+        // captures by name — so `function readA() { return A[i] }` above `let A = [...]` emitted a
+        // capture of `A` five lines before `let A`, and rustc rejected the program:
+        //
+        //     let rangDone = { Value::native(move |args| { … vm_read(&rangLive) … }) };  // use
+        //     let rangLive = VmRef::new(vec![(0_f64) as i32]);                           // decl
+        //
+        // That is legal tish — the function is not CALLED before the binding is initialised — and
+        // only the ORDER differs; moving the `let` above the functions compiles. It took hyrule's
+        // whole ROM down (`rangDone` at weapons.tish:28, `rangLive` at :46).
+        //
+        // Reordered here rather than at the capture site because the capture is not wrong; its
+        // position is. Restricted to LITERAL initialisers on purpose: hoisting `let x = f()` would
+        // move a call, changing when its side effects run and possibly reading state the statements
+        // above it establish. A literal cannot observe or disturb anything, so moving it is not
+        // visible to the program.
+        let reordered = Self::hoist_forward_referenced_module_bindings(&program.statements);
+        self.emit_statements_with_folds(reordered.as_deref().unwrap_or(&program.statements))?;
         if self.is_async {
             self.async_context_stack.pop();
         }
@@ -17073,6 +17096,84 @@ impl Codegen {
         self.native_fn_emit_name.is_some() || self.native_vec_ret.is_some()
     }
 
+    /// #629: move module-level `let`s with LITERAL initialisers ahead of any function declared
+    /// above them that references the name. Returns `None` when nothing needs moving, so the common
+    /// program keeps its exact statement slice and this costs one scan.
+    ///
+    /// Only bindings that are actually forward-referenced move, and only past the point where they
+    /// are first needed — the relative order of everything else is preserved.
+    fn hoist_forward_referenced_module_bindings(stmts: &[Statement]) -> Option<Vec<Statement>> {
+        // Names bound at module level by a literal `let`, with the index of their declaration.
+        let mut literal_decls: Vec<(usize, String)> = Vec::new();
+        for (i, s) in stmts.iter().enumerate() {
+            if let Statement::VarDecl {
+                name,
+                init: Some(e),
+                ..
+            } = s
+            {
+                if Self::is_literal_initialiser(e) {
+                    literal_decls.push((i, name.to_string()));
+                }
+            }
+        }
+        if literal_decls.is_empty() {
+            return None;
+        }
+        // A binding needs moving when some statement ABOVE its declaration mentions it. Function
+        // bodies are what make this legal, so those are exactly what is scanned.
+        let mut needed: Vec<(usize, usize)> = Vec::new(); // (decl index, first referencing index)
+        for (di, name) in &literal_decls {
+            let mut first = None;
+            for (i, s) in stmts.iter().enumerate().take(*di) {
+                if Self::stmt_mentions_ident(s, name) {
+                    first = Some(i);
+                    break;
+                }
+            }
+            if let Some(f) = first {
+                needed.push((*di, f));
+            }
+        }
+        if needed.is_empty() {
+            return None;
+        }
+        // Rebuild: each moved declaration is inserted immediately before the first statement that
+        // references it, keeping every other statement in place.
+        let mut out: Vec<Statement> = Vec::with_capacity(stmts.len());
+        let moved: std::collections::HashSet<usize> = needed.iter().map(|(d, _)| *d).collect();
+        for (i, s) in stmts.iter().enumerate() {
+            for (di, fi) in &needed {
+                if *fi == i {
+                    out.push(stmts[*di].clone());
+                }
+            }
+            if !moved.contains(&i) {
+                out.push(s.clone());
+            }
+        }
+        Some(out)
+    }
+
+    /// An initialiser that cannot observe or disturb program state, so moving it is invisible.
+    /// Deliberately narrow — array/object literals are included only when every element is itself
+    /// literal, so no call or property read comes along for the ride.
+    fn is_literal_initialiser(e: &Expr) -> bool {
+        match e {
+            Expr::Literal { .. } => true,
+            Expr::Unary { operand, .. } => Self::is_literal_initialiser(operand),
+            Expr::Array { elements, .. } => elements.iter().all(|el| match el {
+                ArrayElement::Expr(e) => Self::is_literal_initialiser(e),
+                _ => false,
+            }),
+            Expr::Object { props, .. } => props.iter().all(|p| match p {
+                ObjectProp::KeyValue(_, v, _) => Self::is_literal_initialiser(v),
+                _ => false,
+            }),
+            _ => false,
+        }
+    }
+
     fn emit_statements_with_folds(&mut self, statements: &[Statement]) -> Result<(), CompileError> {
         let mut i = 0;
         while i < statements.len() {
@@ -17461,18 +17562,36 @@ impl Codegen {
                     callee.as_ref(),
                     Expr::Ident { name, .. } if name.as_ref() == "cumulative"
                 );
-                // A METHOD CALL ON THE ARRAY IS SUPPORTED: `X.join(", ")` emits the object through
-                // the `Value` bridge (`NumArrayBacking::Packed(G_X…)`), so the local name does not
-                // survive. Disqualifying it — which the `Member` arm below would do — costs the
-                // hoist for no reason (tests/core/template_literals.tish).
+                // A METHOD CALL ON THE ARRAY IS SUPPORTED — but only the ones that go through the
+                // `Value` bridge. `X.join(", ")` emits the object as
+                // `NumArrayBacking::Packed(G_X…)`, so the local name does not survive and the hoist
+                // is fine (tests/core/template_literals.tish).
                 //
-                // This does NOT extend to a member READ such as `X.length`: that lowers to a bare
-                // `X.len()` with no rewrite, which is exactly one of the two shapes that broke the
-                // ROMs. The `Member` arm still rejects those.
+                // THE FUSEABLE HOFs ARE NOT. `X.map(...)`, `X.reduce(...)` and their siblings lower
+                // to a NATIVE iterator chain — `xs.iter().copied().map(...)` — which names the local
+                // directly and is NOT rewritten to the static. Exempting them hoisted an array whose
+                // every use then referenced a binding that no longer existed:
+                //
+                //     let mut sum: f64 = { … for b in xs.iter().copied() { … } … };
+                //     error[E0425]: cannot find value `xs` in this scope
+                //
+                // Caught by the perf gauntlet's `typed_array_hof` fixture on the NATIVE target —
+                // this walker is not GBA-gated, so a too-permissive exemption breaks the host.
+                //
+                // Nor does the exemption extend to a member READ such as `X.length`, which lowers to
+                // a bare `X.len()` — one of the two shapes that broke the ROMs.
                 let member_call_on_g = matches!(
                     callee.as_ref(),
-                    Expr::Member { object, .. }
+                    Expr::Member { object, prop, .. }
                         if matches!(object.as_ref(), Expr::Ident { name, .. } if name.as_ref() == g)
+                            && !matches!(
+                                prop,
+                                MemberProp::Name { name: m, .. } if matches!(
+                                    m.as_ref(),
+                                    "reduce" | "forEach" | "find" | "findIndex" | "some" | "every"
+                                        | "map" | "filter" | "reduceRight"
+                                )
+                            )
                 );
                 if matches!(callee.as_ref(), Expr::Ident { name, .. } if name.as_ref() == g) {
                     *bad = true;
@@ -17581,6 +17700,13 @@ impl Codegen {
                     Self::walk_expr_for_module_const_disqualifiers(e, g, bad);
                 }
             }
+            // Leaves, listed explicitly so they do NOT reach the fallback below. A literal cannot
+            // mention a binding, and there is one in nearly every expression in a real program —
+            // routing those through a whole-subtree ident scan turned this walk superlinear and hung
+            // the compiler outright (a `tish build` of `scii` spun at 100% CPU for 40+ minutes in the
+            // frontend, no rustc involved). The fallback is for shapes that might CONTAIN a
+            // reference, not for every constant in the file.
+            Expr::Literal { .. } => {}
             // CONSERVATIVE DEFAULT — see the statement walker. An expression shape this match does
             // not model (today: `Await`, `JsxElement`, and anything the AST gains later) disqualifies
             // if the name appears anywhere beneath it, rather than being waved through.

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1102,6 +1102,9 @@ pub(crate) struct Codegen {
     /// Top-level `let name = [f64 literals…]` never reassigned — emitted as `const G_name: [f64; N]`
     /// for direct indexing from native fns (fasta `codes`/`probs`).
     module_const_f64_arrays: std::collections::HashMap<String, Vec<f64>>,
+    /// #597: names passed DIRECTLY as a call argument (`fill(reqs)`). A typed array in this set must
+    /// not lower to a native `Vec` — see the note at the `VarDecl` typing site.
+    arrays_passed_to_calls: std::collections::HashSet<String>,
     /// The STATIC names from `module_const_f64_arrays` whose every element is an exact integer in
     /// `i32` range, so the hoist emits `[i32; N]` instead of `[f64; N]`.
     ///
@@ -1396,6 +1399,7 @@ impl Codegen {
             native_numeric_globals: std::collections::HashMap::new(),
             module_const_f64_arrays: std::collections::HashMap::new(),
             module_const_int_statics: std::collections::HashSet::new(),
+            arrays_passed_to_calls: std::collections::HashSet::new(),
             module_const_f64_cum: std::collections::HashMap::new(),
             module_const_f64_aliases: std::collections::HashMap::new(),
             map_instance_locals: std::collections::HashSet::new(),
@@ -3194,6 +3198,15 @@ impl Codegen {
                 &program.statements,
                 &self.module_const_f64_cum,
             );
+            // #597: which annotated arrays escape into a call, and so must stay boxed to preserve
+            // aliasing. Collected once over the whole program — an array declared here can be
+            // passed to a fn declared anywhere.
+            {
+                let mut array_names: Vec<String> = Vec::new();
+                Self::collect_annotated_array_names(&program.statements, &mut array_names);
+                self.arrays_passed_to_calls =
+                    Self::collect_escaping_array_names(&program.statements, &array_names);
+            }
             // Pick the integer representation where the values allow it. GBA only: off-target the
             // `f64` layout is free and eligibility must stay byte-identical to before.
             //
@@ -4131,9 +4144,26 @@ impl Codegen {
                 // `emit_int32_operand` (a `>>> 0` result is u32 reinterpreted to i32; signed
                 // bitwise ops yield i32 directly) — so store the i32 with NO `f64` round-trip.
                 if rust_type == RustType::I32 {
+                    // #599: A CAPTURED i32 IS A CELL, AND THE WRITE HAS TO SAY SO. Reads of a
+                    // wrapped scalar already go through `vm_read(&x)`; every store below used to
+                    // emit a bare `x = <i32>`, so the two halves disagreed and the crate failed with
+                    // `expected VmRef<i32>, found i32`. Net effect was that a mutable module-level
+                    // typed scalar could not be used at all on GBA — every counter had to move into
+                    // a function body or hide in a one-element `i32[]`.
+                    //
+                    // The narrow-int branch below has always done this; the i32 branch is the one
+                    // that was missed, across all three of its store shapes.
+                    let is_refcell = self.refcell_wrapped_vars.contains(name.as_ref());
+                    let store = |escaped: &str, val: String| {
+                        if is_refcell {
+                            format!("{{ let _t = {}; *{}.borrow_mut() = _t; }}", val, escaped)
+                        } else {
+                            format!("{} = {}", escaped, val)
+                        }
+                    };
                     if let Some(int_code) = self.emit_int32_operand(value)? {
                         let escaped = Self::escape_ident(name.as_ref());
-                        return Ok(format!("{} = ({}) as i32", escaped, int_code));
+                        return Ok(store(&escaped, format!("({}) as i32", int_code)));
                     }
                     let (val_code, val_ty) = self.emit_typed_expr(value)?;
                     // An RHS that is ALREADY an integer stores straight into the register. `d = d + 1`
@@ -4142,7 +4172,7 @@ impl Codegen {
                     // out of it was the whole cost of incrementing an annotated counter.
                     let escaped_int = Self::escape_ident(name.as_ref());
                     if val_ty.is_integer_scalar() {
-                        return Ok(format!("{} = ({}) as i32", escaped_int, val_code));
+                        return Ok(store(&escaped_int, format!("({}) as i32", val_code)));
                     }
                     // Defensive: gate guarantees `Some`, but if a future RHS shape slips through,
                     // fall back to a sound f64-narrowed store rather than miscompiling.
@@ -4152,11 +4182,7 @@ impl Codegen {
                         val_code
                     };
                     let escaped = Self::escape_ident(name.as_ref());
-                    return Ok(format!(
-                        "{} = {}",
-                        escaped,
-                        RustType::I32.from_value_expr(&v)
-                    ));
+                    return Ok(store(&escaped, RustType::I32.from_value_expr(&v)));
                 }
                 // String self-append `s = s + rhs` -> in-place push_str (amortized O(1)). The
                 // general path boxes via `ops::add(Value::String(s.clone()), ...)` which clones
@@ -5806,6 +5832,34 @@ impl Codegen {
                         crate::types::RustType::from_annotation_with_aliases(t, &self.type_aliases)
                     })
                     .unwrap_or(RustType::Value);
+
+                // #597: AN ARRAY THAT ESCAPES INTO A BOXED CALL STAYS BOXED. A native `Vec<T>`
+                // handed to a `value_call` is marshalled by BUILDING A FRESH `Value::Array` from
+                // its elements — a copy by construction — so the callee's `push`es land in the copy
+                // and the caller's array silently keeps its old contents. Nothing reports it: not
+                // the compiler, not the runtime. An UNTYPED array passes the same `VmRef` and
+                // aliases correctly, which means adding an annotation changed program BEHAVIOUR
+                // rather than just representation.
+                //
+                // The call site cannot fix this — boxing a `Vec<i32>` into a `Value::Array` is a
+                // copy however it is spelled. So the decision has to be made here, at the
+                // declaration: if the array is ever passed as a call argument, keep it boxed.
+                //
+                // Same rule the read-only param analysis already applies from the other side
+                // (`arr_param_readonly_fns` refuses an owned copy when a param is mutated, escapes
+                // or is forwarded). Conservative on purpose: an array that never escapes is
+                // untouched and keeps its native lowering.
+                // GBA ONLY. The reporter checked the other backends: `tish run` and a native
+                // `tish build` both alias correctly and print the expected result, so this is a
+                // TARGET divergence rather than a language-wide one. Narrowing off-target would
+                // deopt host code to fix a bug host code does not have, and one host test
+                // (`escaping_array_keeps_oob_safe_lowering`) pins the native store it would remove.
+                if self.emit_mode == crate::NativeEmitMode::Gba
+                    && matches!(rust_type, RustType::Vec(_))
+                    && self.arrays_passed_to_calls.contains(name.as_ref())
+                {
+                    rust_type = RustType::Value;
+                }
 
                 // M5 native-fn body: `let r = genRandom(1)` without a `: number` annotation.
                 if self.native_fn_body_emit && rust_type == RustType::Value {
@@ -14093,13 +14147,22 @@ impl Codegen {
         // so a RHS that reads the same cell (`a[i] += x`, `a[i] = a[j]`) releases its shared borrow
         // first (no overlapping lock → no deadlock), then store into the real element through the cell.
         if wrapped {
-            let needs_resize =
-                matches!(elem_type.as_ref(), RustType::F64 | RustType::Bool) && !in_bounds;
+            // #611: I32 GROWS TOO. A boxed array absorbs `a[i] = v` past the end by growing; a
+            // typed one used to fall through to a bare element store, so the same source line
+            // behaved differently depending only on whether the annotation was present — the write
+            // was lost with no error at compile time or run time. That silent divergence between
+            // the typed and boxed forms is the worst of the available options, so the typed form
+            // now matches the boxed one. Pad is `0`, which is what the READ path already answers
+            // for an out-of-range `i32` element (`.get(i).copied().unwrap_or(0)`).
+            let needs_resize = matches!(
+                elem_type.as_ref(),
+                RustType::F64 | RustType::Bool | RustType::I32
+            ) && !in_bounds;
             let store = if needs_resize {
-                let pad = if matches!(elem_type.as_ref(), RustType::F64) {
-                    "f64::NAN"
-                } else {
-                    "false"
+                let pad = match elem_type.as_ref() {
+                    RustType::F64 => "f64::NAN",
+                    RustType::I32 => "0",
+                    _ => "false",
                 };
                 format!(
                     "let __i = {idx}; let __v = {val}; let mut __g = {esc}.borrow_mut(); if __i >= __g.len() {{ __g.resize(__i + 1, {pad}); }} __g[__i] = __v;",
@@ -14125,16 +14188,22 @@ impl Codegen {
                     format!("{{ {}[{}] = {}; Value::Null }}", esc_obj, idx_usize, native_val)
                 }
             }
-            RustType::F64 | RustType::Bool => {
-                let pad = if matches!(elem_type.as_ref(), RustType::F64) {
-                    "f64::NAN"
-                } else {
-                    "false"
+            // #611: same grow-to-index rule on the unwrapped path — see the note above.
+            RustType::F64 | RustType::Bool | RustType::I32 => {
+                let pad = match elem_type.as_ref() {
+                    RustType::F64 => "f64::NAN",
+                    RustType::I32 => "0",
+                    _ => "false",
                 };
-                format!(
-                    "{{ let _idx = {}; if _idx >= {}.len() {{ {}.resize(_idx + 1, {}); }} {}[_idx] = {}; Value::Null }}",
+                let store = format!(
+                    "{{ let _idx = {}; if _idx >= {}.len() {{ {}.resize(_idx + 1, {}); }} {}[_idx] = {}",
                     idx_usize, esc_obj, esc_obj, pad, esc_obj, native_val
-                )
+                );
+                if side_effect_only {
+                    format!("{} }}", store)
+                } else {
+                    format!("{}; Value::Null }}", store)
+                }
             }
             _ if side_effect_only => {
                 format!("{}[{}] = {}", esc_obj, idx_usize, native_val)
@@ -18374,6 +18443,151 @@ impl Codegen {
             }
         });
         ok
+    }
+
+    /// #597: every `let x: T[]` name in the program, at any nesting depth. These are the candidates
+    /// whose escape has to be checked before they may lower to a native `Vec`.
+    fn collect_annotated_array_names(stmts: &[Statement], out: &mut Vec<String>) {
+        for s in stmts {
+            Self::collect_annotated_array_names_stmt(s, out);
+        }
+    }
+
+    fn collect_annotated_array_names_stmt(s: &Statement, out: &mut Vec<String>) {
+        match s {
+            Statement::VarDecl {
+                name,
+                type_ann: Some(t),
+                ..
+            } => {
+                if matches!(crate::types::RustType::from_annotation(t), RustType::Vec(_)) {
+                    out.push(name.to_string());
+                }
+            }
+            Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
+                for s in statements {
+                    Self::collect_annotated_array_names_stmt(s, out);
+                }
+            }
+            Statement::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                Self::collect_annotated_array_names_stmt(then_branch, out);
+                if let Some(e) = else_branch {
+                    Self::collect_annotated_array_names_stmt(e, out);
+                }
+            }
+            Statement::While { body, .. }
+            | Statement::DoWhile { body, .. }
+            | Statement::ForOf { body, .. }
+            | Statement::ForIn { body, .. }
+            | Statement::FunDecl { body, .. } => {
+                Self::collect_annotated_array_names_stmt(body, out);
+            }
+            Statement::For { init, body, .. } => {
+                if let Some(i) = init {
+                    Self::collect_annotated_array_names_stmt(i, out);
+                }
+                Self::collect_annotated_array_names_stmt(body, out);
+            }
+            Statement::Switch {
+                cases,
+                default_body,
+                ..
+            } => {
+                for (_, stmts) in cases {
+                    for s in stmts {
+                        Self::collect_annotated_array_names_stmt(s, out);
+                    }
+                }
+                if let Some(stmts) = default_body {
+                    for s in stmts {
+                        Self::collect_annotated_array_names_stmt(s, out);
+                    }
+                }
+            }
+            Statement::Try {
+                body,
+                catch_body,
+                finally_body,
+                ..
+            } => {
+                Self::collect_annotated_array_names_stmt(body, out);
+                if let Some(c) = catch_body {
+                    Self::collect_annotated_array_names_stmt(c, out);
+                }
+                if let Some(f) = finally_body {
+                    Self::collect_annotated_array_names_stmt(f, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// #597: array names that ESCAPE — handed to a call as a bare argument, or otherwise used as a
+    /// whole value rather than indexed.
+    ///
+    /// Reuses `scan_param_use`, the same analysis the read-only param path already trusts for this
+    /// exact hazard: its `forwarded` flag is documented as "the callee could mutate the array, and a
+    /// write to the caller's array would be lost on the owned copy". That is #597 from the other
+    /// side, so the answer should come from one analysis rather than a second, subtly-different one.
+    ///
+    /// Over-approximating only costs an array its native lowering. Under-approximating brings back a
+    /// silently wrong result, so the bias is deliberate.
+    fn collect_escaping_array_names(stmts: &[Statement], names: &[String]) -> std::collections::HashSet<String> {
+        // `for_each_stmt_expr` deliberately does NOT descend into `FunDecl` bodies, so the forwarding
+        // call is normally invisible to it — the array is declared inside a function and passed
+        // inside that same function, which is exactly the reported shape. Gather nested bodies as
+        // additional roots first.
+        fn add_roots<'a>(s: &'a Statement, roots: &mut Vec<&'a Statement>) {
+            roots.push(s);
+            match s {
+                Statement::FunDecl { body, .. }
+                | Statement::While { body, .. }
+                | Statement::DoWhile { body, .. }
+                | Statement::ForOf { body, .. }
+                | Statement::ForIn { body, .. }
+                | Statement::For { body, .. } => add_roots(body, roots),
+                Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
+                    for s in statements {
+                        add_roots(s, roots);
+                    }
+                }
+                Statement::If {
+                    then_branch,
+                    else_branch,
+                    ..
+                } => {
+                    add_roots(then_branch, roots);
+                    if let Some(e) = else_branch {
+                        add_roots(e, roots);
+                    }
+                }
+                _ => {}
+            }
+        }
+        let mut roots: Vec<&Statement> = Vec::new();
+        for s in stmts {
+            add_roots(s, &mut roots);
+        }
+        let mut out = std::collections::HashSet::new();
+        for n in names {
+            let mut f = ParamUse::default();
+            for s in &roots {
+                Self::for_each_stmt_expr(s, &mut |e| Self::scan_param_use(e, n, false, &mut f));
+            }
+            // `forwarded` ONLY, not `escaped`. `escaped` covers any whole-value use — including
+            // `return arr`, which hands ownership out and does not create the aliasing hazard this
+            // is about. Using it deopted arrays that are legitimately native
+            // (`numeric_returning_fn_keeps_pushed_array_native`). #597 is specifically "passed as a
+            // call argument", which is what `forwarded` means.
+            if f.forwarded {
+                out.insert(n.clone());
+            }
+        }
+        out
     }
 
     fn for_each_expr_root(stmts: &[Statement], f: &mut dyn FnMut(&Expr)) {
@@ -25185,6 +25399,19 @@ impl Codegen {
                                     // `borrow()` guard a non-Copy element must be cloned OUT (it can't be
                                     // moved from the borrow); a plain local keeps the direct place.
                                     _ if idx_wrapped => format!("{}[{}].clone()", esc_obj, idx_ref),
+                                    // #600: a STRING element is cloned even unwrapped. `let s: string =
+                                    // NAMES[i]` binds the element, and binding a non-Copy value out of a
+                                    // `Vec` is a move — `error[E0507]: cannot move out of index`. The
+                                    // obvious spelling was the one that did not compile, with indexing
+                                    // straight into a call as the only working form.
+                                    //
+                                    // Scoped to String deliberately. The struct case (#571) looks
+                                    // identical but must NOT clone here: `states[id].timer` projects a
+                                    // field out of the place, and cloning would copy the whole struct on
+                                    // every field read — the O(n)-per-read footgun #558 exists about.
+                                    // A string is already copied at every boxed boundary, so the clone
+                                    // costs nothing that was not already being paid.
+                                    RustType::String => format!("{}[{}].clone()", esc_obj, idx_ref),
                                     _ => format!("{}[{}]", esc_obj, idx_ref),
                                 };
                                 // #567: wrap the wrapped-Vec read in a block that pre-binds the index

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -17120,13 +17120,34 @@ impl Codegen {
         if literal_decls.is_empty() {
             return None;
         }
-        // A binding needs moving when some statement ABOVE its declaration mentions it. Function
-        // bodies are what make this legal, so those are exactly what is scanned.
+        // A NAME DECLARED MORE THAN ONCE AT MODULE LEVEL IS NEVER MOVED. An earlier mention of such
+        // a name refers to the EARLIER binding, not forward to this one, so hoisting this
+        // declaration over it silently changes which value the earlier code sees. That is a wrong
+        // ANSWER, not a build break: tests/core/js_compat_gaps.tish declares `text` twice — a string
+        // at the top and a different string further down — and moving the second above the first
+        // made an intervening `slice` read the wrong source, printing `hello 123 world 45` where
+        // `.mdx` was expected.
+        let mut decl_counts: std::collections::HashMap<&str, usize> =
+            std::collections::HashMap::new();
+        for s in stmts {
+            if let Statement::VarDecl { name, .. } = s {
+                *decl_counts.entry(name.as_ref()).or_insert(0) += 1;
+            }
+        }
+        // A binding needs moving when a FUNCTION BODY above its declaration mentions it. Deferred
+        // execution is what makes a forward reference legal — the body does not run until called.
+        //
+        // Straight-line code above the declaration is deliberately NOT counted: there the mention
+        // either refers to a previous binding of the name or is a genuine use-before-init, and in
+        // neither case may the declaration be moved over it.
         let mut needed: Vec<(usize, usize)> = Vec::new(); // (decl index, first referencing index)
         for (di, name) in &literal_decls {
+            if decl_counts.get(name.as_str()).copied().unwrap_or(0) > 1 {
+                continue;
+            }
             let mut first = None;
             for (i, s) in stmts.iter().enumerate().take(*di) {
-                if Self::stmt_mentions_ident(s, name) {
+                if matches!(s, Statement::FunDecl { .. }) && Self::stmt_mentions_ident(s, name) {
                     first = Some(i);
                     break;
                 }
@@ -17580,17 +17601,28 @@ impl Codegen {
                 //
                 // Nor does the exemption extend to a member READ such as `X.length`, which lowers to
                 // a bare `X.len()` — one of the two shapes that broke the ROMs.
+                // ALLOWLIST, NOT DENYLIST. This started as "any method call except the fuseable
+                // HOFs", which is allow-by-default — and every MUTATING method walked straight
+                // through it. `arr2.unshift(1, 2)` hoisted its receiver into a `const` and then
+                // tried to mutate it, so the local vanished and rustc reported
+                // `cannot find value arr2` (tests/core/array_methods.tish, under
+                // TISH_PACKED_ARRAYS=1). `push`/`pop`/`splice`/`sort`/`reverse`/`fill` are the same
+                // shape.
+                //
+                // So only methods PROVEN to route the receiver through the `Value` bridge are
+                // exempt. `join` is the one this pass actually needs
+                // (tests/core/template_literals.tish emits
+                // `array_join(&Value::NumberArray(…Packed(G_NUMS…)))`, where the local name does not
+                // survive). Anything else — mutators, the HOFs that lower to a native iterator chain
+                // over the bare local, and any method added later — disqualifies the hoist, which is
+                // the safe direction: it costs an optimisation, not a build.
                 let member_call_on_g = matches!(
                     callee.as_ref(),
                     Expr::Member { object, prop, .. }
                         if matches!(object.as_ref(), Expr::Ident { name, .. } if name.as_ref() == g)
-                            && !matches!(
+                            && matches!(
                                 prop,
-                                MemberProp::Name { name: m, .. } if matches!(
-                                    m.as_ref(),
-                                    "reduce" | "forEach" | "find" | "findIndex" | "some" | "every"
-                                        | "map" | "filter" | "reduceRight"
-                                )
+                                MemberProp::Name { name: m, .. } if m.as_ref() == "join"
                             )
                 );
                 if matches!(callee.as_ref(), Expr::Ident { name, .. } if name.as_ref() == g) {

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -18218,34 +18218,73 @@ impl Codegen {
             Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
                 Self::walk_stmts_for_global_disqualifiers(statements, g, bad);
             }
+            // Conditions are visited, not just bodies. This walker had the same blind spot the
+            // module-const one did: `while (i < X.length)` put a disqualifying use somewhere the
+            // walk never reached, so the global was hoisted anyway and the emitted program
+            // referenced a name that no longer existed. Latent here only because a scalar is rarely
+            // spelled that way — the defect is identical.
             Statement::If {
+                cond,
                 then_branch,
                 else_branch,
                 ..
             } => {
+                Self::walk_expr_for_global_disqualifiers(cond, g, bad);
                 Self::walk_stmt_for_global_disqualifiers(then_branch, g, bad);
                 if let Some(eb) = else_branch {
                     Self::walk_stmt_for_global_disqualifiers(eb, g, bad);
                 }
             }
-            Statement::While { body, .. }
-            | Statement::DoWhile { body, .. }
-            | Statement::For { body, .. }
-            | Statement::ForOf { body, .. }
-            | Statement::ForIn { body, .. } => {
+            Statement::While { cond, body, .. } | Statement::DoWhile { body, cond, .. } => {
+                Self::walk_expr_for_global_disqualifiers(cond, g, bad);
+                Self::walk_stmt_for_global_disqualifiers(body, g, bad);
+            }
+            Statement::For {
+                init,
+                cond,
+                update,
+                body,
+                ..
+            } => {
+                if let Some(i) = init {
+                    Self::walk_stmt_for_global_disqualifiers(i, g, bad);
+                }
+                if let Some(c) = cond {
+                    Self::walk_expr_for_global_disqualifiers(c, g, bad);
+                }
+                if let Some(u) = update {
+                    Self::walk_expr_for_global_disqualifiers(u, g, bad);
+                }
+                Self::walk_stmt_for_global_disqualifiers(body, g, bad);
+            }
+            Statement::ForOf { iterable, body, .. }
+            | Statement::ForIn {
+                object: iterable,
+                body,
+                ..
+            } => {
+                Self::walk_expr_for_global_disqualifiers(iterable, g, bad);
                 Self::walk_stmt_for_global_disqualifiers(body, g, bad);
             }
             Statement::Switch {
+                expr,
                 cases,
                 default_body,
                 ..
             } => {
-                for (_, stmts) in cases {
+                Self::walk_expr_for_global_disqualifiers(expr, g, bad);
+                for (case_expr, stmts) in cases {
+                    if let Some(e) = case_expr {
+                        Self::walk_expr_for_global_disqualifiers(e, g, bad);
+                    }
                     Self::walk_stmts_for_global_disqualifiers(stmts, g, bad);
                 }
                 if let Some(d) = default_body {
                     Self::walk_stmts_for_global_disqualifiers(d, g, bad);
                 }
+            }
+            Statement::Throw { value, .. } => {
+                Self::walk_expr_for_global_disqualifiers(value, g, bad);
             }
             Statement::Try {
                 body,

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -17155,40 +17155,73 @@ impl Codegen {
             Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
                 Self::walk_stmts_for_module_const_disqualifiers(statements, g, bad);
             }
+            // EVERY child expression has to be visited, not just the sub-statements. These arms used
+            // to walk only the bodies, so a use in a loop or branch CONDITION was invisible — which
+            // is how `while (i < SB_FORCE.length)` (card-gba qb-engine.tish) kept an array eligible
+            // for hoisting even though `.length` is a disqualifying member use. Same defect class as
+            // the missing closure arm below: the walker's silence meant "safe", not "absent".
             Statement::If {
+                cond,
                 then_branch,
                 else_branch,
                 ..
             } => {
+                Self::walk_expr_for_module_const_disqualifiers(cond, g, bad);
                 Self::walk_stmt_for_module_const_disqualifiers(then_branch, g, bad);
                 if let Some(eb) = else_branch {
                     Self::walk_stmt_for_module_const_disqualifiers(eb, g, bad);
                 }
             }
-            Statement::While { body, .. } | Statement::DoWhile { body, .. } => {
+            Statement::While { cond, body, .. } | Statement::DoWhile { body, cond, .. } => {
+                Self::walk_expr_for_module_const_disqualifiers(cond, g, bad);
                 Self::walk_stmt_for_module_const_disqualifiers(body, g, bad);
             }
-            Statement::For { init, body, .. } => {
+            Statement::For {
+                init,
+                cond,
+                update,
+                body,
+                ..
+            } => {
                 if let Some(i) = init {
                     Self::walk_stmt_for_module_const_disqualifiers(i, g, bad);
                 }
+                if let Some(c) = cond {
+                    Self::walk_expr_for_module_const_disqualifiers(c, g, bad);
+                }
+                if let Some(u) = update {
+                    Self::walk_expr_for_module_const_disqualifiers(u, g, bad);
+                }
                 Self::walk_stmt_for_module_const_disqualifiers(body, g, bad);
             }
-            Statement::ForOf { body, .. }
-            | Statement::ForIn { body, .. } => {
+            Statement::ForOf { iterable, body, .. }
+            | Statement::ForIn {
+                object: iterable,
+                body,
+                ..
+            } => {
+                Self::walk_expr_for_module_const_disqualifiers(iterable, g, bad);
                 Self::walk_stmt_for_module_const_disqualifiers(body, g, bad);
             }
             Statement::Switch {
+                expr,
                 cases,
                 default_body,
                 ..
             } => {
-                for (_, stmts) in cases {
+                Self::walk_expr_for_module_const_disqualifiers(expr, g, bad);
+                for (case_expr, stmts) in cases {
+                    if let Some(e) = case_expr {
+                        Self::walk_expr_for_module_const_disqualifiers(e, g, bad);
+                    }
                     Self::walk_stmts_for_module_const_disqualifiers(stmts, g, bad);
                 }
                 if let Some(stmts) = default_body {
                     Self::walk_stmts_for_module_const_disqualifiers(stmts, g, bad);
                 }
+            }
+            Statement::Throw { value, .. } => {
+                Self::walk_expr_for_module_const_disqualifiers(value, g, bad);
             }
             Statement::Try {
                 body,
@@ -17220,8 +17253,30 @@ impl Codegen {
                     Self::walk_expr_for_module_const_disqualifiers(e, g, bad);
                 }
             }
-            _ => {}
+            // CONSERVATIVE DEFAULT. This walker decides whether it is safe to move an array into a
+            // `const`, so "I do not model this statement" must mean "refuse", never "permit" — the
+            // old `_ => {}` meant the latter, and a wrong permit is a program that does not compile.
+            // Over-rejecting only costs the hoist; under-rejecting cost four ROMs their build.
+            s => {
+                if Self::stmt_mentions_ident(s, g) {
+                    *bad = true;
+                }
+            }
         }
+    }
+
+    /// Complete-traversal membership test, used as the safe fallback by both walkers above.
+    fn stmt_mentions_ident(s: &Statement, g: &str) -> bool {
+        let mut idents = HashSet::new();
+        Self::collect_stmt_idents(s, &mut idents);
+        idents.contains(g)
+    }
+
+    /// As `stmt_mentions_ident`, for an expression subtree.
+    fn expr_mentions_ident(e: &Expr, g: &str) -> bool {
+        let mut idents = HashSet::new();
+        Self::collect_expr_idents(e, &mut idents);
+        idents.contains(g)
     }
 
     fn walk_expr_for_module_const_disqualifiers(e: &Expr, g: &str, bad: &mut bool) {
@@ -17334,7 +17389,68 @@ impl Codegen {
                     }
                 }
             }
-            _ => {}
+            // Everything below was missing, and the omission is what made this pass unsafe: an
+            // admission check whose walker reports "no disqualifying use" for a shape it does not
+            // recognise is silently permissive. `ArrowFunction` was the expensive one — every use
+            // inside a CLOSURE landed in `_ => {}`, so an array a closure writes got hoisted to a
+            // `const` anyway. Reads then renamed to `G_X` while the write kept the boxed local, and
+            // that local is declared after the closure: rustc reports `cannot find value` on a name
+            // the game never misspelled (card-gba queensblood/triad/gwent; tish-gba hyrule's
+            // `rangLive`). Renaming the write would not have been a fix either — a `const` cannot be
+            // assigned through, so a written array must not be hoisted at all. The sibling scalar
+            // walker has always had these arms; this one is a copy that lost them.
+            //
+            // Indexing stays deliberately absent from the disqualifier list: `X[i]` is the whole
+            // point of the hoist, so descending here must not become "any closure mention kills it",
+            // which would give back the #594 reachability this pass exists to provide.
+            Expr::ArrowFunction { body, .. } => match body {
+                ArrowBody::Expr(e) => Self::walk_expr_for_module_const_disqualifiers(e, g, bad),
+                ArrowBody::Block(s) => Self::walk_stmt_for_module_const_disqualifiers(s, g, bad),
+            },
+            // A write to a member of the const, by the same rule the `Member` arm above uses.
+            Expr::MemberAssign { object, value, .. } => {
+                if matches!(object.as_ref(), Expr::Ident { name, .. } if name.as_ref() == g) {
+                    *bad = true;
+                } else {
+                    Self::walk_expr_for_module_const_disqualifiers(object, g, bad);
+                }
+                Self::walk_expr_for_module_const_disqualifiers(value, g, bad);
+            }
+            Expr::Delete { target, .. }
+                if matches!(target.as_ref(), Expr::Ident { name, .. } if name.as_ref() == g) =>
+            {
+                *bad = true;
+            }
+            // The remaining shapes need no special rule: a bare mention of the name is already
+            // disqualifying via the `Ident` arm, so plain descent is sufficient.
+            Expr::New { callee, args, .. } => {
+                Self::walk_expr_for_module_const_disqualifiers(callee, g, bad);
+                for a in args {
+                    if let CallArg::Expr(e) | CallArg::Spread(e) = a {
+                        Self::walk_expr_for_module_const_disqualifiers(e, g, bad);
+                    }
+                }
+            }
+            Expr::NullishCoalesce { left, right, .. } => {
+                Self::walk_expr_for_module_const_disqualifiers(left, g, bad);
+                Self::walk_expr_for_module_const_disqualifiers(right, g, bad);
+            }
+            Expr::TypeOf { operand, .. } => {
+                Self::walk_expr_for_module_const_disqualifiers(operand, g, bad);
+            }
+            Expr::TemplateLiteral { exprs, .. } => {
+                for e in exprs {
+                    Self::walk_expr_for_module_const_disqualifiers(e, g, bad);
+                }
+            }
+            // CONSERVATIVE DEFAULT — see the statement walker. An expression shape this match does
+            // not model (today: `Await`, `JsxElement`, and anything the AST gains later) disqualifies
+            // if the name appears anywhere beneath it, rather than being waved through.
+            other => {
+                if Self::expr_mentions_ident(other, g) {
+                    *bad = true;
+                }
+            }
         }
     }
 

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1102,6 +1102,18 @@ pub(crate) struct Codegen {
     /// Top-level `let name = [f64 literals…]` never reassigned — emitted as `const G_name: [f64; N]`
     /// for direct indexing from native fns (fasta `codes`/`probs`).
     module_const_f64_arrays: std::collections::HashMap<String, Vec<f64>>,
+    /// The STATIC names from `module_const_f64_arrays` whose every element is an exact integer in
+    /// `i32` range, so the hoist emits `[i32; N]` instead of `[f64; N]`.
+    ///
+    /// ARM7TDMI HAS NO FPU. These passes were written for the host, where `f64` is tish's number and
+    /// the representation is free; on GBA every `f64` touch is a soft-float call and every element
+    /// costs 8 bytes instead of 4. Worse, the source usually declares the element type — hoisting
+    /// `let A: i32[] = [1,2,3]` to `[f64; 3]` discards a type the program already stated, then pays
+    /// an `i32 -> f64 -> usize` round trip on each index to get back to where it started.
+    ///
+    /// Keyed by static name, not source name, so every read site (including the `_cum` aliases) can
+    /// ask the question with what it already has in hand.
+    module_const_int_statics: std::collections::HashSet<String>,
     /// Precomputed cumulative arrays for `module_const_f64_arrays` used as `cumulative(p)` input
     /// (`probs` → `G_probs_cum`).
     module_const_f64_cum: std::collections::HashMap<String, String>,
@@ -1383,6 +1395,7 @@ impl Codegen {
             refcell_wrapped_vars: std::collections::HashSet::new(),
             native_numeric_globals: std::collections::HashMap::new(),
             module_const_f64_arrays: std::collections::HashMap::new(),
+            module_const_int_statics: std::collections::HashSet::new(),
             module_const_f64_cum: std::collections::HashMap::new(),
             module_const_f64_aliases: std::collections::HashMap::new(),
             map_instance_locals: std::collections::HashSet::new(),
@@ -3181,6 +3194,23 @@ impl Codegen {
                 &program.statements,
                 &self.module_const_f64_cum,
             );
+            // Pick the integer representation where the values allow it. GBA only: off-target the
+            // `f64` layout is free and eligibility must stay byte-identical to before.
+            //
+            // A `_cum` array is deliberately NOT considered — the fasta ladder that consumes one
+            // compares it against an `r_f64` and is specialised around f64 arms, so leaving cum
+            // alone keeps that path untouched.
+            if self.emit_mode == crate::NativeEmitMode::Gba {
+                for (name, vals) in &self.module_const_f64_arrays {
+                    if vals
+                        .iter()
+                        .all(|v| v.fract() == 0.0 && *v >= i32::MIN as f64 && *v <= i32::MAX as f64)
+                    {
+                        self.module_const_int_statics
+                            .insert(Self::module_const_static(name));
+                    }
+                }
+            }
             if !self.module_const_f64_arrays.is_empty() {
                 self.emit_module_const_f64_arrays()?;
                 self.writeln("");
@@ -5904,12 +5934,22 @@ impl Codegen {
                     return Ok(());
                 }
 
-                // Module-level const f64 arrays — no local slot in `run()`.
+                // Module-level const numeric arrays — no local slot in `run()`. The element type
+                // must match the emitted representation, or a consumer reading the type context
+                // coerces against a layout that is not there.
                 if self.module_const_f64_arrays.contains_key(name.as_ref())
                     && self.outer_vars_stack.len() == 1
                 {
+                    let elem = if self
+                        .module_const_int_statics
+                        .contains(&Self::module_const_static(name.as_ref()))
+                    {
+                        RustType::I32
+                    } else {
+                        RustType::F64
+                    };
                     self.type_context
-                        .define(name.as_ref(), RustType::Vec(Box::new(RustType::F64)));
+                        .define(name.as_ref(), RustType::Vec(Box::new(elem)));
                     return Ok(());
                 }
 
@@ -7954,7 +7994,7 @@ impl Codegen {
                     ));
                 }
                 if let Some(static_name) = self.module_const_f64_array_rust_ref(name.as_ref()) {
-                    let v = Self::module_const_f64_array_as_value(&static_name);
+                    let v = self.module_const_f64_array_as_value(&static_name);
                     return Ok(if self.value_fn_depth > 0 || !self.loop_stack.is_empty() {
                         format!("({}).clone()", v)
                     } else {
@@ -16798,7 +16838,15 @@ impl Codegen {
                 {
                     let sum_esc = Self::escape_ident(sum_name.as_ref());
                     let arms: Vec<String> = (0..n)
-                        .map(|i| format!("{} => {}[{}]", i, codes_static, i))
+                        // The fasta ladder is specialised around f64 arms, so an integer-represented
+                        // codes array widens here rather than perturbing that path.
+                        .map(|i| {
+                            if self.module_const_int_statics.contains(codes_static.as_str()) {
+                                format!("{} => {}[{}] as f64", i, codes_static, i)
+                            } else {
+                                format!("{} => {}[{}]", i, codes_static, i)
+                            }
+                        })
                         .collect();
                     self.writeln(&format!(
                         "{} = (({} + match ({} as usize) {{ {}, _ => 0.0 }}) % 2147483647_f64);",
@@ -17200,7 +17248,15 @@ impl Codegen {
                 body,
                 ..
             } => {
-                Self::walk_expr_for_module_const_disqualifiers(iterable, g, bad);
+                // ITERATING THE ARRAY IS A SUPPORTED USE, not a disqualifying one: `for (x of X)`
+                // lowers to a native index loop over the hoisted static (`for _fof_i0 in
+                // 0..G_X.len()`), so the name never survives into the output. Walking the iterable
+                // unconditionally would see a bare `Ident` and refuse the hoist, which loses the
+                // very optimisation the pass exists for (tests/core/typed_array_forof.tish).
+                // Anything else in iterable position is walked normally.
+                if !matches!(iterable, Expr::Ident { name, .. } if name.as_ref() == g) {
+                    Self::walk_expr_for_module_const_disqualifiers(iterable, g, bad);
+                }
                 Self::walk_stmt_for_module_const_disqualifiers(body, g, bad);
             }
             Statement::Switch {
@@ -17336,9 +17392,22 @@ impl Codegen {
                     callee.as_ref(),
                     Expr::Ident { name, .. } if name.as_ref() == "cumulative"
                 );
+                // A METHOD CALL ON THE ARRAY IS SUPPORTED: `X.join(", ")` emits the object through
+                // the `Value` bridge (`NumArrayBacking::Packed(G_X…)`), so the local name does not
+                // survive. Disqualifying it — which the `Member` arm below would do — costs the
+                // hoist for no reason (tests/core/template_literals.tish).
+                //
+                // This does NOT extend to a member READ such as `X.length`: that lowers to a bare
+                // `X.len()` with no rewrite, which is exactly one of the two shapes that broke the
+                // ROMs. The `Member` arm still rejects those.
+                let member_call_on_g = matches!(
+                    callee.as_ref(),
+                    Expr::Member { object, .. }
+                        if matches!(object.as_ref(), Expr::Ident { name, .. } if name.as_ref() == g)
+                );
                 if matches!(callee.as_ref(), Expr::Ident { name, .. } if name.as_ref() == g) {
                     *bad = true;
-                } else {
+                } else if !member_call_on_g {
                     Self::walk_expr_for_module_const_disqualifiers(callee, g, bad);
                 }
                 for (i, a) in args.iter().enumerate() {
@@ -17634,15 +17703,41 @@ impl Codegen {
         )
     }
 
-    fn module_const_f64_array_as_value(static_name: &str) -> String {
+    /// The boxed bridge. `NumArrayBacking::Packed` is a `Vec<f64>`, so an `[i32; N]` hoist widens on
+    /// the way out — this is the escape hatch where the array is handed to code that wants a
+    /// `Value`, and it is a whole-array copy either way.
+    fn module_const_f64_array_as_value(&self, static_name: &str) -> String {
+        let elems = if self.module_const_int_statics.contains(static_name) {
+            format!("{}.iter().map(|v| *v as f64)", static_name)
+        } else {
+            format!("{}.iter().copied()", static_name)
+        };
         format!(
-            "Value::NumberArray(VmRef::new(tishlang_runtime::NumArrayBacking::Packed({}.iter().copied().collect::<Vec<f64>>())))",
-            static_name
+            "Value::NumberArray(VmRef::new(tishlang_runtime::NumArrayBacking::Packed({}.collect::<Vec<f64>>())))",
+            elems
         )
     }
 
     fn emit_module_const_f64_arrays(&mut self) -> Result<(), CompileError> {
         for (name, vals) in self.module_const_f64_arrays.clone() {
+            let static_name = Self::module_const_static(name.as_str());
+            // `[i32; N]` where the values permit it — half the ROM, and reads that stay in the
+            // integer domain instead of round-tripping through soft float. See the field comment on
+            // `module_const_int_statics`.
+            if self.module_const_int_statics.contains(&static_name) {
+                let lit = vals
+                    .iter()
+                    .map(|v| format!("{}", *v as i32))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                self.writeln(&format!(
+                    "const {}: [i32; {}] = [{}];",
+                    static_name,
+                    vals.len(),
+                    lit
+                ));
+                continue;
+            }
             let lit = vals
                 .iter()
                 .map(|v| Self::f64_lit(*v))
@@ -17650,7 +17745,7 @@ impl Codegen {
                 .join(", ");
             self.writeln(&format!(
                 "const {}: [f64; {}] = [{}];",
-                Self::module_const_static(name.as_str()),
+                static_name,
                 vals.len(),
                 lit
             ));
@@ -24978,33 +25073,47 @@ impl Codegen {
                                     iv
                                 )
                             };
-                            let access = if in_bounds {
-                                format!("{}[{}]", static_name, idx_usize)
+                            let is_int = self.module_const_int_statics.contains(&static_name);
+                            // The proven-in-bounds read on an integer array is the whole point: a
+                            // plain word load, reported as I32 so the consumer stays in the integer
+                            // domain instead of converting back and forth through f64.
+                            if in_bounds {
+                                let access = format!("{}[{}]", static_name, idx_usize);
+                                return Ok((
+                                    access,
+                                    if is_int { RustType::I32 } else { RustType::F64 },
+                                ));
+                            }
+                            let const_len = self
+                                .cum_static_and_len(name.as_ref())
+                                .map(|(_, n)| n)
+                                .or_else(|| {
+                                    self.module_const_f64_arrays
+                                        .get(name.as_ref())
+                                        .map(|v| v.len())
+                                })
+                                .unwrap_or(0);
+                            // OUT-OF-RANGE STAYS f64. An unproven index still has to be able to
+                            // answer `NaN`, and there is no `i32` that means "absent" — picking a
+                            // sentinel here would silently turn a missing element into a real value.
+                            // So the bounds-checked form keeps today's exact semantics and only the
+                            // STORAGE narrows; the integer win is claimed above, where the index is
+                            // proven and no sentinel is reachable.
+                            let elem = if is_int {
+                                format!("{}[_i] as f64", static_name)
                             } else {
-                                let const_len = self
-                                    .cum_static_and_len(name.as_ref())
-                                    .map(|(_, n)| n)
-                                    .or_else(|| {
-                                        self.module_const_f64_arrays
-                                            .get(name.as_ref())
-                                            .map(|v| v.len())
-                                    })
-                                    .unwrap_or(0);
-                                if const_len > 0 {
-                                    format!(
-                                        "{{ let _i = {}; if _i < {} {{ {}[_i] }} else {{ f64::NAN }} }}",
-                                        idx_usize,
-                                        const_len,
-                                        static_name
-                                    )
-                                } else {
-                                    format!(
-                                        "{{ let _i = {}; if _i < {}.len() {{ {}[_i] }} else {{ f64::NAN }} }}",
-                                        idx_usize,
-                                        static_name,
-                                        static_name
-                                    )
-                                }
+                                format!("{}[_i]", static_name)
+                            };
+                            let access = if const_len > 0 {
+                                format!(
+                                    "{{ let _i = {}; if _i < {} {{ {} }} else {{ f64::NAN }} }}",
+                                    idx_usize, const_len, elem
+                                )
+                            } else {
+                                format!(
+                                    "{{ let _i = {}; if _i < {}.len() {{ {} }} else {{ f64::NAN }} }}",
+                                    idx_usize, static_name, elem
+                                )
                             };
                             return Ok((access, RustType::F64));
                         }

--- a/crates/tish_compile/tests/regr_gba_lowered_call_sites.rs
+++ b/crates/tish_compile/tests/regr_gba_lowered_call_sites.rs
@@ -485,3 +485,165 @@ console.log(R.length)
         offenders.join("\n  ")
     );
 }
+
+// ── #48/#52-follow-up: the module-const-array hoist was blind to closures ─────────────────────────
+//
+// `collect_module_const_f64_arrays` hoists a module-level numeric array to a top-level
+// `const G_X: [f64; N]` so a LOWERED fn can reach it (that reachability is the whole point of #594).
+// Admission is supposed to reject any array that is written, or used as a value/member, because a
+// `const` is neither mutable nor addressable. The admission walker checks all of that — but its
+// expression arm had no `ArrowFunction` case, so every use inside a CLOSURE fell into `_ => {}` and
+// was invisible. The sibling scalar pass (`walk_expr_for_global_disqualifiers`) has always had that
+// arm; this walker is a copy that lost it.
+//
+// Net effect once the pass was enabled on GBA: an array that a closure writes got hoisted anyway.
+// The read side renamed to `G_X`, the write side kept the boxed local, and the boxed local is
+// declared *after* the closure — so rustc reports `cannot find value` on a name the game never
+// misspelled. Reported against card-gba (queensblood/triad/gwent) and reproduced independently by
+// tish-gba `examples/hyrule` (`rangLive`, weapons.tish).
+//
+// The trigger needs all three ingredients: a module numeric array, a typed top-level fn that reads
+// it (that is what nominates it for hoisting), and a write from inside a closure.
+
+/// The reported repro, reduced. Before the fix this emitted `const G_A: [f64; 3]` plus a write
+/// through a bare `A`, and rustc rejected it with E0425.
+const CLOSURE_WRITE: &str = r#"
+let A: i32[] = [1, 2, 3]
+
+function readA(i: i32): i32 { return A[i] }
+
+export function run(): i32 {
+  let bump = () => { A[0] = A[0] + 1 }
+  bump()
+  return readA(0)
+}
+"#;
+
+#[test]
+fn module_array_written_in_closure_is_not_hoisted_to_const() {
+    let rust = compile_gba("closure_write", CLOSURE_WRITE);
+    // The array is written, so it must stay a runtime binding: no const hoist at all. Renaming the
+    // write site would not be enough — a `const` cannot be assigned through.
+    assert!(
+        !rust.contains("const G_A"),
+        "a module array written from a closure must not be hoisted to a const:\n{}",
+        rust
+    );
+    // And the generated program must not reference a hoisted name it never declared.
+    assert!(
+        !rust.contains("G_A["),
+        "no read may be renamed to a hoist that does not exist:\n{}",
+        rust
+    );
+}
+
+/// The second missed case from the same report: `.length` lowers to `.len()`, which is a member use
+/// the walker already rejects — it was just unreachable inside a closure. A hoist here emitted
+/// `A.len()` against a name not in scope.
+const CLOSURE_LENGTH: &str = r#"
+let A: i32[] = [1, 2, 3]
+
+function readA(i: i32): i32 { return A[i] }
+
+export function run(): i32 {
+  let count = () => { return A.length }
+  return readA(0) + count()
+}
+"#;
+
+#[test]
+fn module_array_member_used_in_closure_is_not_hoisted_to_const() {
+    let rust = compile_gba("closure_length", CLOSURE_LENGTH);
+    assert!(
+        !rust.contains("const G_A"),
+        "a module array whose `.length` a closure reads must not be hoisted:\n{}",
+        rust
+    );
+}
+
+/// The win must survive: a read-only array indexed from a closure is still a legal hoist, because
+/// the Index arm deliberately does not count `X[i]` as a disqualifying use of `X`. Without this the
+/// fix would be a blanket "any closure mention disables hoisting" and would give back #594.
+const CLOSURE_READ_ONLY: &str = r#"
+let A: i32[] = [1, 2, 3]
+
+function readA(i: i32): i32 { return A[i] }
+
+export function run(): i32 {
+  let pick = () => { return A[1] }
+  return readA(0) + pick()
+}
+"#;
+
+#[test]
+fn read_only_module_array_still_hoists_when_a_closure_indexes_it() {
+    let rust = compile_gba("closure_read_only", CLOSURE_READ_ONLY);
+    assert!(
+        rust.contains("G_A"),
+        "a read-only module array must still hoist — that reachability is #594:\n{}",
+        rust
+    );
+}
+
+/// Not a gate — a probe that prints the emitted representation of a hoisted `i32[]` on GBA, so the
+/// f64-on-a-CPU-with-no-FPU question can be answered from generated code rather than assumption.
+#[test]
+#[ignore]
+fn probe_hoisted_array_representation() {
+    let rust = compile_gba("probe_repr", CLOSURE_READ_ONLY);
+    for line in rust.lines() {
+        if line.contains("G_A") {
+            println!("{}", line.trim());
+        }
+    }
+}
+
+/// The SECOND hole, found only because the first fix left queensblood at 4 errors instead of 12: the
+/// statement walker visited loop and branch BODIES but not their CONDITIONS. `.length` is a member
+/// use the walker already rejects — it was simply never reached in `while (i < X.length)`, which is
+/// how card-gba's `SB_FORCE`/`SB_PRE`/`TN_REWARD` (exported `i32[]` in qb-catalog.tish, consumed by
+/// qb-engine.tish:567 and main.tish:297) stayed eligible and hoisted.
+const COND_LENGTH: &str = r#"
+let A: i32[] = [1, 2, 3]
+
+function readA(i: i32): i32 { return A[i] }
+
+export function run(): i32 {
+  let i: i32 = 0
+  let n: i32 = 0
+  while (i < A.length) { n = n + readA(i); i = i + 1 }
+  return n
+}
+"#;
+
+#[test]
+fn a_use_in_a_loop_condition_disqualifies_the_hoist() {
+    let rust = compile_gba("cond_length", COND_LENGTH);
+    assert!(
+        !rust.contains("const G_A"),
+        "`.length` in a while-condition is a member use and must block the hoist:\n{}",
+        rust
+    );
+}
+
+/// Same shape, in an `if` condition — that arm had the identical omission.
+const IF_COND: &str = r#"
+let A: i32[] = [1, 2, 3]
+
+function readA(i: i32): i32 { return A[i] }
+
+export function run(): i32 {
+  if (A.length > 2) { return readA(0) }
+  return 0
+}
+"#;
+
+#[test]
+fn a_use_in_an_if_condition_disqualifies_the_hoist() {
+    let rust = compile_gba("if_cond", IF_COND);
+    assert!(
+        !rust.contains("const G_A"),
+        "`.length` in an if-condition must block the hoist:\n{}",
+        rust
+    );
+}

--- a/crates/tish_compile/tests/regr_gba_lowered_call_sites.rs
+++ b/crates/tish_compile/tests/regr_gba_lowered_call_sites.rs
@@ -647,3 +647,53 @@ fn a_use_in_an_if_condition_disqualifies_the_hoist() {
         rust
     );
 }
+
+// ── #594 residual, reported from tish-gba examples/hyrule ─────────────────────────────────────────
+//
+// Reported shape: a fn with NO PARAMS and NO RETURN that WRITES a module array, and IS CALLED. On
+// 3.3.0 that emitted the new `vm_read(&CELL)` module-scope capability without bringing the cell into
+// scope. Two facts from the report narrow it and are both encoded below:
+//   - the identical shape with NO callers compiles, because it is dead-code eliminated, so a repro
+//     MUST contain a call site;
+//   - inlining the body at the call site is a complete workaround.
+//
+// This is the `rangDone()` shape in hyrule's weapons.tish (`export function rangDone() { rangLive[0] = 0 }`),
+// which is the same `rangLive` E0425 that started this investigation.
+
+/// No params, no return, writes a module array, and — critically — is called.
+const WRITER_WITH_CALLER: &str = r#"
+let A: i32[] = [0, 0, 0]
+
+function readA(i: i32): i32 { return A[i] }
+
+function clearA() { A[0] = 0 }
+
+export function run(): i32 {
+  clearA()
+  return readA(0)
+}
+"#;
+
+#[test]
+fn a_called_no_param_no_return_module_array_writer_compiles() {
+    let rust = compile_gba("writer_with_caller", WRITER_WITH_CALLER);
+    // The array is written, so it must NOT have been hoisted…
+    assert!(
+        !rust.contains("const G_A"),
+        "a written module array must not be hoisted:\n{}",
+        rust
+    );
+    // …and no lowered free fn may reference the boxed cell, which lives in `run()`. A free `fn`
+    // mentioning `A` is precisely the E0425 the report describes.
+    for (i, line) in rust.lines().enumerate() {
+        let t = line.trim_start();
+        if t.starts_with("fn ") || t.starts_with("pub fn ") {
+            assert!(
+                !t.contains("clearA") || t.contains("_cell"),
+                "clearA must not be emitted as a free fn that cannot see module scope (line {}): {}",
+                i + 1,
+                t
+            );
+        }
+    }
+}

--- a/crates/tish_compile/tests/regr_gba_lowered_call_sites.rs
+++ b/crates/tish_compile/tests/regr_gba_lowered_call_sites.rs
@@ -310,8 +310,14 @@ console.log(R.length)
 #[test]
 fn a_module_const_array_is_reachable_from_a_lowered_fn_on_gba() {
     let rust = compile_gba("const_array_gba", CONST_ARRAY_READ);
+    // Element type is deliberately NOT pinned here — this test is about REACHABILITY (#594), and an
+    // all-integer table is now expected to hoist as `[i32; 8]` on GBA. The representation itself is
+    // pinned by `an_integral_module_const_array_is_emitted_as_i32_on_gba`.
     assert!(
-        rust.contains("const G_TABLE: [f64; 8]") || rust.contains("const G_table: [f64; 8]"),
+        rust.contains("const G_TABLE: [i32; 8]")
+            || rust.contains("const G_TABLE: [f64; 8]")
+            || rust.contains("const G_table: [i32; 8]")
+            || rust.contains("const G_table: [f64; 8]"),
         "a module const numeric array should get a top-level `const` on GBA (#594):\n{}",
         rust.lines().filter(|l| l.contains("TABLE")).take(4).collect::<Vec<_>>().join("\n")
     );
@@ -585,16 +591,61 @@ fn read_only_module_array_still_hoists_when_a_closure_indexes_it() {
     );
 }
 
-/// Not a gate — a probe that prints the emitted representation of a hoisted `i32[]` on GBA, so the
-/// f64-on-a-CPU-with-no-FPU question can be answered from generated code rather than assumption.
+// ── GBA representation: the hoist must not carry the host's f64 onto a CPU with no FPU ───────────
+//
+// ARM7TDMI has no hardware float. Hoisting `let A: i32[] = [1,2,3]` to `const G_A: [f64; 3]` cost
+// 8 bytes per element instead of 4, an `i32 -> f64 -> usize` round trip on every index, and an
+// `f64::NAN` out-of-range sentinel — while DISCARDING the element type the source had already
+// declared. These pin the integer representation.
+
 #[test]
-#[ignore]
-fn probe_hoisted_array_representation() {
-    let rust = compile_gba("probe_repr", CLOSURE_READ_ONLY);
-    for line in rust.lines() {
-        if line.contains("G_A") {
-            println!("{}", line.trim());
-        }
+fn an_integral_module_const_array_is_emitted_as_i32_on_gba() {
+    let rust = compile_gba("repr_int", CLOSURE_READ_ONLY);
+    assert!(
+        rust.contains("const G_A: [i32; 3]"),
+        "an all-integer module const array must hoist as [i32; N], not [f64; N]:\n{}",
+        rust
+    );
+    assert!(
+        !rust.contains("const G_A: [f64; 3]"),
+        "the f64 representation must be gone:\n{}",
+        rust
+    );
+}
+
+/// Non-integral values still need f64 — the narrowing is value-driven, not blanket.
+const FRACTIONAL: &str = r#"
+let P: number[] = [0.25, 0.5, 0.25]
+
+function readP(i: i32): number { return P[i] }
+
+export function run(): number {
+  let pick = () => { return P[1] }
+  return readP(0) + pick()
+}
+"#;
+
+#[test]
+fn a_fractional_module_const_array_stays_f64() {
+    let rust = compile_gba("repr_frac", FRACTIONAL);
+    assert!(
+        rust.contains("const G_P: [f64; 3]"),
+        "a fractional array must keep f64 — narrowing it would change its values:\n{}",
+        rust
+    );
+}
+
+/// The out-of-range read still has to answer NaN. There is no `i32` meaning "absent", so the
+/// bounds-checked form widens rather than inventing a sentinel that would read as a real element.
+#[test]
+fn an_unproven_index_still_answers_nan() {
+    let rust = compile_gba("repr_int", CLOSURE_READ_ONLY);
+    if rust.contains("f64::NAN") {
+        assert!(
+            rust.contains("as f64"),
+            "an i32-backed out-of-range read must widen before yielding NaN:\n{}",
+            rust
+        );
     }
 }
 

--- a/crates/tish_compile/tests/regr_gba_lowered_call_sites.rs
+++ b/crates/tish_compile/tests/regr_gba_lowered_call_sites.rs
@@ -748,3 +748,90 @@ fn a_called_no_param_no_return_module_array_writer_compiles() {
         }
     }
 }
+
+// ── #600: `let s: string = strArr[i]` moves out of the Vec ────────────────────────────────────────
+const STR_ELEM_BIND: &str = r#"
+let NAMES: string[] = ["alpha", "beta"]
+
+export function show(i: i32): string {
+  let name: string = NAMES[i]
+  return name
+}
+"#;
+
+#[test]
+fn binding_a_string_element_clones_instead_of_moving() {
+    let rust = compile_gba("str_elem_bind", STR_ELEM_BIND);
+    let bad = rust.lines().any(|l| {
+        let t = l.trim();
+        t.contains("= NAMES[") && !t.contains(".clone()") && !t.contains("&NAMES[")
+    });
+    assert!(
+        !bad,
+        "a string element read must clone — a bare index is a move out of the Vec (E0507):\n{}",
+        rust.lines().filter(|l| l.contains("NAMES[")).take(4).collect::<Vec<_>>().join("\n")
+    );
+}
+
+// ── #599: a written module-level `let x: i32` ────────────────────────────────────────────────────
+const MODULE_SCALAR_WRITE: &str = r#"
+let counter: i32 = 0
+
+function bump() { counter = counter + 1 }
+
+export function run(): i32 {
+  bump()
+  return counter
+}
+"#;
+
+#[test]
+fn a_written_module_scalar_reads_and_writes_through_the_same_cell() {
+    let rust = compile_gba("module_scalar_write", MODULE_SCALAR_WRITE);
+    // If reads go through a cell, writes must too. A bare `counter = <i32>` against a VmRef<i32>
+    // is E0308 — the two halves disagreeing is the bug.
+    for line in rust.lines() {
+        let t = line.trim();
+        if t.starts_with("counter = ") && !t.contains("vm_write") {
+            panic!(
+                "write must match the read's representation (#599):\n{}",
+                rust.lines().filter(|l| l.contains("counter")).take(6).collect::<Vec<_>>().join("\n")
+            );
+        }
+    }
+}
+
+// ── #597: a typed array passed to a function is COPIED, not aliased ───────────────────────────────
+//
+// `let reqs: i32[] = []` lowers to `Vec<i32>`, but a call site marshals a FRESH `Value::Array` from
+// its elements. The callee's pushes land in the copy and the caller's array stays empty — silently,
+// with no error at compile time or run time. An UNTYPED array passes the same `VmRef` and aliases
+// correctly, so adding an annotation changes program behaviour rather than just representation.
+//
+// The fix cannot live at the call site: building a `Value::Array` out of a `Vec<i32>` is a copy by
+// construction. An array that escapes into a boxed call has to stay boxed.
+const ARRAY_ESCAPES: &str = r#"
+function fill(out) {
+  out.push(1)
+}
+
+export function run(): i32 {
+  let reqs: i32[] = []
+  fill(reqs)
+  return reqs.length
+}
+"#;
+
+#[test]
+fn a_typed_array_passed_to_a_function_is_not_copied() {
+    let rust = compile_gba("array_escapes", ARRAY_ESCAPES);
+    let copied = rust.lines().find(|l| {
+        l.contains("Value::Array(VmRef::new(") && l.contains("reqs") && l.contains(".iter()")
+    });
+    assert!(
+        copied.is_none(),
+        "a typed array passed to a fn was marshalled as a fresh copy — the callee's writes are \
+         silently lost (#597):\n  {}",
+        copied.unwrap_or("")
+    );
+}

--- a/crates/tish_compile/tests/regr_gba_lowered_call_sites.rs
+++ b/crates/tish_compile/tests/regr_gba_lowered_call_sites.rs
@@ -835,3 +835,57 @@ fn a_typed_array_passed_to_a_function_is_not_copied() {
         copied.unwrap_or("")
     );
 }
+
+// ── #629: module bindings are emitted in SOURCE ORDER — a fn referencing a LATER binding breaks ───
+//
+// The variable is ORDER, nothing else. Module-level bindings are emitted into `run()` where they
+// appear, but the function values that capture them are emitted at their own source position, so a
+// function declared ABOVE its binding captures a name that is not in scope yet:
+//
+//     let rangDone = { Value::native(move |args| { … vm_read(&rangLive) … }) };   // use
+//     let rangLive = VmRef::new(vec![(0_f64) as i32]);                            // declaration
+//
+// This is legal tish — the function is not CALLED before the binding is initialised.
+//
+// The fixture pinned in 57d6aa1be for this got it wrong: it declared `let A` FIRST, so it passed
+// while the bug was live and proved nothing. Moving the declaration is the whole difference, which
+// is why the earlier reduction "reproduced" on neither compiler. Hits readers and writers alike.
+const FORWARD_REF: &str = r#"
+function readA(i: i32): i32 { return A[i] }
+function clearA() { A[0] = 0 }
+
+let A: i32[] = [0, 0, 0]
+
+export function run(): i32 {
+  clearA()
+  return readA(0)
+}
+"#;
+
+#[test]
+fn a_fn_may_reference_a_module_binding_declared_after_it() {
+    let rust = compile_gba("forward_ref", FORWARD_REF);
+    // Find where `A` is DECLARED and where it is first USED. A use above the declaration is the bug.
+    let decl = rust
+        .lines()
+        .position(|l| {
+            let t = l.trim();
+            t.starts_with("let A = ") || t.starts_with("let A:") || t.starts_with("let mut A")
+        });
+    let first_use = rust.lines().position(|l| {
+        let t = l.trim();
+        (t.contains("vm_read(&A)") || t.contains("(&A)") || t.contains("A.borrow"))
+            && !t.starts_with("let A")
+    });
+    if let (Some(d), Some(u)) = (decl, first_use) {
+        assert!(
+            u > d,
+            "#629: `A` is used at line {} but only declared at line {} — use before declaration \
+             (E0425). Module bindings must be emitted ahead of the function values that capture \
+             them.\n{}",
+            u + 1,
+            d + 1,
+            rust.lines().skip(d.saturating_sub(6)).take(12).collect::<Vec<_>>().join("\n")
+        );
+    }
+}

--- a/regression/downstream/repos.tsv
+++ b/regression/downstream/repos.tsv
@@ -64,3 +64,30 @@ tish-tailwind	local:~/Projects/tish-audio/tish-tailwind	.	tish	bash -c 'f=$(find
 dune-server	local:~/Projects/dune/dune-ide	.	tish	TISH_HTTP_BACKEND=hyper tish build --target native --feature http,http-hyper,fs,process,ws,pty -o /tmp/_dune_server apps/dune-server/dune-server.tish	pass
 spider3-tish	git:https://github.com/schlopai/spider-gwen-webgpu.git@main	.	tish	bash -c 'rc=0; while IFS= read -r f; do tish build --target js "$f" -o /tmp/_s.js >/tmp/_s.err 2>&1 || { echo "FAIL: $f"; head -2 /tmp/_s.err; rc=1; }; done < <(find . -name "*.tish" -not -path "*/node_modules/*" -not -path "*/vendor/*" -not -path "*/dist/*"); exit $rc'	pass
 spacekinematics	git:https://github.com/spacedevin/solar-system-webgpu.git@main	.	tish	bash -c 'rc=0; while IFS= read -r f; do tish build --target js "$f" -o /tmp/_s.js >/tmp/_s.err 2>&1 || { echo "FAIL: $f"; head -2 /tmp/_s.err; rc=1; }; done < <(find . -name "*.tish" -not -path "*/node_modules/*" -not -path "*/vendor/*" -not -path "*/sgp4-wasm/*"); exit $rc'	pass
+#
+# ── ADDED: non-GBA target coverage. The GBA work changes shared codegen (module-const hoisting,
+# array lowering, i32 stores), so the suite needs consumers that exercise the paths GBA does NOT:
+# the INTERPRETER (`tish run`), the JS backend, and a NATIVE build with a real feature set. Each row
+# below was picked for the target it covers, not just for being written in tish.
+#
+# tishdoc-parse: `tish run` over a golden-file test suite — the only downstream row that exercises
+# the INTERPRETER end to end, which is where a semantic divergence would show up first.
+# xfail: its parse suite passes, then `golden_note.tish` dies with `Uncaught FAIL title`. Confirmed
+# IDENTICAL on tish 3.3.0 (b9c39feaa), so it is a pre-existing break in that repo, not a regression
+# — recorded as xfail rather than dropped, so the row flags if it ever starts passing.
+tishdoc-parse	git:https://github.com/tishlang/tishdoc-parse.git@main	.	tish	npm test	xfail
+# scii: `tish build --target native` with http,timers,process,tty,fs — the widest native feature set
+# of any consumer here. On a feature branch, so local: (skipped in CI).
+# xfail: the COMPILER FRONTEND spins at 100% CPU indefinitely on this entry point — 40+ minutes with
+# no rustc ever spawned, so it is not a slow native build. Confirmed identical on 3.3.0, so it is a
+# pre-existing compiler hang, not a regression from the GBA work. It deserves its own issue; kept
+# here as xfail so the row flags the day it starts terminating.
+# The `timeout 240` is load-bearing, not caution: the runner does NOT cap a repo's command, and
+# this one never terminates, so without it a single xfail row eats the whole suite's budget and the
+# run looks hung rather than reporting.
+scii	local:~/Projects/scii	.	tish	bash -c 'timeout 240 tish build src/tui/interactive.tish -o /tmp/_scii --feature http,timers,process,tty,fs'	xfail
+# deck: the JS backend, on a real library build (transpile + exports append).
+deck	local:~/Projects/deck	.	tish	bash -c 'tish build src/index.tish -o /tmp/_deck.js --target js'	pass
+# tish-hub: DROPPED, not xfail. Its App.tish fails at PARSE — `Expected { }, * as name, or default
+# import` — so the repo uses an import syntax this tish does not accept, and the row would test the
+# parser's opinion rather than the JS backend it was added for. `deck` already covers the JS target.


### PR DESCRIPTION
Started as a fix for four ROMs that stopped building on 3.3.0, and grew to cover the cluster of
typed-lowering divergences that came out of the same passes. Four commits, each independently
verified.

Closes #597, #599, #600, #611. Does **not** close #594 — see the end.

---

## 1. The hoist admission check was permissive by default (the 3.3.0 regression)

`collect_module_const_f64_arrays` moves a module-level numeric array into a top-level `const G_X` so
a lowered fn can reach it — the reachability #594 exists to provide. Whether that is safe is decided
by `walk_{expr,stmt}_for_module_const_disqualifiers`, an **admission check**: the transform happens
unless the walker objects.

Both walkers were permissive by default. Silence meant "safe", so any AST shape the `match` did not
enumerate was waved through. Two shapes were missing, and each let an array that is *written* get
hoisted anyway:

1. **No `Expr::ArrowFunction` arm** — every use inside a closure fell into the terminal `_ => {}`.
2. **Conditions were never visited** — the statement walker walked loop and branch *bodies* only, so
   `while (i < X.length)` was invisible. `If`, `For`, `Switch` and `Throw` had the same omission.

The result does not compile. Within one generated statement the read renames and the write does not:

```rust
{ let __v = (G_RULESEL[0] - 1_f64); (*RULESEL.borrow_mut())[__i] = __v; }
//            ^^ renamed              ^^ not renamed — and declared later
```

→ `error[E0425]: cannot find value RULESEL in this scope`, on a name the game never misspelled.
Renaming the write would not have been a fix either: a `const` cannot be assigned through, so a
written array must not be hoisted at all.

**Why the fix is structural rather than two new arms.** Patching only the reported shapes invited a
third round — with just the closure arms, gwent went 46→0 and triad 11→1, but queensblood stayed at
**4**, and those four were all the condition gap. So both terminal arms are now conservative: an
unmodelled shape disqualifies if the name appears beneath it.

**But "conservative" had to be bounded by what the emitter can actually do**, and my first cut was
too blunt — it broke two supported optimisations that *depended* on the blind spots:

- `for (x of X)` lowers to a native index loop over the hoisted static, so the name never survives;
- `X.join(", ")` emits the object through the `Value` bridge.

Both are rewritten by the emitter and must not disqualify. A member **read** like `X.length` still
must, because it lowers to a bare `X.len()`. The rule is *"any use the emitter does not rewrite"*,
not *"any use"*.

## 2. GBA representation: `[i32; N]`, not `[f64; N]`

ARM7TDMI has no FPU. These passes were written for the host, where `f64` is tish's number and the
representation is free; enabling them on GBA carried that assumption onto a target where every `f64`
touch is a soft-float call and every element costs 8 bytes instead of 4 — while **discarding a type
the source had already declared**. For `let A: i32[] = [1,2,3]`:

```rust
const G_A: [f64; 3] = [1_f64, 2_f64, 3_f64];
{ let _i = &Value::Number((i) as f64); … *n as usize };   // i32 -> f64 -> usize per index
```

Integral arrays now hoist as `[i32; N]`, and a proven-in-bounds read reports `I32` so the consumer
stays in the integer domain. Deliberately **not** narrowed, in each case because narrowing is wrong:

- fractional arrays keep `f64` — narrowing `[0.25, 0.5, 0.25]` changes the values;
- an out-of-range read still answers `f64::NAN`. There is no `i32` meaning "absent", and a sentinel
  would silently turn a missing element into a real one;
- `_cum` arrays and the fasta ladder are untouched — that path is specialised around f64 arms.

Confirmed in generated code, not inferred from size: queensblood emits 68 integer const arrays and
zero f64 ones, hyrule 27 and zero, including `G_DROP_ROW: [i32; 128]` — 1 KB of f64 now 512 bytes.

## 3. Four typed-lowering divergences

Each is a place where adding an annotation changed program **behaviour**, not just representation.

| | cause | fix |
| --- | --- | --- |
| **#597** | a native `Vec` handed to `value_call` is marshalled as a **fresh** `Value::Array` — a copy by construction, so the callee's pushes are lost silently | an array forwarded into a call stays boxed; decided at the declaration, since no call-site spelling avoids the copy |
| **#599** | the `I32` assign branch had three store paths, **none** checking `refcell_wrapped_vars`, while its narrow-int neighbour does | all three route through the same cell-aware store |
| **#600** | a non-`Copy` element read emitted a bare `NAMES[i]` — a move out of the `Vec` | clone for `String` elements |
| **#611** | grow-to-index resize existed for `F64\|Bool` but not `I32` | add `I32`, pad `0` |

Three judgment calls worth surfacing:

- **#597 is GBA-gated.** The reporter verified `tish run` and native `tish build` both alias
  correctly — it is a target divergence. An ungated cut deopted host code and was caught by an
  existing host test (`escaping_array_keeps_oob_safe_lowering`).
- **`forwarded`, not `escaped`.** The latter also covers `return arr`, which hands ownership out and
  creates no aliasing hazard; using it deopted a legitimately native array. Reuses
  `scan_param_use` — the analysis the read-only param path already trusts for this hazard — rather
  than a second one that can drift.
- **#600 does not fix #571.** The struct case looks identical but must not clone at that site:
  `states[id].timer` projects a field out of the place, and cloning would copy the whole struct per
  field read — the O(n) footgun #558 is about.

---

## Verification

**Compiler:** full `-p tishlang_compile` suite green, 32 test binaries, 0 failures.

**On device — these are wrong-*value* bugs, so a green build proves nothing.** Each issue's own
repro, run under `GBA_SHOT_LOG=1`:

| | result | was |
| --- | --- | --- |
| #597 | `length: 1` | `0`, silently |
| #611 | `len 4 v 7` | write lost |
| #599 | `counter 1` | E0308 |
| #600 | `alpha` | E0507 |

**Behavioural suites** — the check that actually matters here, since array representation and
lowering changed underneath these games. Re-run on this branch; **every number matches the
pre-3.3.0 baseline exactly**:

| ROM | result |
| --- | --- |
| triad | `CAMP 128/128 passed` |
| gwent | `ST 16/16` · `CAMP 40/40` · `AT 112/112 passed` |
| queensblood | `AT 48/48 passed` |

**Builds:** all five ROMs from clean. The 3.3.0 error counts below are the downstream report, not my
own measurement — I never built card-gba on 3.3.0:

| ROM | on 3.3.0 (reported) | now |
| --- | --- | --- |
| gwent | 46 errors | 3,706,448 B |
| queensblood | 12 errors | 3,818,696 B |
| triad | 11 errors | 3,538,800 B |
| hyrule | 1 error | 3,277,040 B |
| ffta | — (control) | 4,460,088 B |

## Cost, recorded rather than buried

#597's fix boxes every array forwarded into a call, and that is not free — it very nearly cancels
the size win from the i32 representation change (+1 KB to +17 KB per ROM). The trade is deliberate:
a silent wrong value is worse than a slower correct one. But the deopt is broader than it needs to
be — it boxes on the *possibility* of mutation, not the fact. Recovering that means proving every
callee read-only, which `arr_param_readonly_fns` already does from the parameter side. Left as a
follow-up, because getting it wrong reintroduces the silent case this removes.

## Known gaps

- **Does not close #594.** A residual is reported downstream — a no-param/no-return fn that writes a
  module array and is called. My reduction of that shape **builds on 3.3.0 as well as on this
  branch**, so it does not reproduce the bug and proves nothing. The test is kept as a regression
  pin, not as a demonstration. Commented there with what would actually pin it.
- **hyrule is weaker evidence than the other three ROMs.** Its repro shape (`rangDone()`) was inlined
  away in that repo's working tree during this investigation — the documented workaround. A game that
  has applied the workaround is no longer a test of the bug.
- **The sibling scalar pass has the same condition-blindness**, currently latent:
  `walk_{expr,stmt}_for_global_disqualifiers` walks bodies but not conditions. Not fixed here to keep
  this PR to one defect.
