### PR TITLE
fix(native): #630 — detect_native_vec_fns livelocks (two fixpoints re-adding what the other rejects)

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -20706,6 +20706,14 @@ impl Codegen {
                 }
             }
         }
+        // #630: A NAME REMOVED HERE IS REJECTED FOR GOOD. `collect_bad_vec_callsites` is a
+        // SOUNDNESS verdict — the fn is called somewhere in a way the native-vec ABI cannot
+        // represent — and that fact is a property of the program, which does not change during this
+        // analysis. Re-admitting it later can only produce the same wrong answer.
+        //
+        // Recording it is also what makes the forwarding fixpoint below terminate; see the note
+        // there.
+        let mut rejected: std::collections::HashSet<String> = std::collections::HashSet::new();
         loop {
             let mut remove: Vec<String> = Vec::new();
             for s in &program.statements {
@@ -20717,6 +20725,7 @@ impl Codegen {
                 break;
             }
             for n in remove {
+                rejected.insert(n.clone());
                 sigs.remove(&n);
             }
             if sigs.is_empty() {
@@ -20752,6 +20761,22 @@ impl Codegen {
                     if Self::ann_is_simple(return_type.as_ref(), "fixed") {
                         continue;
                     }
+                    // #630: AND IT MUST NOT RE-ADD A NAME THE REMOVAL PASS ALREADY REJECTED. This is
+                    // what makes the analysis terminate. Without it the two fixpoints fight: the
+                    // forwarding pass admits `F`, the removal pass below proves `F` unsound and
+                    // drops it, `added` is true so the outer loop runs again, and `F` — re-evaluated
+                    // against a program that has not changed — is admitted again. Forever.
+                    //
+                    // The only exits were `!added` and `sigs.is_empty()`, and an oscillating pair
+                    // satisfies neither: measured on the reporter's project it sat at a steady
+                    // `sigs=3` for 200+ iterations at 100% CPU, with no cargo child and nothing
+                    // printed, which is why it read as a dead build rather than a slow one.
+                    //
+                    // With this guard every outer iteration must admit a name never admitted before,
+                    // so the loop is bounded by the number of top-level fns.
+                    if rejected.contains(name.as_ref()) {
+                        continue;
+                    }
                     if let Some(sig) = Self::infer_vec_fn_sig_forwarding(params, body, &sigs) {
                         let has_array_param = sig
                             .params
@@ -20778,6 +20803,7 @@ impl Codegen {
                     break;
                 }
                 for n in remove {
+                    rejected.insert(n.clone());
                     sigs.remove(&n);
                 }
                 if sigs.is_empty() {

--- a/regression/downstream/repos.tsv
+++ b/regression/downstream/repos.tsv
@@ -79,12 +79,25 @@ tishdoc-parse	git:https://github.com/tishlang/tishdoc-parse.git@main	.	tish	npm 
 # scii: `tish build --target native` with http,timers,process,tty,fs — the widest native feature set
 # of any consumer here. On a feature branch, so local: (skipped in CI).
 # xfail: the COMPILER FRONTEND spins at 100% CPU indefinitely on this entry point — 40+ minutes with
-# no rustc ever spawned, so it is not a slow native build. Confirmed identical on 3.3.0, so it is a
-# pre-existing compiler hang, not a regression from the GBA work. It deserves its own issue; kept
-# here as xfail so the row flags the day it starts terminating.
-# The `timeout 240` is load-bearing, not caution: the runner does NOT cap a repo's command, and
-# this one never terminates, so without it a single xfail row eats the whole suite's budget and the
-# run looks hung rather than reporting.
+# no rustc ever spawned. That was #630 — `detect_native_vec_fns` livelocked: its forwarding fixpoint
+# re-admitted a fn its removal fixpoint had just rejected, so neither exit condition (`!added`,
+# `sigs.is_empty()`) was ever reached. FIXED in this branch: the analysis now completes and the build
+# reaches codegen.
+#
+# STILL xfail, for a DIFFERENT reason the hang was masking. Past the analysis, codegen fails with
+# `error[E0425]: cannot find value HELP_COLUMNS` — a cross-module forward reference: `export let
+# HELP_COLUMNS` in src/ui/view.tish is emitted after top-level code that reads it. That is #629's
+# class, not #630's, and it is not fixable by the module-statement reorder shipped for #629, which
+# deliberately refuses to move a declaration over STRAIGHT-LINE code (there a mention is either a
+# use-before-init or a reference to an earlier binding). It needs module-ordering work.
+#
+# Note this reproduces only with the LOCAL workspace lattish wired in, which is what the runner does
+# and what a plain `tish build` in the repo does not — so a direct build of the same entry point can
+# succeed while this row fails. Do not take a green local build as evidence for this row.
+#
+# The `timeout 240` STAYS, and is load-bearing rather than caution: the runner does not cap a repo's
+# command, so if the livelock ever returns, the row reports a failure instead of consuming the whole
+# suite's budget and making the run look hung — which is exactly how #630 first presented.
 scii	local:~/Projects/scii	.	tish	bash -c 'timeout 240 tish build src/tui/interactive.tish -o /tmp/_scii --feature http,timers,process,tty,fs'	xfail
 # deck: the JS backend, on a real library build (transpile + exports append).
 deck	local:~/Projects/deck	.	tish	bash -c 'tish build src/index.tish -o /tmp/_deck.js --target js'	pass


### PR DESCRIPTION
Fixes #630.

## It is a livelock, not a cost problem

The issue reasonably reads as "project-sized ASTs are expensive" — the sampled stack is dominated by
`detect_native_vec_fns` → `collect_bad_vec_callsites` → deep recursive walks. It is not. The pass
never terminates, on any input that hits the shape, regardless of size.

`detect_native_vec_fns` runs two fixpoints, and they fight:

```rust
loop {                              // forwarding fixpoint
    if eligible { sigs.insert(name); added = true; }
    if !added { break; }            // only exit
    loop { ... sigs.remove(n) ... } // removal can undo that insert
    if sigs.is_empty() { break; }   // the other only exit
}
```

The forwarding pass admits `F`. The removal pass proves `F` unsound and drops it. `added` is true, so
the outer loop runs again — and `F`, re-evaluated against a program that has not changed, is admitted
again. Neither exit condition is ever reached: something *was* added, and `sigs` is not empty.

Confirmed by instrumenting the outer loop and building the reporter's project: **a steady `sigs=3`
across 200+ iterations**, no growth, no convergence. That is why it presents as a dead build — 100%
CPU, no cargo child, nothing printed.

## Fix

A rejection set. `collect_bad_vec_callsites` is a **soundness verdict** — the fn is called somewhere
in a way the native-vec ABI cannot represent — and it is a property of the program, which does not
change during this analysis. A name it rejects can never legitimately be re-admitted; doing so can
only reproduce the same wrong answer.

So rejections are recorded, and the forwarding fixpoint skips any name already rejected. That is
correct on its own terms, and it is also what bounds the loop: every outer iteration must now admit a
name never admitted before, so it terminates in at most the number of top-level fns.

**This does not narrow eligibility.** The guard only suppresses re-admission of a name the removal
pass already proved unsound. Since that verdict is deterministic over an unchanged program, a name
that would survive removal is never rejected in the first place, so it is never skipped here.

## Verification

| | |
| --- | --- |
| reporter's repro (`scii`, `--feature http,timers,process,tty,fs`) | never terminated → **`Built:` in 52s** |
| `tishlang_compile` | 190 tests, 0 failures |
| `integration_test` | 25 passed, 0 failed |
| perf gauntlet | soundness clean; `spectral_norm` 65.00x, `nbody` 119.98x, `matmul` 9.56x — no eligibility lost |
| downstream regression | 21 PASS, 0 regressions |

The gauntlet matters more than the unit suites here: native-vec eligibility is exactly what its
typed-vs-boxed ratios measure, so a fix that quietly stopped admitting functions would show up there
as a lost speedup rather than as a failing test. `spectral_norm` is the specific fixture the
forwarding fixpoint exists for (`multiplyAtAv` threading arrays into `multiplyAv`/`multiplyAtv`), so
that is where over-rejection would surface first. It held at 65.00x.

## `scii` is unblocked but still does not build — and that is NOT this bug

The reporter's project now gets past the analysis, which is what #630 is. Codegen then fails with

```
error[E0425]: cannot find value `HELP_COLUMNS` in this scope
```

a CROSS-MODULE forward reference — `export let HELP_COLUMNS` in `src/ui/view.tish` emitted after
top-level code that reads it. That is #629's class and needs module-ordering work; the
module-statement reorder shipped for #629 deliberately refuses to move a declaration over
straight-line code, where a mention is either a use-before-init or a reference to an earlier binding.
Filed separately.

The downstream row therefore stays `xfail`, with the distinction recorded, rather than being flipped
green on a repo that does not build. One trap worth repeating from the manifest note: this only
reproduces with the LOCAL workspace lattish wired in, which is what the runner does and a plain
`tish build` in the repo does not — so a direct build of the same entry point can succeed while the
row fails.

## Deliberately not in this PR

The issue raises three asks. Only the first is addressed:

1. **Cap / cache / incrementalize the pass** — moot. There is nothing to cap once the loop cannot
   cycle; capping would have hidden the livelock behind a bound rather than fixing it.
2. **Progress logging before nested cargo** — real and worth doing. A cold `lto = "fat"` +
   `codegen-units = 1` build of `tishlang_runtime` genuinely looks hung for minutes. It is a separate
   change to `run_cargo_build` (which uses `Command::output()`, so nothing streams) and does not
   belong in a correctness fix.
3. **`find_runtime_path_for_project` prefers the npm runtime over the local checkout**, producing
   cargo API skew (`get_prop_ic`) — a real trap, unrelated mechanism, deserves its own issue.
