### PR TITLE
feat(build): #618 — package.json `packageOverrides` swaps a module at build time

### DIFF
--- a/crates/tish_compile/src/resolve.rs
+++ b/crates/tish_compile/src/resolve.rs
@@ -1231,6 +1231,29 @@ fn resolve_import_path(
             spec
         ));
     }
+    // #618: build-time package-variant selection. `package.json` may remap an import specifier to
+    // another module, which is tish's equivalent of a cargo feature swapping one implementation for
+    // another:
+    //
+    //     "tish": { "packageOverrides": { "./drop_tables": "./drop_tables_pocket" } }
+    //
+    // Applied to the SPECIFIER before any resolution, so it works for relative paths and package
+    // names alike, and the replacement is then resolved by the ordinary rules (relative to the
+    // importing file, as the original would have been). Matching is exact on the written
+    // specifier — no prefix or glob matching, so an override cannot silently capture an import the
+    // author did not mean to redirect.
+    //
+    // A remapped specifier is NOT re-checked against the override table: one substitution per
+    // import, so a table that maps A->B and B->A terminates instead of looping.
+    let overridden = {
+        let cfg = read_project_tish_config(project_root);
+        cfg.get("packageOverrides")
+            .and_then(|o| o.as_object())
+            .and_then(|o| o.get(spec))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+    };
+    let spec: &str = overridden.as_deref().unwrap_or(spec);
     if !spec.starts_with("./") && !spec.starts_with("../") {
         if let Some(path) = resolve_bare_spec(spec, from_dir, project_root) {
             return Ok(path);


### PR DESCRIPTION
feat(build): #618 — package.json `packageOverrides` swaps a module at build time

tish had no way to select one implementation over another at build time, so a build-time variant had
to be a source edit. Concretely: Magical Drop's board width is a cargo feature on the Rust side
(`pocket`), while the tish port hardcodes `R_COLS: i32 = 7` in a generated `drop_tables.tish`. The
6-wide tables already exist and were simply unreachable — which also puts half the golden
conformance corpus (`*.pocket.trace`) out of reach of the tish core.

    "tish": { "packageOverrides": { "./drop_tables": "./drop_tables_pocket" } }

The remap is applied to the SPECIFIER, before any resolution, so it works the same for a relative
path and a package name, and the replacement then resolves by the ordinary rules — relative to the
importing file, exactly as the original would have.

Three deliberate limits, each so an override cannot do something surprising:

  * EXACT match on the written specifier. No prefix or glob matching, so an override cannot silently
    capture an import the author did not mean to redirect.
  * ONE substitution per import. A remapped specifier is not re-checked against the table, so a
    config mapping `A -> B` and `B -> A` terminates instead of looping.
  * Applied per PROJECT (`package.json` at the project root), which is the granularity the issue
    asks for — one example selects its own variant without affecting a sibling.

VALIDATION — identical source and identical import statement, config alone changes the module:

    no override                                    ->  "wide 7"
    "./tables.tish" -> "./tables_pocket.tish"      ->  "pocket 6"

  tishlang_compile   all test binaries, 0 failures
  integration_test   25 passed, 0 failed

No gauntlet run: this is module resolution, not codegen — no lowering changes.

Fixes #618