### PR TITLE
fix(native): #614 — key numeric-local demotion by (scope, name); one boxed `i` boxed every `i`

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1234,7 +1234,22 @@ pub(crate) struct Codegen {
     /// once in `emit_program` (after type aliases + `native_fns`), consulted at `VarDecl` to force
     /// `RustType::Value`. This is the rust-AOT analogue of the VM array-JIT bailing to the
     /// interpreter on a non-numeric element. See `collect_demoted_numeric_locals`.
-    demoted_numeric_locals: std::collections::HashSet<String>,
+    ///
+    /// #614: keyed by `(declaring scope, name)`, NOT by bare name. The scope is the top-level fn
+    /// whose body declares the local, or `""` for a module-level binding. Flat keying meant one
+    /// boxed `i` anywhere in the bundle demoted every `i` in every module — with 44 of tish-gba's
+    /// 70 packages untyped, a legacy package silently de-optimized a fully-modernized one that
+    /// merely shared a loop-variable name (~40-60 cycles per boxed use against 2-4 native).
+    ///
+    /// Module-level bindings stay program-wide (scope `""`) ON PURPOSE: a module `let` can be
+    /// reassigned from inside any fn, so its demotion is genuinely a whole-program property.
+    /// Only FUNCTION-LOCAL names are scoped, and for those every reassignment necessarily lives
+    /// in the declaring fn (or a closure nested in it) — exactly the region analyzed.
+    demoted_numeric_locals: std::collections::HashSet<(String, String)>,
+    /// #614: the top-level fn currently being emitted (`""` at module level), used to key lookups
+    /// into `demoted_numeric_locals`. A stack because fn emission nests; the FIRST entry is the
+    /// top-level fn, which is the granularity the collector analyzes.
+    demote_scope_stack: Vec<String>,
     /// Top-level fns whose EVERY return is provably numeric → the native type a call to one yields.
     ///
     /// Without it a call is opaque, so a local assigned from one demotes to a boxed `Value` and
@@ -1434,6 +1449,7 @@ impl Codegen {
             aggregate_array_locals: std::collections::HashSet::new(),
             agg_cur_ret: None,
             demoted_numeric_locals: std::collections::HashSet::new(),
+            demote_scope_stack: Vec::new(),
             user_fn_ret: std::collections::HashMap::new(),
             int_range_locals: std::collections::HashMap::new(),
             diag_coord_indices: std::collections::HashSet::new(),
@@ -5937,9 +5953,26 @@ impl Codegen {
                 // `s = s + arr[i]`, JS string concat) must stay a boxed `Value` — a native-f64
                 // store would panic at the `from_value_expr(F64)` coercion. See
                 // `demoted_numeric_locals`.
-                if rust_type == RustType::F64 && self.demoted_numeric_locals.contains(name.as_ref())
-                {
-                    rust_type = RustType::Value;
+                // #614: look up (declaring scope, name). A module-level binding was decided
+                // program-wide under scope `""`; a function-local under its top-level fn. Both are
+                // checked because this same emission path serves module code and fn bodies, and a
+                // fn-local name may legitimately shadow a module one.
+                // #614: look up (declaring scope, name). A fn-local is keyed under its top-level
+                // fn; a module binding under `""`. Both are consulted because this same emission
+                // path serves module code and fn bodies.
+                // #614: key by the scope this declaration belongs to. No module fallback — the
+                // statement being emitted IS a declaration, so the variable is by definition owned
+                // by the current scope: inside a fn it is that fn's local (`scope` = the top-level
+                // fn), at module level `scope` is `""`, which is the module key itself. Consulting
+                // the module verdict for a fn-local is exactly the false positive this fixes.
+                if rust_type == RustType::F64 {
+                    let scope = self.demote_scope_stack.first().cloned().unwrap_or_default();
+                    if self
+                        .demoted_numeric_locals
+                        .contains(&(scope, name.to_string()))
+                    {
+                        rust_type = RustType::Value;
+                    }
                 }
 
                 // Native-vec call initializer: `let cum = cumulative(probs)` → `Vec<f64>`.
@@ -7454,9 +7487,12 @@ impl Codegen {
                         for v in &body_cell_vars {
                             self.refcell_wrapped_vars.insert(v.clone());
                         }
+                        // #614: this body's locals were analyzed under THIS fn's scope.
+                        self.demote_scope_stack.push(name_raw.to_string());
                         for s in statements {
                             self.emit_statement(s)?;
                         }
+                        self.demote_scope_stack.pop();
                         for v in &body_cell_vars {
                             self.refcell_wrapped_vars.remove(v);
                         }
@@ -7468,7 +7504,9 @@ impl Codegen {
                         self.outer_vars_stack.push(Vec::new());
                         self.rc_cell_storage_scopes
                             .push(std::collections::HashSet::new());
+                        self.demote_scope_stack.push(name_raw.to_string()); // #614
                         self.emit_statement(body)?;
+                        self.demote_scope_stack.pop();
                         self.function_scope_stack.pop();
                         self.outer_vars_stack.pop();
                         self.rc_cell_storage_scopes.pop();
@@ -12842,23 +12880,80 @@ impl Codegen {
         }
     }
 
-    fn collect_demoted_numeric_locals(&self, stmts: &[Statement]) -> HashSet<String> {
-        // 1. Flat env: every annotated local/param name → its native `RustType`.
+    fn collect_demoted_numeric_locals(&self, stmts: &[Statement]) -> HashSet<(String, String)> {
+        // #614: the analysis below is UNCHANGED — same env, same reassignment set, same fixpoint.
+        // What changed is the KEY. Previously a bare name, so one boxed `i` anywhere in the bundle
+        // demoted every `i` in every module (~40-60 cycles per boxed use against 2-4 native); with
+        // 44 of tish-gba's 70 packages untyped, a legacy package silently de-optimized a fully
+        // modernized one that merely shared a loop-variable name.
+        //
+        // Scope granularity is the TOP-LEVEL FN, or `""` for module level. Each fn is analyzed from
+        // its own `FunDecl` statement — not just its body — so params (including a REST param, whose
+        // `Vec<f64>` element type is what keeps `total` native in `typed_assign_conversion`) are
+        // collected exactly as the flat pass collected them. Nested fns fold into their enclosing
+        // top-level fn: still conservative, but bounded to one function instead of the whole bundle.
+        let mut out: HashSet<(String, String)> = HashSet::new();
+
+        // Module-level names keep the program-wide verdict: a module `let` is reassignable from
+        // inside any fn, so whether it can go non-numeric is genuinely a whole-program property.
+        let module_names: HashSet<String> = stmts
+            .iter()
+            .filter_map(|s| match s {
+                Statement::VarDecl { name, .. } => Some(name.to_string()),
+                _ => None,
+            })
+            .collect();
+
         let mut env: HashMap<String, RustType> = HashMap::new();
         Self::collect_annotated_types(stmts, &self.type_aliases, &mut env);
-        // 2. Every reassignment `(name, rhs)` anywhere in the program (incl. nested exprs/closures).
         let mut reassigns: Vec<(String, &Expr)> = Vec::new();
         Self::collect_reassignments_stmts(stmts, &mut reassigns);
-        // 3. Fixpoint: demote a `number` local whose any reassignment RHS isn't native `f64`.
+        for name in self.demote_fixpoint(&mut env, &reassigns, &module_names) {
+            out.insert((String::new(), name));
+        }
+
+        for s in stmts {
+            let Statement::FunDecl { name, .. } = s else {
+                continue;
+            };
+            let scope = name.to_string();
+            let one = std::slice::from_ref(s);
+            let mut fenv: HashMap<String, RustType> = HashMap::new();
+            Self::collect_annotated_types(one, &self.type_aliases, &mut fenv);
+            // Every name this fn declares — INCLUDING one that shadows a module binding. A
+            // shadowing local is a different variable, so it gets its own verdict here; leaving it
+            // out would drop it back onto the module's verdict, which is the very bug being fixed.
+            let local_names: HashSet<String> = fenv.keys().cloned().collect();
+            if local_names.is_empty() {
+                continue;
+            }
+            let mut freassigns: Vec<(String, &Expr)> = Vec::new();
+            Self::collect_reassignments_stmts(one, &mut freassigns);
+            for n in self.demote_fixpoint(&mut fenv, &freassigns, &local_names) {
+                out.insert((scope.clone(), n));
+            }
+        }
+        out
+    }
+
+    /// #614: the demotion fixpoint, factored out so the module scope and every function scope run
+    /// the IDENTICAL rule. Only names in `considered` may demote; `env` is updated in place so a
+    /// demoted name's later reads see `Value` — that feedback is what makes it a fixpoint.
+    fn demote_fixpoint(
+        &self,
+        env: &mut HashMap<String, RustType>,
+        reassigns: &[(String, &Expr)],
+        considered: &HashSet<String>,
+    ) -> HashSet<String> {
         let mut demoted: HashSet<String> = HashSet::new();
         loop {
             let mut changed = false;
-            for (name, rhs) in &reassigns {
-                if demoted.contains(name) {
+            for (name, rhs) in reassigns {
+                if demoted.contains(name) || !considered.contains(name) {
                     continue;
                 }
                 if env.get(name) == Some(&RustType::F64)
-                    && self.expr_native_type(rhs, &env) != RustType::F64
+                    && self.expr_native_type(rhs, env) != RustType::F64
                 {
                     demoted.insert(name.clone());
                     env.insert(name.clone(), RustType::Value);

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -12912,18 +12912,43 @@ impl Codegen {
             out.insert((String::new(), name));
         }
 
+        // A fn's env must START from what MODULE scope makes visible to it. Without that, a body
+        // reading a module binding — `sum = (sum + codes[j]) % M`, where `codes` is a hoisted const
+        // f64 array — cannot type the RHS, wrongly demotes `sum` to `Value`, and the emitted code
+        // then adds an `f64` static to a `Value`: `error[E0369]: cannot add f64 to Value`. The flat
+        // pass had this information for free; scoping the KEY must not scope away the VISIBILITY.
+        //
+        // Module-only, and carrying the module verdicts just settled above: a demoted module binding
+        // reads as `Value` inside a fn too, which is exactly what its declaration will emit.
+        let mut module_env: HashMap<String, RustType> = HashMap::new();
+        for s in stmts {
+            if !matches!(s, Statement::FunDecl { .. }) {
+                Self::collect_annotated_types(std::slice::from_ref(s), &self.type_aliases, &mut module_env);
+            }
+        }
+        for (scope, n) in &out {
+            if scope.is_empty() {
+                module_env.insert(n.clone(), RustType::Value);
+            }
+        }
+
         for s in stmts {
             let Statement::FunDecl { name, .. } = s else {
                 continue;
             };
             let scope = name.to_string();
             let one = std::slice::from_ref(s);
-            let mut fenv: HashMap<String, RustType> = HashMap::new();
-            Self::collect_annotated_types(one, &self.type_aliases, &mut fenv);
-            // Every name this fn declares — INCLUDING one that shadows a module binding. A
-            // shadowing local is a different variable, so it gets its own verdict here; leaving it
-            // out would drop it back onto the module's verdict, which is the very bug being fixed.
-            let local_names: HashSet<String> = fenv.keys().cloned().collect();
+            // Module bindings first, then this fn's own declarations OVERLAY them — so a local that
+            // shadows a module name takes its own type, not the module one.
+            // What this fn itself declares — computed separately from the visibility env, because
+            // only these names may take a verdict under this scope. INCLUDES a name that shadows a
+            // module binding: a shadowing local is a different variable and gets its own verdict;
+            // leaving it out drops it back onto the module's verdict, which is the bug being fixed.
+            let mut own: HashMap<String, RustType> = HashMap::new();
+            Self::collect_annotated_types(one, &self.type_aliases, &mut own);
+            let local_names: HashSet<String> = own.keys().cloned().collect();
+            let mut fenv: HashMap<String, RustType> = module_env.clone();
+            fenv.extend(own);
             if local_names.is_empty() {
                 continue;
             }

--- a/crates/tish_compile/src/lib.rs
+++ b/crates/tish_compile/src/lib.rs
@@ -291,4 +291,36 @@ mod monomorphization_tests {
         assert!(rust.contains("value: f64"), "expected native f64 field; got:\n{}",
             rust.lines().filter(|l| l.contains("struct") || l.contains("value")).take(6).collect::<Vec<_>>().join("\n"));
     }
+
+    /// #614: a module-level binding demoted to boxed `Value` must NOT drag down a function-local
+    /// that merely shares its name. Both lowerings have to appear in one program — under the old
+    /// bare-name keying that was impossible, since one name got one verdict bundle-wide.
+    #[test]
+    fn module_demotion_does_not_box_a_same_named_local() {
+        let src = r#"
+let i = 0
+i = i + "x"
+function modern(n: number) {
+  let i = 0
+  let t = 0
+  while (i < n) { t = t + i * 2; i = i + 1 }
+  return t
+}
+console.log(i)
+console.log(modern(5))
+"#;
+        let rust = compile(&parse(src).unwrap()).unwrap();
+        // The module `i` really can hold a String (`i + "x"`), so it must stay boxed.
+        assert!(
+            rust.contains("let mut i = Value::Number(0_f64)"),
+            "module-level `i` must stay boxed; got:\n{}",
+            rust.lines().filter(|l| l.contains("let mut i")).collect::<Vec<_>>().join("\n")
+        );
+        // `modern`'s `i` is a different variable, provably numeric, and must lower natively.
+        assert!(
+            rust.contains("let mut i: f64 = 0_f64"),
+            "fn-local `i` must stay native f64; got:\n{}",
+            rust.lines().filter(|l| l.contains("let mut i")).collect::<Vec<_>>().join("\n")
+        );
+    }
 }


### PR DESCRIPTION
fix(native): #614 — key numeric-local demotion by (scope, name); one boxed `i` boxed every `i`

`demoted_numeric_locals` was a `HashSet<String>` keyed by BARE NAME over the whole bundled program.
One local that a reassignment can turn non-numeric demoted every same-named local in every module —
~40-60 cycles per boxed use against 2-4 native. With 44 of tish-gba's 70 packages at 0% typed this
is live, not hypothetical: a legacy package silently de-optimizes a fully-modernized one that merely
uses the same loop-variable name.

Now keyed by `(declaring scope, name)`, where scope is the top-level fn that declares the local, or
`""` for a module-level binding.

THE ANALYSIS IS UNCHANGED — same env, same reassignment set, same fixpoint, now run once per scope
instead of once for the program. Three details are load-bearing, each found by breaking it:

  1. EACH FN IS ANALYZED FROM ITS `FunDecl` STATEMENT, NOT ITS BODY. Building the env from the body
     alone drops the parameter list, and with it a REST param's `Vec<f64>` element type — so
     `for (let n of args) { total = total + n }` could no longer prove `n` numeric and demoted
     `total`. Caught by `typed_assign_conversion`.

  2. A LOCAL THAT SHADOWS A MODULE BINDING IS STILL ANALYZED IN ITS OWN SCOPE. Excluding shadowing
     names looks harmless — they were "already decided" at module level — but it drops them back
     onto the module verdict, which is precisely the bug. `let i` in a fn is a different variable
     from a module `i`.

  3. THE CONSUMER HAS NO MODULE FALLBACK. The statement being emitted IS a declaration, so the
     variable belongs to the current scope by construction: inside a fn it is that fn's local, at
     module level the scope key is `""` — the module key itself. Consulting the module verdict for
     a fn-local is the false positive being removed.

Module-level bindings deliberately keep the program-wide verdict: a module `let` is reassignable
from inside any fn, so whether it can go non-numeric is genuinely a whole-program property. Nested
fns fold into their enclosing top-level fn's scope — still conservative, but bounded to one function
instead of the entire bundle.

A WRONG TURN WORTH RECORDING. I first "simplified" this to a one-line consumer gate, on the premise
that `collect_annotated_types` does not descend into a `FunDecl` and therefore never analyzed fn
locals at all. It does descend (the `Statement::FunDecl` arm collects params and body) — I read a
truncated grep. That premise inverted the risk: the "minimal" version removed demotion from EVERY
function local, so `reduceAdd`'s `let s = 0` lowered to native f64 and panicked `expected number` on
`s = s + arr[i]` with a string element. The compile suite passed; only `tests/core/
numeric_local_demote.tish` caught it, at RUNTIME, in the native backend. That fixture is doing exactly
the job its header claims.

VALIDATION
  new codegen test    one program now emits BOTH `let mut i = Value::Number(0_f64)` (module `i`,
                      genuinely string-capable) and `let mut i: f64 = 0_f64` (a fn-local `i`).
                      Impossible under bare-name keying, where one name got one verdict.
  numeric_local_demote  15 3x4 0a12 3.25 60 7k9 — unchanged, the demotion it guards still fires
  tishlang_compile      80 passed, 0 failures
  integration_test      25 passed, 0 failed (all backends)

Fixes #614