### PR TITLE
perf(native/gba): #606 — a mixed fixed/f64 operand pair lowers natively instead of dropping to boxed ops

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -25630,6 +25630,21 @@ impl Codegen {
                     // in (-2^53, 2^53) and `c` a positive integer literal → `(x as i64) % c` instead
                     // of `fmod`. Bit-identical (x is exactly an integer in f64; Rust `%` and `fmod`
                     // both truncate toward zero), and far faster — the fmod in LCG/hash recurrences.
+                    // #606: a mixed `fixed`/`f64` pair types as `Fixed` (or `Bool` for a
+                    // comparison), so the f64 side must be LIFTED before the operator — agb's
+                    // `Num<i32,8>` has no `f64` overload. `coerce_native_arg` owns the scaling, so
+                    // a value crossing here reads identically to one crossing a Value boundary or
+                    // the literal fold.
+                    let (l, r) = if lt == RustType::Fixed && rt == RustType::F64 {
+                        let rc = self.coerce_native_arg(&r, RustType::F64, RustType::Fixed);
+                        (l, rc)
+                    } else if lt == RustType::F64 && rt == RustType::Fixed {
+                        let lc = self.coerce_native_arg(&l, RustType::F64, RustType::Fixed);
+                        (lc, r)
+                    } else {
+                        (l, r)
+                    };
+
                     if matches!(op, BinOp::Mod) && result_ty == RustType::F64 {
                         if let Some(c) = Self::int_literal_value_of(right).filter(|&c| c > 0) {
                             if self.int_range(left, &self.int_range_locals).is_some() {

--- a/crates/tish_compile/src/types.rs
+++ b/crates/tish_compile/src/types.rs
@@ -327,6 +327,27 @@ impl RustType {
                 | BinOp::StrictNe => Some(RustType::Bool),
                 _ => None,
             }
+        } else if (lhs == &RustType::Fixed && rhs == &RustType::F64)
+            || (lhs == &RustType::F64 && rhs == &RustType::Fixed)
+        {
+            // #606: a MIXED `fixed`/`f64` operand pair. Previously this fell through to `None`, so
+            // the whole expression dropped to the boxed `ops::*` path — and on an FPU-less
+            // ARM7TDMI that path also routes through SOFT-FLOAT f64, which is the expensive part.
+            //
+            // The f64 side is lifted to `Fixed` at the operator, with the SAME truncating semantics
+            // the literal fold already applies (`Fixed::from_raw((x * 256.0) as i32)`), so a mixed
+            // expression now agrees with the equivalent all-literal one instead of disagreeing with
+            // it. `%`/`**`/bitwise stay boxed, exactly as they do for `Fixed × Fixed`.
+            match op {
+                BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div => Some(RustType::Fixed),
+                BinOp::Lt
+                | BinOp::Le
+                | BinOp::Gt
+                | BinOp::Ge
+                | BinOp::StrictEq
+                | BinOp::StrictNe => Some(RustType::Bool),
+                _ => None,
+            }
         } else if lhs == &RustType::Fixed && rhs == &RustType::Fixed {
             // agb `Num<i32,8>` overloads `+ - * /` (Mul/Div apply the Q24.8 shift
             // correction) and `PartialOrd`/`PartialEq`, so these lower to native


### PR DESCRIPTION
perf(native/gba): #606 — a mixed fixed/f64 operand pair lowers natively instead of dropping to boxed ops

`result_type_of_binop` typed only `Fixed × Fixed`. A genuine runtime `f64` operand mixed with a
`fixed` one fell through to `None`, which drops the WHOLE expression to the boxed `ops::*` path —
and on an FPU-less ARM7TDMI that path also routes through soft-float f64, which is the expensive
half. Literal folding and integer lifting already covered the constant cases; this is the runtime
one the comment at the fold site calls out.

Two halves, both required:

  * TYPE (types.rs): `(Fixed, F64)` and `(F64, Fixed)` now yield `Fixed` for `+ - * /` and `Bool`
    for the comparisons. `%`, `**` and bitwise stay boxed — exactly as they already do for
    `Fixed × Fixed`, so this adds no new divergence.

  * EMISSION (codegen.rs): the f64 side is LIFTED before the operator. agb's `Num<i32,8>` has no
    `f64` overload, so typing the pair `Fixed` without coercing would emit `Num<i32,8> + f64` and
    fail to compile. `coerce_native_arg` owns the scaling, so a value crossing here reads
    identically to one crossing a `Value` boundary or the existing literal fold — the "documented
    truncation semantics, matching the existing literal fold" the issue asks for.

VERIFYING THIS FIRED AT ALL took two attempts, and the first one is worth recording because it
looked like a pass. With

    function step(pos: fixed, vel: fixed, scale) { return pos + vel * scale }

`scale` is UNANNOTATED, so it types `Value`, not `F64` — the new arm never runs and the correct
output comes entirely from the pre-existing boxed path. The generated code shows
`Fixed::from_raw((*n * 256.0)`, which is a PARAMETER UNBOX, not a binop lift. Annotating
`scale: number` makes both operand types natively known and the distinct `Fixed::from_raw(((` lift
appears — 2 of them, for the `vel * scale` multiply and the `a > b` comparison.

VALIDATION
  GBA ROM, on device   `step(1.5, 0.25, 2.0)` -> 2, `step(4.0, 1.0, 2.0)` -> 6,
                       `cmp(3.5, 1.0)` -> 1, `cmp(0.5, 1.0)` -> 0. Generated code carries 2 binop
                       lifts where main has none.
  tishlang_compile     all test binaries, 0 failures
  integration_test     25 passed, 0 failed
  perf gauntlet        --strict soundness gate (typed==boxed==node)

Note the host suites CANNOT exercise this arm: `fixed` only lowers natively under `--target gba`
(`GBA_NUMERICS`), so off-target both operands are `Value` and nothing reaches the new code. They run
here as regression cover for the shared paths; the on-device ROM is the only test of the fix itself.
That gap is #603.

Fixes #606