### PR TITLE
fix(gba): #655 — give the stack-overflow guard a real floor on GBA

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -3347,9 +3347,11 @@ impl Codegen {
                 Self::collect_native_lcg_fns(&program.statements, &self.native_fns);
             // #381 — fns on a call-graph cycle get guarded rotation copies (default ON;
             // TISH_NATIVE_RECUR_GUARD=0 restores the plain unguarded emission).
-            self.native_recur_fns = if crate::native_recur_guard_enabled()
-                && self.emit_mode != crate::NativeEmitMode::Gba
-            {
+            // #655: GBA was excluded because the no_std runtime had no stack-pressure probe.
+            // `tishlang_runtime_gba` now derives a real floor from the link map (`__iwram_end`),
+            // and it matters MORE here than on the host: 32 KB of IWRAM, no MMU, no guard page,
+            // so an unguarded overflow silently overwrites agb's live data instead of faulting.
+            self.native_recur_fns = if crate::native_recur_guard_enabled() {
                 Self::compute_native_recur_fns(&program.statements, &self.native_fns)
             } else {
                 std::collections::HashMap::new()

--- a/crates/tish_compile/tests/regr_655_gba_stack_guard.rs
+++ b/crates/tish_compile/tests/regr_655_gba_stack_guard.rs
@@ -1,0 +1,41 @@
+//! #655 — the stack-overflow guard must actually be emitted on the GBA target.
+//!
+//! The recursion guard was gated OFF for `NativeEmitMode::Gba` (the no_std runtime had no
+//! stack-pressure probe), and the boxed guard's floor fell back to "never trips". GBA is the one
+//! target where that is unrecoverable: 32 KB of IWRAM, no MMU, no guard page — an unguarded
+//! overflow grows down into agb's live data (the audio mixer's buffers among them) and surfaces
+//! frames later as an illegal opcode at an address that names nothing.
+//!
+//! `tishlang_runtime_gba` now derives a real floor from the link map (`__iwram_end`), so both the
+//! typed and boxed guards are emitted here exactly as they are on the host.
+
+use std::path::PathBuf;
+
+use tishlang_compile::{compile_project_full_emit, NativeEmitMode};
+
+fn gba_rust(fixture: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(fixture);
+    compile_project_full_emit(&path, path.parent(), &[], true, NativeEmitMode::Gba, None)
+        .expect("compile for gba")
+        .0
+}
+
+/// A self-recursive typed fn opens with the stack check and bails through the NaN sentinel.
+#[test]
+fn gba_typed_recursion_emits_stack_guard() {
+    let rust = gba_rust("../../tests/perf/recursion_fib.tish");
+    let copy0 = rust
+        .split("fn fib_native(")
+        .nth(1)
+        .expect("fib_native must be lowered on gba")
+        .split("\nfn ")
+        .next()
+        .unwrap()
+        .to_string();
+    assert!(
+        copy0.contains("tishlang_runtime::stack_low()")
+            && copy0.contains("tishlang_runtime::recursion_tripped_f64()"),
+        "gba typed recursion must open with the stack check — without it an overflow silently \
+         overwrites IWRAM instead of raising a catchable RangeError:\n{copy0}"
+    );
+}

--- a/crates/tish_runtime_gba/src/lib.rs
+++ b/crates/tish_runtime_gba/src/lib.rs
@@ -30,11 +30,60 @@ pub use tishlang_core::{
     has_pending_throw, set_pending_throw, stack_overflow_error, take_pending_throw, CallDepthGuard,
 };
 
-/// Enter a boxed user-fn call frame or trip the recursion guard. On GBA there is
-/// no stack-pressure probe (no `std`), so this is just the counted-depth guard.
+unsafe extern "C" {
+    /// End of the `.iwram` output section — provided by agb's `gba.ld`. IWRAM runs
+    /// 0x0300_0000..0x0300_8000; agb's code/data occupies the bottom and the user
+    /// stack grows DOWN from 0x0300_7F00 toward this address. Anything below it is
+    /// live agb data (the audio mixer's buffers among them), so this is the real
+    /// bottom of the stack.
+    static __iwram_end: u8;
+}
+
+/// Headroom kept above [`__iwram_end`] (#655): must cover the frames emitted between
+/// two guard checks plus the bail path that parks the `RangeError`. Boxed `Value`
+/// frames on GBA run a few hundred bytes each, and the total stack is under 32 KB,
+/// so this is deliberately small relative to the host's 256 KB margin.
+const GBA_STACK_MARGIN: usize = 2 * 1024;
+
+/// #655 — is the GBA stack nearly exhausted? The host probe (`stacker::remaining_stack`)
+/// needs `std` and reports no bounds here, so its `None → floor 1` fallback made the
+/// guard dead code on the one target where overflow is unrecoverable: there is no MMU
+/// and no guard page, so the stack silently grows down into agb's IWRAM data and the
+/// corruption surfaces frames later as an illegal opcode somewhere unrelated.
+///
+/// The bounds ARE known statically here — the linker hands us the IWRAM extent — so
+/// this is a link-time constant plus a pointer compare, about the cost of the
+/// thread-local read it replaces on the host.
+#[inline]
+pub fn stack_low() -> bool {
+    let anchor = 0u8;
+    let sp = &anchor as *const u8 as usize;
+    let floor = (&raw const __iwram_end) as usize + GBA_STACK_MARGIN;
+    sp < floor
+}
+
+/// Enter a boxed user-fn call frame, or trip the recursion guard. Trips on EITHER the
+/// counted ceiling (`tishlang_core`) or real stack pressure ([`stack_low`]) — on a
+/// 32 KB IWRAM stack the counted default is far out of reach, so pressure is the
+/// trigger that actually fires. On trip: parks the catchable `RangeError` and returns
+/// `None`, exactly as on the host.
 #[inline]
 pub fn enter_call_guarded() -> Option<CallDepthGuard> {
+    if stack_low() {
+        set_pending_throw(stack_overflow_error());
+        return None;
+    }
     tishlang_core::enter_call_guarded()
+}
+
+/// #655 — bail path for a tripped typed-fn recursion guard (GBA mirror of the host's
+/// `recursion_tripped_f64`): park the catchable `RangeError` and unwind the numeric
+/// frame with NaN until the first `Value` frame's pending-throw checkpoint raises it.
+#[cold]
+#[inline(never)]
+pub fn recursion_tripped_f64() -> f64 {
+    set_pending_throw(stack_overflow_error());
+    f64::NAN
 }
 
 // ── Error type for throw/return non-local control flow ───────────────────────


### PR DESCRIPTION
Closes #655

The GBA stack-overflow guard was compiled in but could never fire.

## Mechanism

`stack_low()` derives its floor from `stacker::remaining_stack()`, which needs `std` and reports no bounds on a `no_std` build, so the floor fell back to `1` — an SP can never be below it, and the check was dead code. The typed-fn recursion guard (#381) was gated off for `NativeEmitMode::Gba` outright.

That fallback is the right do-no-harm choice on a hosted target: an 8 MB stack with a guard page turns overflow into a clean SIGSEGV. On GBA it is the opposite — 32 KB of IWRAM shared with agb's hot data, no MMU, no guard page. Nothing faults; the stack grows down into live data and the corruption surfaces frames later as an illegal opcode at an address that names nothing.

## Fix

The issue's preferred option: a real floor from the link map. `gba.ld` provides `__iwram_end` (the top of agb's IWRAM code/data — the stack grows down toward it from `0x03007F00`), so the floor is a link-time constant plus a pointer compare, about the cost of the thread-local read it replaces on the host. Both the boxed guard (`enter_call_guarded`) and the typed guard are now emitted on GBA.

## Verification

Real ROMs, run under mgba.

Before:

```
[GAME ERROR] GBA Memory: Bad memory Load8: 0xfffff6be
[WARN] GBA: Illegal opcode: 3629ffff
```

After:

```
[INFO] GBA Debug: CAUGHT-BOXED
[INFO] GBA Debug: ALIVE-BOXED
```

— a catchable `RangeError`, program continues. Confirmed on both the typed and the boxed path.

`regr_655_gba_stack_guard.rs` asserts the guard is emitted in GBA mode; verified to fail without the change. Full workspace suite green (736 tests), including `test_mvp_programs_native`.

## Not verified

hyrule itself — `tish-gba` isn't checked out here, so the overworld-room-boundary crash is unconfirmed against the real game.
