### PR TITLE
fix(resolve): #587 — colliding exported names across modules must be isolated too (JS hoisting → infinite recursion)

### DIFF
--- a/crates/tish/tests/scope_merge.rs
+++ b/crates/tish/tests/scope_merge.rs
@@ -108,3 +108,93 @@ fn scope_tish_crate_routes_native() {
         "@scope package with tish.crate must NOT be merged as Tish source"
     );
 }
+
+// ── #587: two modules exporting the SAME name, flattened into one scope ──────────────────────────
+//
+// `isolate_private_top_level_bindings` renamed colliding PRIVATE top-level names but skipped
+// exported ones, on the reasoning that "exported names stay stable so imports keep resolving".
+// `module_exports` is an indirection from export name to source symbol, so that was stricter than
+// necessary — and leaving the collision produced a silently WRONG program rather than a slower one.
+//
+// The barrel pattern is where it bites: `import { greet as _greet }` + a local `export fn greet`
+// that calls `_greet`. Flattened, that emits two `function greet` declarations, and because JS
+// function declarations HOIST, the second overwrote the first BEFORE `const _greet = greet` ran.
+// `_greet` then pointed at the wrapper and the program recursed until the stack blew.
+//
+// The entry module is excluded from renaming on purpose: its exports are the bundle's public
+// surface, so moving those would change the API the caller sees. Only the dep is renamed here.
+
+/// dep exports `greet`; barrel imports it aliased and re-exports its own `greet` wrapper.
+fn setup_barrel() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::create_dir_all(root.join("dep")).unwrap();
+    fs::create_dir_all(root.join("app")).unwrap();
+    fs::write(
+        root.join("dep/lib.tish"),
+        "export fn greet(name) { return \"hi \" + name }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("app/barrel.tish"),
+        "import { greet as _greet } from \"../dep/lib.tish\"\n\
+         export fn greet(name) { return _greet(name) }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("main.tish"),
+        "import { greet } from \"./app/barrel.tish\"\nconsole.log(greet(\"world\"))\n",
+    )
+    .unwrap();
+    dir
+}
+
+#[test]
+fn colliding_exported_names_are_isolated_across_modules() {
+    let dir = setup_barrel();
+    let root = dir.path();
+    let modules = resolve_project(&root.join("main.tish"), Some(root)).expect("resolve");
+    let merged = merge_modules(modules).expect("merge");
+
+    // The two `greet` declarations must not both be named `greet` in the flat program — that is the
+    // collision, and on the JS target hoisting silently resolves it the wrong way.
+    let greet_decls: Vec<&str> = merged
+        .program
+        .statements
+        .iter()
+        .filter_map(|s| match s {
+            Statement::FunDecl { name, .. } => Some(name.as_ref()),
+            _ => None,
+        })
+        .filter(|n| n.starts_with("greet"))
+        .collect();
+    assert!(
+        greet_decls.len() >= 2,
+        "expected both modules' greet fns in the merged program, got {:?}",
+        greet_decls
+    );
+    let bare = greet_decls.iter().filter(|n| **n == "greet").count();
+    assert!(
+        bare <= 1,
+        "two top-level `greet` declarations survived the merge — on the JS target the later one \
+         hoists over the former and the barrel's alias captures the wrapper (infinite recursion). \
+         Got {:?}",
+        greet_decls
+    );
+
+    // The alias must bind to the DEP's symbol, not to the local wrapper.
+    let alias_target = merged.program.statements.iter().find_map(|s| match s {
+        Statement::VarDecl {
+            name,
+            init: Some(Expr::Ident { name: src, .. }),
+            ..
+        } if name.as_ref() == "_greet" => Some(src.to_string()),
+        _ => None,
+    });
+    if let Some(target) = alias_target {
+        assert_ne!(
+            target, "greet",
+            "`_greet` must not bind to the ambiguous bare `greet`; it should name the dep's symbol"
+        );
+    }
+}

--- a/crates/tish_compile/src/resolve.rs
+++ b/crates/tish_compile/src/resolve.rs
@@ -1445,10 +1445,26 @@ fn collect_destructure_names(pattern: &DestructPattern, out: &mut HashSet<String
 
 /// Rename each module's non-exported top-level bindings whose name also occurs as a top-level
 /// name in another module, isolating module-private declarations (#97).
-fn isolate_private_top_level_bindings(modules: &mut [ResolvedModule]) {
+///
+/// #587: this ALSO covers colliding EXPORTED names in non-entry modules, returning
+/// `renamed symbol -> original export name` per module so the export table can still be keyed by the
+/// name importers ask for. The original carve-out ("exported names stay stable so imports keep
+/// resolving") was stricter than necessary: `module_exports` is already an INDIRECTION from export
+/// name to source symbol, so the symbol is free to move as long as the key does not.
+///
+/// Leaving exported collisions alone was not merely a missed optimisation — it silently produced a
+/// wrong program. Two modules exporting `greet`, flattened into one scope, emit two
+/// `function greet` declarations; JS function declarations HOIST, so the second overwrote the first
+/// before `const _greet = greet` ran, and a barrel that re-wrapped its own import recursed until the
+/// stack blew.
+///
+/// The ENTRY module is deliberately excluded: its exports are the bundle's public surface, so
+/// renaming them would change the API the caller sees.
+fn isolate_private_top_level_bindings(modules: &mut [ResolvedModule]) -> Vec<HashMap<String, String>> {
     let n = modules.len();
+    let mut export_renames: Vec<HashMap<String, String>> = vec![HashMap::new(); n];
     if n < 2 {
-        return; // a single module cannot collide with another
+        return export_renames; // a single module cannot collide with another
     }
     let mut decls: Vec<HashSet<String>> = vec![HashSet::new(); n];
     let mut exported: Vec<HashSet<String>> = vec![HashSet::new(); n];
@@ -1471,13 +1487,35 @@ fn isolate_private_top_level_bindings(modules: &mut [ResolvedModule]) {
             *count.entry(name.as_str()).or_insert(0) += 1;
         }
     }
+    // #587: for EXPORTED names the question is different, and `occupancy` answers the wrong one.
+    // It counts import bindings, so a dep's exported `greet` looks like it collides with the
+    // importer's binding of that same `greet` — but those are one thing, not two, and renaming on
+    // that basis breaks nothing yet churns every ordinary import. A real collision is another module
+    // DECLARING the name, so exported renames key off declarations only.
+    let mut decl_count: HashMap<&str, usize> = HashMap::new();
+    for d in &decls {
+        for name in d {
+            *decl_count.entry(name.as_str()).or_insert(0) += 1;
+        }
+    }
     for (i, m) in modules.iter_mut().enumerate() {
+        let is_entry = i + 1 == n; // the entry module is last — its exports are the public surface
         let mut renames: HashMap<String, Arc<str>> = HashMap::new();
         for name in &decls[i] {
-            if exported[i].contains(name) {
-                continue; // exported names stay stable so imports keep resolving
+            if count.get(name.as_str()).copied().unwrap_or(0) <= 1 {
+                continue; // no collision — leave it exactly as it is (zero blast radius)
             }
-            if count.get(name.as_str()).copied().unwrap_or(0) > 1 {
+            if exported[i].contains(name) {
+                // #587: an exported collision in a NON-ENTRY module is renamed too, and the new
+                // symbol is recorded so `module_exports` can still answer to the original name.
+                // Gated on DECLARATION count — see the note above.
+                if is_entry || decl_count.get(name.as_str()).copied().unwrap_or(0) <= 1 {
+                    continue;
+                }
+                let renamed = format!("{name}__m{i}");
+                export_renames[i].insert(renamed.clone(), name.clone());
+                renames.insert(name.clone(), Arc::from(renamed));
+            } else {
                 renames.insert(name.clone(), Arc::from(format!("{name}__m{i}")));
             }
         }
@@ -1491,6 +1529,7 @@ fn isolate_private_top_level_bindings(modules: &mut [ResolvedModule]) {
             rewrite_stmt_scope(stmt, &mut active, true);
         }
     }
+    export_renames
 }
 
 /// Apply the rename for a *declared* name. At module top level the binding is the canonical
@@ -1896,7 +1935,7 @@ pub fn merge_modules(mut modules: Vec<ResolvedModule>) -> Result<MergedProgram, 
     }
 
     // #97: isolate module-private top-level bindings before they are flattened together.
-    isolate_private_top_level_bindings(&mut modules);
+    let export_renames = isolate_private_top_level_bindings(&mut modules);
 
     let path_to_idx: HashMap<PathBuf, usize> = modules
         .iter()
@@ -1916,7 +1955,14 @@ pub fn merge_modules(mut modules: Vec<ResolvedModule>) -> Result<MergedProgram, 
                             }
                             _ => continue,
                         };
-                        module_exports[idx].insert(name.clone(), name);
+                        // #587: if this symbol was renamed for an exported collision, the export
+                        // table must still answer to the name importers ask for — key by the
+                        // ORIGINAL, point at the renamed symbol.
+                        let key = export_renames[idx]
+                            .get(&name)
+                            .cloned()
+                            .unwrap_or_else(|| name.clone());
+                        module_exports[idx].insert(key, name);
                     }
                     ExportDeclaration::Default(_) => {
                         let default_name = format!("__default_{}", idx);


### PR DESCRIPTION
fix(resolve): #587 — colliding EXPORTED names across modules must be isolated too

Two modules exporting the same name are flattened into one scope, and nothing renamed either of
them, so the emitted JS declared the name twice:

    function greet (name) { return "hi " + name }   // dep
    const _greet = greet;                           // binds to the LATER greet
    function greet (name) { return _greet(name) }   // barrel

JS function declarations HOIST, so the second overwrote the first BEFORE `const _greet = greet` ran.
`_greet` then pointed at the wrapper rather than the import, and the barrel recursed until the stack
blew — `RangeError: Maximum call stack size exceeded`. This is the ordinary "renamed import + a
same-name re-export wrapper" barrel pattern.

`isolate_private_top_level_bindings` (#97) already renamed colliding PRIVATE top-level names, but
skipped exported ones:

    if exported[i].contains(name) {
        continue; // exported names stay stable so imports keep resolving
    }

That premise is stricter than it needs to be. `module_exports` is an INDIRECTION from export name to
source symbol, so the symbol is free to move as long as the key does not. Non-entry modules now have
colliding exports renamed, with `renamed symbol -> original export name` recorded so the export table
still answers to the name importers ask for.

The ENTRY module is excluded deliberately: its exports are the bundle's public surface, so renaming
those would change the API the caller sees.

Not a missed optimisation — leaving the collision produced a silently WRONG program, which is why it
was filed and triaged high rather than medium.

ONE THING THE EXISTING TESTS CAUGHT, worth recording because the first cut looked right:

The rename must key off DECLARATION count, not `occupancy`. `occupancy` includes import bindings, so
a dep's exported `greet` appeared to collide with the importer's binding of that same `greet` — one
thing, not two — and renaming on that basis churned every ordinary import. Four pre-existing
`scope_merge` tests failed on exactly that, correctly: an ordinary merged package must keep its name.
A real collision is another module DECLARING the name.

VERIFICATION

  #587 repro          RangeError -> "hi world" on ALL THREE targets (js / interp / native)
  scope_merge         6 passed, 0 failed (incl. the new
                      `colliding_exported_names_are_isolated_across_modules`)
  tishlang_compile    32 binaries, 0 failures
  integration_test    25 passed, 0 failed

The merger runs for every multi-module program on every target, so the cross-target check is the
load-bearing one here — a fix verified only on the target that showed the bug would prove nothing
about the other two.