### PR TITLE
perf(native): #609 — typed-array HOFs lower for i32[] receivers, not just Vec<f64>

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -26832,7 +26832,12 @@ impl Codegen {
         let RustType::Vec(inner) = self.type_context.get_type(recv_name.as_ref()) else {
             return Ok(None);
         };
-        if *inner != RustType::F64 {
+        // #609: the element-type gate exists in TWO places — here and at the top of
+        // `try_native_vec_hof`. Widening only the inner one changes nothing, because this one
+        // returns first: the array is boxed whole into a `Value::Array` and handed to
+        // `tishlang_runtime::array_map`, which is the per-element `value_call` path this issue is
+        // about. Both must agree.
+        if *inner != RustType::F64 && *inner != RustType::I32 {
             return Ok(None);
         }
         let recv_code = Self::escape_ident(recv_name.as_ref()).into_owned();
@@ -26861,8 +26866,14 @@ impl Codegen {
         method: &str,
         args: &[CallArg],
     ) -> Result<Option<(String, RustType)>, CompileError> {
-        // Only numeric arrays for now: `.copied()` needs a `Copy` element.
-        if *elem != RustType::F64 {
+        // `.copied()` needs a `Copy` element, which both of these are.
+        //
+        // #609: `i32` joins `f64` here. On GBA every idiomatic array is `i32[]`, so restricting the
+        // fast path to `Vec<f64>` meant `.map/.filter/.some/.every` fell back to one boxed
+        // `value_call` PER ELEMENT on exactly the arrays the target guidance tells you to write.
+        //
+        // `reduce` is deliberately NOT extended — see its arm below.
+        if *elem != RustType::F64 && *elem != RustType::I32 {
             return Ok(None);
         }
         let Some(CallArg::Expr(Expr::ArrowFunction { params, body, .. })) = args.first() else {
@@ -26894,7 +26905,12 @@ impl Codegen {
             res
         };
         match method {
-            "reduce" => {
+            // #609 stops short here on purpose. The accumulator is typed `f64` (or `i64` for the
+            // integer-range form); with an `i32` element the body would mix an `i32` binding into
+            // that accumulator — `acc = acc + x` either fails to compile or silently changes
+            // overflow behaviour from f64's exact-integer range to i32 wrapping. That is a results
+            // question, not a speed one, so it wants its own change with its own tests.
+            "reduce" if *elem == RustType::F64 => {
                 if args.len() != 2 || params.len() != 2 {
                     return Ok(None);
                 }
@@ -26988,7 +27004,7 @@ impl Codegen {
                 let Some(x) = simple_name(&params[0]) else {
                     return Ok(None);
                 };
-                let (body_code, body_ty) = emit_with(self, &[(&x, RustType::F64)])?;
+                let (body_code, body_ty) = emit_with(self, &[(&x, elem.clone())])?;
                 if !body_ty.is_native() {
                     return Ok(None);
                 }
@@ -27008,17 +27024,21 @@ impl Codegen {
                 let Some(x) = simple_name(&params[0]) else {
                     return Ok(None);
                 };
-                let (body_code, body_ty) = emit_with(self, &[(&x, RustType::F64)])?;
+                let (body_code, body_ty) = emit_with(self, &[(&x, elem.clone())])?;
                 if body_ty != RustType::Bool {
                     return Ok(None);
                 }
                 let x_esc = Self::escape_ident(x.as_ref()).into_owned();
+                // A filter PRESERVES the element type — collecting to `Vec<f64>` from an `i32`
+                // receiver would not compile, and silently widening would change what the caller
+                // gets back.
                 Ok(Some((
                     format!(
-                        "{recv}.iter().copied().filter(|&{x}| {body}).collect::<Vec<f64>>()",
-                        recv = recv, x = x_esc, body = body_code
+                        "{recv}.iter().copied().filter(|&{x}| {body}).collect::<Vec<{ety}>>()",
+                        recv = recv, x = x_esc, body = body_code,
+                        ety = elem.to_rust_type_str()
                     ),
-                    RustType::Vec(Box::new(RustType::F64)),
+                    RustType::Vec(Box::new(elem.clone())),
                 )))
             }
             "some" | "every" => {
@@ -27028,7 +27048,7 @@ impl Codegen {
                 let Some(x) = simple_name(&params[0]) else {
                     return Ok(None);
                 };
-                let (body_code, body_ty) = emit_with(self, &[(&x, RustType::F64)])?;
+                let (body_code, body_ty) = emit_with(self, &[(&x, elem.clone())])?;
                 if body_ty != RustType::Bool {
                     return Ok(None);
                 }


### PR DESCRIPTION
perf(native): #609 — typed-array HOFs lower for i32[] receivers, not just Vec<f64>

`try_native_vec_hof` bailed unless the element type was exactly `RustType::F64`, so on GBA — where
every idiomatic array is `i32[]` — `.map/.filter/.some/.every` always took the boxed path: the whole
array copied into a `Value::Array`, then one `value_call` PER ELEMENT through
`tishlang_runtime::array_map`/`array_filter`. That punished exactly the arrays the target guidance
tells you to write.

`i32` now joins `f64`. Measured on a GBA ROM whose receiver is a real native `Vec<i32>`:

    before:  array_map / array_filter + per-element value_call
    after:   .iter().copied().map(..)                     -> Vec<i32>
             .iter().copied().filter(..).collect::<Vec<i32>>()
             .iter().copied().any(..)      // some
             .iter().copied().all(..)      // every
             ZERO boxed array_* calls left in the generated program

THE GATE EXISTS IN TWO PLACES, and widening only one changes nothing. `native_vec_hof_for_call`
checks the element type before dispatching, and `try_native_vec_hof` checks it again on entry. The
first returns early, the array is boxed whole, and the "fix" is a no-op. Both now admit `I32`.
(I found this the slow way: the first attempt widened the inner gate alone, the generated code was
byte-identical, and only instrumenting the dispatcher showed it was never being called at all.)

`filter` collects to `Vec<{elem}>` rather than the hardcoded `Vec<f64>` — collecting an `i32`
receiver into `Vec<f64>` does not compile, and widening the element type would change what the
caller gets back.

TWO THINGS DELIBERATELY LEFT OUT, both because they change RESULTS rather than speed:

  * `reduce` stays `f64`-only. Its accumulator is typed `f64` (or `i64` for the integer-range form);
    binding an `i32` element into it either fails to compile or silently swaps f64's exact-integer
    range for i32 wrapping. That wants its own change with its own tests.

  * `map` whose BODY type differs from the target still boxes. `let ys: i32[] = xs.map(v => v * 2)`
    types the body `f64` (an `i32` times a number literal — #608's `result_type_of_binop` requiring
    BOTH operands F64), so the result is `Vec<f64>` against a `Vec<i32>` target and the caller's
    exact-match check rejects it. Forcing a `Vec<f64>` -> `Vec<i32>` coercion here would truncate
    silently, so this stays blocked on #608 rather than being papered over.

    Verified as exactly that boundary, not a gap in this change:
        let ident: i32[]    = XS.map(v => v)      -> lowers, collect::<Vec<i32>>
        let mulF:  number[] = XS.map(v => v * 2)  -> lowers, collect::<Vec<f64>>
        let mulI:  i32[]    = XS.map(v => v * 2)  -> boxed  (body f64 vs i32 target)

VALIDATION
  GBA ROM, on device   map/filter/some/every over an `i32[]`: d2=2 d5=5, evens=3 first=0 last=4,
                       some=true every=true — and 0 boxed `array_*` in the generated crate.
  tishlang_compile     all test binaries, 0 failures
  integration_test     25 passed, 0 failed
  perf gauntlet        --strict, soundness gate (typed==boxed==node)

Fixes #609