### PR TITLE
perf(native): #645 — a promoted array's read leaves the integer domain; 63.2 → 0.65 ticks/element

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -13278,8 +13278,28 @@ impl Codegen {
     }
 
     fn index_in_bounds(&self, index: &Expr, arr: &str) -> bool {
-        let Some(len) = self.vec_fixed_len.get(arr) else {
-            return false;
+        // #645: a PROMOTED module-const array knows its own length unconditionally — it is a
+        // `const G_X: [i32; N]`, fixed at emit time. `vec_fixed_len` is per-scope inference and is
+        // NOT populated for it in every body, so the SAME expression proved in bounds inside a
+        // function's native twin and failed inside its boxed closure — the twin got a direct
+        // integer read while the closure, which is the copy a boxed call actually runs, kept the
+        // bounds-checked `f64`/NaN form. Falling back to the static's own length makes the proof
+        // scope-independent, which is what a compile-time constant deserves.
+        let owned_len;
+        let len = match self.vec_fixed_len.get(arr) {
+            Some(l) => l,
+            None => match self
+                .module_const_f64_arrays
+                .get(arr)
+                .map(|v| v.len())
+                .filter(|n| *n > 0)
+            {
+                Some(n) => {
+                    owned_len = BoundKey::Const(n as i64);
+                    &owned_len
+                }
+                None => return false,
+            },
         };
         let Expr::Ident { name: idx, .. } = index else {
             if let Expr::Literal {
@@ -13293,6 +13313,32 @@ impl Codegen {
                     }
                 } else if Self::int_literal_value(*n) == Some(0) {
                     return true;
+                }
+            }
+            // #645: a MASK bounds its result exactly. For any i32 `x` and a non-negative literal
+            // mask `M`, `x & M` lies in `[0, M]` — the AND clears every bit above M's highest,
+            // including the sign bit, so a negative `x` cannot escape the range either. That makes
+            // `A[k & 63]` provably in bounds for a 64-element `A` without knowing anything about
+            // `k`.
+            //
+            // Worth the special case because it is the idiomatic way to index a power-of-two table,
+            // and without it such a read misses the proven-in-bounds path and falls to the
+            // bounds-checked form — which returns `f64` (it must be able to answer NaN), dragging
+            // an otherwise all-integer expression through an f64 round trip on EVERY element.
+            if let Expr::Binary { op: BinOp::BitAnd, left, right, .. } = index {
+                let mask_of = |e: &Expr| -> Option<i64> {
+                    if let Expr::Literal { value: Literal::Number(n), .. } = e {
+                        Self::int_literal_value(*n).filter(|v| *v >= 0)
+                    } else {
+                        None
+                    }
+                };
+                if let Some(m) = mask_of(right).or_else(|| mask_of(left)) {
+                    if let BoundKey::Const(len) = len {
+                        if m < *len {
+                            return true;
+                        }
+                    }
                 }
             }
             return self.sub_index_in_bounds(index, arr);
@@ -25745,20 +25791,15 @@ impl Codegen {
                             name.as_ref(),
                         ) {
                             let in_bounds = self.index_in_bounds(index, name.as_ref());
-                            let (idx_code, idx_ty) = self.emit_typed_expr(index)?;
-                            let idx_usize = if idx_ty == RustType::F64 {
-                                format!("({}) as usize", idx_code)
-                            } else {
-                                let iv = if idx_ty.is_native() {
-                                    idx_ty.to_value_expr(&idx_code)
-                                } else {
-                                    idx_code
-                                };
-                                format!(
-                                    "{{ let _i = &{}; if let Value::Number(n) = _i {{ *n as usize }} else {{ panic!(\"array index must be a number\") }} }}",
-                                    iv
-                                )
-                            };
+                            // #645: use the SHARED index lowering. This site used to accept only
+                            // `F64` natively and push everything else — including a perfectly good
+                            // integer expression — through `Value::Number(..)` and back, or through
+                            // an `i32 -> f64 -> usize` cast. On a target with no FPU that cast is a
+                            // soft-float call PER ELEMENT, which is most of what made a promoted
+                            // array's read expensive. `emit_index_usize` already has the int-domain
+                            // shortcut (`(int).max(0) as usize`, where `.max(0)` reproduces f64's
+                            // saturate-to-zero for a negative index).
+                            let idx_usize = self.emit_index_usize(index)?;
                             let is_int = self.module_const_int_statics.contains(&static_name);
                             // The proven-in-bounds read on an integer array is the whole point: a
                             // plain word load, reported as I32 so the consumer stays in the integer


### PR DESCRIPTION
perf(native): #645 — a promoted array's read leaves the integer domain; 63.2 -> 0.65 ticks/element

A module array literal is promoted to a Rust `const G_X: [i32; N]` — correct, a literal table belongs
in ROM — but reading one cost ~37x what the same data built with `.push()` cost. On hardware, per
element:

    before   63.2 ticks
    after     0.65 ticks      (~97x; the pushed-array baseline is 1.69)

THE REPORTED CAUSE IS ALREADY GONE. The issue documents a `Value::Number(i as f64)` built and matched
back out per element. Current `main` emits no such thing — zero `array index must be a number` in the
generated crate. Measured before touching anything: 63.2 vs 1.69, so the 37x was real, but not for
the reported reason. Two other defects were carrying it.

**1. The in-bounds proof was SCOPE-DEPENDENT.** The fast path already existed: a proven-in-bounds
read emits `G_X[i]` typed `I32` and stays in the integer domain. But `index_in_bounds` requires
`vec_fixed_len`, which is per-body inference — so the SAME expression proved inside a function's
native twin and failed inside its boxed closure:

    line 566 (twin):     acc = acc.wrapping_add(G_LITERAL[..])            // proven, integer
    line  41 (closure):  acc = to_int32((acc as f64) + { if _i < 64 { G_LITERAL[_i] as f64 } .. })

and the closure is the copy a boxed call actually runs, so the measurement never moved. A promoted
array's length is a compile-time constant; the proof now falls back to it and is scope-independent.

Also taught the proof that a MASK bounds its result: for any i32 `x` and non-negative literal `M`,
`x & M` is in `[0, M]` — the AND clears every bit above M's highest, including the sign bit, so a
negative `x` cannot escape it either. `A[k & 63]` on a 64-element `A` is the idiomatic power-of-two
table index and previously proved nothing.

**2. The promoted-static path built its OWN index, bypassing the shared lowering.** It handled only
`RustType::F64` natively and pushed everything else — including a perfectly good integer expression —
through `(i as f64) as usize` or a `Value::Number` round trip. `emit_index_usize` has had the
int-domain shortcut all along (`(int).max(0) as usize`, where `.max(0)` reproduces f64's
saturate-to-zero for a negative index). This site now calls it.

That second one is where the bulk of the time was: **the GBA has no FPU**, so every `i32 -> f64`
conversion in the index is a soft-float call, per element, in the innermost loop.

STAGED MEASUREMENTS, so the attribution is not guesswork (ticks per read, `examples/bench-access`):

    baseline                          63.2
    + scope-independent bounds proof  19.4     (bounds check gone; f64 index remains)
    + shared index lowering            0.65    (soft-float conversion gone)
    pushed-array baseline              1.69

`sink=126881` is IDENTICAL across all four runs — the loops are not being elided, the same reads
happen and produce the same sum.

⚠️ `bench-access/verify.sh` CANNOT SEE THIS YET, and quietly says so wrongly. It builds via
`npm run build`, which resolves `tish` up to `tish-gba/node_modules/.bin/tish` — a stale PREBUILT
binary — so it re-measured 63.22 and reported every assertion "ok", including the one this issue
says should start failing. Anyone validating this fix must build with `target/release/tish`
directly, or refresh that binary first; otherwise the fix reads as a no-op. Once refreshed, the
"a literal array reads far slower than a pushed one" assertion should be deleted rather than
retuned, per the issue.

VALIDATION
  tishlang_compile   all test binaries, 0 failures
  integration_test   25 passed, 0 failed
  perf gauntlet      --strict soundness gate (typed==boxed==node)
  GBA hardware       bench-access, staged numbers above

Fixes #645