### PR TITLE
perf(native): #647 (part) — a zero-argument fn may lower natively; 553 → 26 ticks

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -12701,9 +12701,16 @@ impl Codegen {
     /// function that mixes the two. A function whose whole signature is `i32` has one convention
     /// and keeps the coercion at the boundary, where the caller does it once on an argument that is
     /// usually already an integer.
+    ///
+    /// #647: ZERO PARAMETERS QUALIFY. The rule above is about keeping ONE coercion convention
+    /// across a signature — and a signature with no parameters has nothing to be inconsistent
+    /// about, so the reason the rule exists cannot apply to it. Excluding it cost every niladic
+    /// accessor (`rCols()`, `rPocket()`, `atkLines()`) a boxed `value_call`: measured at 55 ticks
+    /// against ~0 for the identical body taking one argument. The body proof still runs, so a
+    /// zero-arg fn that touches something unlowerable is rejected on its body, as before — this
+    /// only stops rejecting it on its (empty) parameter list.
     fn fn_sig_all_i32(params: &[FunParam], return_type: &Option<TypeAnnotation>) -> bool {
         return_type.as_ref().is_some_and(Self::ann_is_i32)
-            && !params.is_empty()
             && params.iter().all(|p| {
                 matches!(p, FunParam::Simple(tp)
                     if tp.default.is_none()


### PR DESCRIPTION
perf(native): #647 (part) — a zero-argument fn may lower natively; 553 -> 26 ticks

`fn_sig_all_i32` required `!params.is_empty()`, so a function whose whole signature is `i32` was
refused the native ABI purely for taking no arguments:

    export function call0(): i32 { return 1 }        // 553 ticks — boxed value_call
    export function call4(a: i32, …): i32 { … }      //  26 ticks — direct native fn, inlines

Identical bodies, and the only difference is the parameter count. Every niladic accessor in these
packages paid it — `rCols()`, `rPocket()`, `atkLines()` — on every call.

WHY THE GUARD WAS WRONG. The rule it belongs to is sound and worth keeping: an `: i32` parameter
reached through the boxed path is ToInt32-coerced on entry, while a native `f64` parameter is not, so
`3.7` would arrive as `3` one way and `3.7` the other. Admitting `: i32` per-annotation would do
exactly that to a function mixing the two, which is why the check is all-or-nothing across a
signature.

That reasoning is about keeping ONE convention across a signature. A signature with no parameters has
nothing to be inconsistent about, so the rule cannot apply to it — the empty case was swept up by an
`is_empty()` guard that has no separate justification, and the doc comment never gave one.

The body proof is untouched. A zero-argument function that reads module state, or does anything else
the native path cannot express, is still rejected — on its BODY, which is the correct reason. This
only stops rejecting it on its (empty) parameter list.

MEASURED — `examples/bench-access`, GBA hardware, ticks*100 per op:

    call0()   553 -> 26      (21x; now identical to call1/call4/call8 at 26, which is the
                              empty-loop floor — i.e. the call is free)
    call4()    26 -> 26      unchanged control
    sink      126881         identical, so nothing was optimised away

`call0_native` now appears in the generated crate; `call4_native` (control) still does.

SCOPE — THIS IS THE SMALLER OF THE TWO FALLBACKS #647 OFFERS, not the main ask. The headline request
— lowering a function that TOUCHES MODULE STATE, so `atkBuild`'s seven-integer call stops boxing
seven `Value::Number`s and unboxing them again — is untouched here. That is the same architectural
work as #631: a mutable module array has no top-level home on GBA (it is a `let` inside `run()`), so
a free `fn` has nothing to reach. Shipping the measured 21x rather than holding it behind that.

FOLLOW-UPS this creates, both in tish-gba:
  * `bench-access/verify.sh` asserts `a ZERO-argument call is >10x a 4-argument one` — that should
    now FAIL and be rewritten to pin the new model. ⚠️ It cannot see this yet: it builds via
    `npm run build`, which resolves `tish` to a STALE PREBUILT binary at
    `tish-gba/node_modules/.bin/tish`, so it re-measures the old numbers and reports everything green.
    Refresh that binary (or build with `target/release/tish`) before believing it.
  * #647's own table lists `call0()` as "no twin, 55 ticks"; that row is now wrong.

VALIDATION
  tishlang_compile   all test binaries, 0 failures
  integration_test   25 passed, 0 failed
  perf gauntlet      --strict soundness gate

Partially addresses #647 — the zero-argument fallback only. The headline ask (lowering a fn that touches module state) is left open; it is the same work as #631.