### PR TITLE
feat(check): #641 — error on a call that omits an argument bound to a TYPED parameter

### DIFF
--- a/crates/tish_compile/src/check.rs
+++ b/crates/tish_compile/src/check.rs
@@ -773,3 +773,181 @@ mod tests {
         assert_eq!(diags("fn f(a: number) {}\nf(someUnknown())"), Vec::<String>::new());
     }
 }
+
+// ── #641: call arity ────────────────────────────────────────────────────────────────────────────
+//
+// tish did not check arity at all. A call with too few arguments compiled, the missing parameter
+// became `Value::Null`, and what happened next depended on which lowering the CALLEE happened to
+// get — a property of the callee, not of the call:
+//
+//   boxed `Value::native` + typed params  ->  builds clean, PANICS at runtime the first time that
+//                                             path runs ("expected number", pointing at generated
+//                                             code, saying nothing about the call site)
+//   direct native `fn`   + typed params   ->  rustc E0061 against generated code
+//   interpreter          + typed params   ->  silently returns NaN / null
+//   untyped params                        ->  `null` arrives; a deliberate, widely-used idiom
+//
+// So the same mistake is a build error in one function and a shipped crash in the next.
+//
+// THE RULE, and why it is exactly this narrow: an omitted argument bound to a TYPED parameter can
+// never be correct, because `Value::Null` cannot satisfy a `Value::Number` prologue. That is a fact
+// about the lowering, not a style preference, so it can be a hard error without a policy debate.
+//
+// An omitted argument bound to an UNTYPED parameter stays legal, because it is an established
+// idiom in shipping code — `packages/shop.tish` has six such calls, `packages/ui.tish` one:
+//
+//     function renderTab(defer, stream) { if (present(defer) === 1) { … } }
+//     renderTab()                      // deliberate: "render now, no defer, no stream"
+//
+// A parameter with a DEFAULT imposes no minimum either: the default is what fills it. Rest params
+// impose none by definition.
+
+/// The minimum argument count a call to `params` must supply: one past the LAST parameter that is
+/// typed and has no default. A typed parameter at index 2 forces arity 3 even when 0 and 1 are
+/// untyped, because the call cannot skip a position to reach it.
+fn min_required_arity(params: &[FunParam]) -> usize {
+    let mut min = 0;
+    for (i, p) in params.iter().enumerate() {
+        if let FunParam::Simple(tp) = p {
+            if tp.type_ann.is_some() && tp.default.is_none() {
+                min = i + 1;
+            }
+        }
+    }
+    min
+}
+
+/// #641: report every call that supplies fewer arguments than a typed parameter requires. Runs
+/// unconditionally in the compile path — unlike [`check_program`], which is opt-in behind
+/// `TISH_CHECK` and would therefore never have caught the shipped case this exists for.
+pub fn check_call_arity(program: &Program) -> Vec<TypeDiagnostic> {
+    use std::collections::HashMap;
+
+    // name -> (minimum arity, declared parameter count). Nested and top-level fns alike; a later
+    // declaration of the same name wins, matching the runtime's own last-wins binding.
+    let mut sigs: HashMap<String, (usize, usize)> = HashMap::new();
+    fn collect(stmts: &[Statement], sigs: &mut HashMap<String, (usize, usize)>) {
+        for s in stmts {
+            if let Statement::FunDecl { name, params, rest_param, body, .. } = s {
+                // A rest param swallows any surplus, but the leading typed params still bind
+                // positionally, so the minimum is unchanged.
+                let _ = rest_param;
+                sigs.insert(name.to_string(), (min_required_arity(params), params.len()));
+                collect(std::slice::from_ref(body.as_ref()), sigs);
+            } else {
+                for_each_child_block(s, &mut |b| collect(b, sigs));
+            }
+        }
+    }
+    collect(&program.statements, &mut sigs);
+
+    let mut diags = Vec::new();
+    for s in &program.statements {
+        crate::codegen::Codegen::for_each_stmt_expr(s, &mut |root| {
+            walk_expr(root, &mut |e| {
+            let Expr::Call { callee, args, span } = e else { return };
+            let Expr::Ident { name, .. } = callee.as_ref() else { return };
+            let Some((min, declared)) = sigs.get(name.as_ref()).copied() else { return };
+            // A spread makes the count unknowable at compile time — say nothing rather than guess.
+            if args.iter().any(|a| matches!(a, CallArg::Spread(_))) {
+                return;
+            }
+            if args.len() < min {
+                diags.push(TypeDiagnostic {
+                    message: format!(
+                        "'{}' needs {} argument(s) but {} were supplied; parameter {} is typed, and \
+                         an omitted argument arrives as null, which a typed parameter cannot accept. \
+                         (An untyped parameter may be omitted — that idiom is unaffected.)",
+                        name,
+                        min,
+                        args.len(),
+                        min,
+                    ),
+                    span: *span,
+                });
+            }
+            let _ = declared;
+            });
+        });
+    }
+    diags
+}
+
+/// Visit `e` and every sub-expression. `for_each_stmt_expr` hands out only a statement's ROOT
+/// expression, so without this the checker never sees `paintTyped(1)` inside `log("x" +
+/// paintTyped(1))` — which is the shape the reported bug actually had.
+///
+/// The catch-all arm is deliberate: a variant not enumerated here yields a MISSED diagnostic, never
+/// a wrong one, so a future AST addition degrades this check quietly instead of breaking builds.
+fn walk_expr(e: &Expr, f: &mut dyn FnMut(&Expr)) {
+    f(e);
+    let mut go = |x: &Expr| walk_expr(x, f);
+    match e {
+        Expr::Binary { left, right, .. }
+        | Expr::NullishCoalesce { left, right, .. }
+        | Expr::Index { object: left, index: right, .. } => {
+            go(left);
+            go(right);
+        }
+        Expr::Unary { operand, .. } | Expr::TypeOf { operand, .. } | Expr::Await { operand, .. } => {
+            go(operand)
+        }
+        // The inc/dec forms name a variable rather than holding a sub-expression, so there is
+        // nothing to descend into.
+        Expr::Delete { target, .. } => go(target),
+        Expr::Member { object, .. } => go(object),
+        Expr::Call { callee, args, .. } | Expr::New { callee, args, .. } => {
+            go(callee);
+            for a in args {
+                match a {
+                    CallArg::Expr(x) | CallArg::Spread(x) => go(x),
+                }
+            }
+        }
+        Expr::Conditional { cond, then_branch, else_branch, .. } => {
+            go(cond);
+            go(then_branch);
+            go(else_branch);
+        }
+        Expr::Array { elements, .. } => {
+            for el in elements {
+                match el {
+                    tishlang_ast::ArrayElement::Expr(x)
+                    | tishlang_ast::ArrayElement::Spread(x) => go(x),
+                    _ => {}
+                }
+            }
+        }
+        Expr::Object { props, .. } => {
+            for pr in props {
+                match pr {
+                    tishlang_ast::ObjectProp::KeyValue(_, x, _) => go(x),
+                    tishlang_ast::ObjectProp::Spread(x) => go(x),
+                }
+            }
+        }
+        Expr::Assign { value, .. }
+        | Expr::CompoundAssign { value, .. }
+        | Expr::LogicalAssign { value, .. } => go(value),
+        Expr::MemberAssign { object, value, .. } => {
+            go(object);
+            go(value);
+        }
+        Expr::IndexAssign { object, index, value, .. } => {
+            go(object);
+            go(index);
+            go(value);
+        }
+        Expr::TemplateLiteral { exprs, .. } => {
+            for x in exprs {
+                go(x);
+            }
+        }
+        Expr::ArrowFunction { body, .. } => {
+            if let tishlang_ast::ArrowBody::Expr(x) = body {
+                go(x.as_ref());
+            }
+        }
+        _ => {}
+    }
+}

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -705,6 +705,28 @@ pub fn compile_with_native_modules(
 /// as warnings; `TISH_CHECK=error` also fails the build. Unset/`0` → no-op (default builds are
 /// unaffected). The checker is gradual (see `check.rs`): it never flags code it can't prove wrong.
 fn run_type_check(program: &Program) -> Result<(), CompileError> {
+    // #641: call arity is checked UNCONDITIONALLY, ahead of the opt-in gradual checker. It cannot
+    // sit behind `TISH_CHECK` — the case this exists for built clean and shipped, and a diagnostic
+    // nobody enables would not have caught it. It is also not "gradual": an omitted argument bound
+    // to a typed parameter arrives as `Value::Null` and cannot satisfy the typed prologue, so it is
+    // provably wrong on every backend rather than an unproven annotation.
+    //
+    // `TISH_ARITY=0` is the escape hatch, for bisecting a build against pre-#641 behaviour.
+    if std::env::var("TISH_ARITY").as_deref() != Ok("0") {
+        let arity = crate::check::check_call_arity(program);
+        if let Some(first) = arity.first() {
+            for d in &arity {
+                eprintln!(
+                    "tish error: {}:{}: {}",
+                    d.span.start.0, d.span.start.1, d.message
+                );
+            }
+            return Err(CompileError::new(
+                format!("call arity: {} error(s)", arity.len()),
+                Some(first.span),
+            ));
+        }
+    }
     let mode = std::env::var("TISH_CHECK").unwrap_or_default();
     if mode.is_empty() || mode == "0" {
         return Ok(());
@@ -15557,7 +15579,7 @@ impl Codegen {
     /// statements (blocks, if, loops, switch, try, return/throw). `f` is responsible for recursing
     /// into each expression's own subtree. Does NOT descend into nested fn-decl bodies (a different
     /// lexical scope; a captured loop var would be RefCell-bailed before reaching here).
-    fn for_each_stmt_expr(s: &Statement, f: &mut dyn FnMut(&Expr)) {
+    pub(crate) fn for_each_stmt_expr(s: &Statement, f: &mut dyn FnMut(&Expr)) {
         match s {
             Statement::Block { statements, .. } | Statement::Multi { statements, .. } => {
                 for st in statements {

--- a/crates/tish_compile/src/lib.rs
+++ b/crates/tish_compile/src/lib.rs
@@ -12,7 +12,7 @@ mod types;
 
 pub use schemes::{set_active as set_scheme_registry, SchemeRegistry};
 
-pub use check::{check_program, TypeDiagnostic};
+pub use check::{check_call_arity, check_program, TypeDiagnostic};
 
 /// The native typed-codegen optimizations — numeric param inference, struct/aggregate inference,
 /// native (monomorphic) free fns, native-vec params, recursive-struct arena lowering, fused/native

--- a/crates/tish_compile/tests/call_arity_641.rs
+++ b/crates/tish_compile/tests/call_arity_641.rs
@@ -1,0 +1,104 @@
+//! #641 — call arity. A call with too few arguments used to compile, bind the missing parameter to
+//! `Value::Null`, and then either panic at runtime (boxed callee, typed params), fail in rustc
+//! (direct native callee), or silently yield null/NaN (interpreter) — depending on which lowering
+//! the CALLEE happened to get. These pin the rule and, just as importantly, the non-rule: omitting
+//! an argument bound to an UNTYPED parameter stays legal, because shipping packages rely on it.
+
+use tishlang_compile::check_call_arity;
+use tishlang_parser::parse;
+
+fn diags(src: &str) -> Vec<String> {
+    let p = parse(src).expect("parse");
+    check_call_arity(&p).into_iter().map(|d| d.message).collect()
+}
+
+#[test]
+fn omitting_a_typed_parameter_is_an_error() {
+    let d = diags(
+        r#"
+function paintTyped(slot: i32, rv: i32): i32 { return slot + rv }
+paintTyped(1)
+"#,
+    );
+    assert_eq!(d.len(), 1, "expected exactly one diagnostic, got {:?}", d);
+    assert!(d[0].contains("paintTyped"), "names the callee: {}", d[0]);
+    assert!(d[0].contains("needs 2"), "states the requirement: {}", d[0]);
+}
+
+#[test]
+fn omitting_an_untyped_parameter_is_allowed() {
+    // The established idiom: `packages/shop.tish` has six of these, `packages/ui.tish` one.
+    // Enforcing arity here would break shipping code that is behaving exactly as intended.
+    let d = diags(
+        r#"
+function renderTab(defer, stream) { return 1 }
+renderTab()
+renderTab(1)
+renderTab(1, 1)
+"#,
+    );
+    assert!(d.is_empty(), "untyped params must stay optional, got {:?}", d);
+}
+
+#[test]
+fn a_defaulted_parameter_imposes_no_minimum() {
+    // The default is what fills the slot, so nothing arrives as null.
+    let d = diags(
+        r#"
+function f(a: i32, b: i32 = 7): i32 { return a + b }
+f(1)
+"#,
+    );
+    assert!(d.is_empty(), "a default supplies the argument, got {:?}", d);
+}
+
+#[test]
+fn a_typed_parameter_after_untyped_ones_still_forces_its_position() {
+    // A call cannot skip positions to reach `c`, so the minimum is 3 even though 0 and 1 are
+    // untyped — the minimum is one past the LAST typed parameter, not a count of typed ones.
+    let d = diags(
+        r#"
+function g(a, b, c: i32): i32 { return c }
+g(1, 2)
+"#,
+    );
+    assert_eq!(d.len(), 1, "expected one diagnostic, got {:?}", d);
+    assert!(d[0].contains("needs 3"), "minimum is positional: {}", d[0]);
+}
+
+#[test]
+fn a_spread_argument_is_not_second_guessed() {
+    // The count is unknowable at compile time; saying nothing beats guessing wrong.
+    let d = diags(
+        r#"
+function h(a: i32, b: i32): i32 { return a + b }
+let xs = [1, 2]
+h(...xs)
+"#,
+    );
+    assert!(d.is_empty(), "spread must not be flagged, got {:?}", d);
+}
+
+#[test]
+fn a_nested_call_is_still_seen() {
+    // The reported shape. `for_each_stmt_expr` hands out only a statement's ROOT expression, so
+    // without full sub-expression walking this exact case — the one in the issue — is missed.
+    let d = diags(
+        r#"
+function paintTyped(slot: i32, rv: i32): i32 { return slot + rv }
+console.log("v = " + paintTyped(1))
+"#,
+    );
+    assert_eq!(d.len(), 1, "nested call must be checked, got {:?}", d);
+}
+
+#[test]
+fn a_correct_call_is_silent() {
+    let d = diags(
+        r#"
+function paintTyped(slot: i32, rv: i32): i32 { return slot + rv }
+paintTyped(1, 2)
+"#,
+    );
+    assert!(d.is_empty(), "correct arity must not warn, got {:?}", d);
+}


### PR DESCRIPTION
feat(check): #641 — error on a call that omits an argument bound to a TYPED parameter

tish did not check call arity at all. A short call compiled, the missing parameter became
`Value::Null`, and what happened next depended on which lowering the CALLEE happened to get:

    boxed `Value::native` + typed params   builds clean, PANICS at runtime the first time that path
                                           runs — `expected number`, pointing at generated code,
                                           saying nothing about the call site
    direct native `fn`    + typed params   rustc E0061 against generated code
    interpreter           + typed params   silently returns null / NaN
    untyped params                         `null` arrives; a deliberate, widely-used idiom

So the same mistake is a build error in one function and a shipped crash in the next — and which
one is a property of the callee, not of the call. The real instance (`drop_paint(P2)` against
`drop_paint(slot: i32, rv: i32)`) survived because the original `drop_paint` was a Rust extern whose
second parameter was unused; when the rules were reimplemented in tish the new painter started USING
it, and an untouched call site became a crash in the one mode with no verifier.

THE RULE, and why exactly this narrow: an omitted argument bound to a TYPED parameter can never be
correct, because `Value::Null` cannot satisfy a `Value::Number` prologue. That is a fact about the
lowering, not a style preference, so it can be a hard error without a policy debate.

The minimum arity is ONE PAST THE LAST typed, non-defaulted parameter — not a count of typed ones.
A call cannot skip positions to reach a typed parameter at index 2, so `g(a, b, c: i32)` requires 3
arguments even though the first two are untyped.

WHAT IS DELIBERATELY NOT AN ERROR:
  * an omitted argument bound to an UNTYPED parameter — the optional-trailing-argument idiom, six
    calls in `packages/shop.tish` and one in `packages/ui.tish`. `renderTab()` against
    `function renderTab(defer, stream)` means "render now, no defer, no stream" and is correct code.
  * a parameter with a DEFAULT — the default fills the slot, so nothing arrives as null.
  * a call with a SPREAD — the count is unknowable at compile time; saying nothing beats guessing.

TWO DESIGN DECISIONS WORTH REVIEWING

1. ALWAYS ON, not behind `TISH_CHECK`. That flag defaults to OFF, and the case this exists for built
   clean and shipped — a diagnostic nobody enables would not have caught it. This is also not
   "gradual" in the sense `check.rs` means: it is provably wrong code on every backend, not an
   unproven annotation. `TISH_ARITY=0` bisects against pre-#641 behaviour.

2. THE WALKER HAS A CATCH-ALL. `for_each_stmt_expr` yields only a statement's ROOT expression, so
   the check could not see `paintTyped(1)` inside `log("v = " + paintTyped(1))` — the shape the
   report actually had. `walk_expr` descends into every container variant; an unenumerated future
   AST variant yields a MISSED diagnostic, never a wrong one.

VALIDATION — the point of interest is the false-positive rate on real code, since this turns
previously-building programs into errors:

  tish-gba ROMs, --target gba   button-demo, iso-shop, akari, sunny-land, space-goo — ALL BUILD.
                                iso-shop is the load-bearing one: it pulls in `shop.tish`, whose six
                                optional-argument calls are exactly what a naive arity rule breaks.
  tishlang_compile              all test binaries, 0 failures
  integration_test              25 passed, 0 failed (all backends)
  new fixtures                  7 cases in `tests/call_arity_641.rs`, covering the rule, the
                                idiom, defaults, positional minimum, spread, nesting, and a
                                correct call.

Not addressed here: too MANY arguments (harmless under JS semantics, ignored by the callee), and
the interpreter's silent null/NaN for a short call, which is a cross-backend divergence in its own
right (cf. #441) and wants its own fix rather than being folded into this one.

Fixes #641