### PR TITLE
fix(resolve): #653 — a local named export must survive collision isolation

### DIFF
--- a/crates/tish/tests/scope_merge.rs
+++ b/crates/tish/tests/scope_merge.rs
@@ -198,3 +198,93 @@ fn colliding_exported_names_are_isolated_across_modules() {
         );
     }
 }
+
+// ── #653: a LOCAL named export (`export { A }`) of a top-level binding ───────────────────────────
+//
+// `collect_module_top_level_names` only treated `export const A` / `export fn f` as exported, so a
+// binding exported via the `export { A }` (no `from`) form looked module-PRIVATE. The isolation pass
+// then renamed it to `A__m0` while the export table still keyed off `A`, pointing every importer at
+// a symbol that no longer existed — "Undefined variable: A" at best, and on the native target the
+// same class of mismatch that #653 saw as a silently wrong constant.
+
+/// Two modules exporting the same constant name, one of them via `export { … }`. Every importer
+/// must land on ITS OWN module's value.
+#[test]
+fn local_named_export_survives_collision_isolation() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(
+        root.join("frames.tish"),
+        "const HERO_WALK = 0\nconst ITEM_BOMB = 0\nexport { HERO_WALK, ITEM_BOMB as IFRAME_BOMB }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("hero.tish"),
+        "export const HERO_WALK = 1\nexport const ITEM_BOMB = 1\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("main.tish"),
+        "import { HERO_WALK, ITEM_BOMB } from \"./hero.tish\"\n\
+         import { HERO_WALK as SLOT, IFRAME_BOMB } from \"./frames.tish\"\n\
+         console.log(HERO_WALK, SLOT, ITEM_BOMB, IFRAME_BOMB)\n",
+    )
+    .unwrap();
+
+    let modules = resolve_project(&root.join("main.tish"), Some(root)).expect("resolve");
+    let merged = merge_modules(modules).expect("merge");
+
+    // Collect top-level declarations and the alias bindings the imports lowered to.
+    let mut declared: Vec<String> = Vec::new();
+    for s in &merged.program.statements {
+        match s {
+            Statement::VarDecl { name, .. } | Statement::FunDecl { name, .. } => {
+                declared.push(name.to_string())
+            }
+            Statement::Export { declaration, .. } => {
+                if let tishlang_ast::ExportDeclaration::Named(inner) = declaration.as_ref() {
+                    if let Statement::VarDecl { name, .. } | Statement::FunDecl { name, .. } =
+                        inner.as_ref()
+                    {
+                        declared.push(name.to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    for s in &merged.program.statements {
+        if let Statement::VarDecl {
+            name,
+            init: Some(Expr::Ident { name: src, .. }),
+            ..
+        } = s
+        {
+            if matches!(name.as_ref(), "HERO_WALK" | "SLOT" | "ITEM_BOMB" | "IFRAME_BOMB") {
+                assert!(
+                    declared.iter().any(|d| d == src.as_ref()),
+                    "import alias `{}` binds to `{}`, which is not declared in the merged program \
+                     (#653: a locally-named export was renamed out from under its export table)",
+                    name,
+                    src
+                );
+            }
+            // The `export { … }` module's bindings must NOT collapse onto the other module's
+            // symbol — that is #653's silent wrong value (`SLOT` reading hero's 1, not frames' 0).
+            if name.as_ref() == "SLOT" {
+                assert_eq!(
+                    src.as_ref(),
+                    "HERO_WALK__m1",
+                    "`SLOT` must bind to frames.tish's own HERO_WALK, not to hero.tish's"
+                );
+            }
+            if name.as_ref() == "IFRAME_BOMB" {
+                assert_eq!(
+                    src.as_ref(),
+                    "ITEM_BOMB__m1",
+                    "`IFRAME_BOMB` must bind to frames.tish's own ITEM_BOMB, not to hero.tish's"
+                );
+            }
+        }
+    }
+}

--- a/crates/tish_compile/src/resolve.rs
+++ b/crates/tish_compile/src/resolve.rs
@@ -1421,6 +1421,22 @@ fn collect_module_top_level_names(
                 collect_module_top_level_names(statements, decls, exported, imports);
             }
             Statement::Export { declaration, .. } => {
+                // #653/#415: a LOCAL named export (`export { A }`, no `from`) exports an
+                // already-declared top-level binding. Without this the binding looks module-private,
+                // gets renamed by the isolation pass below, and the export table — which keys off the
+                // ORIGINAL name — points at a symbol that no longer exists.
+                if let ExportDeclaration::ReExport {
+                    specifiers,
+                    from: None,
+                    ..
+                } = declaration.as_ref()
+                {
+                    for spec in specifiers {
+                        if let ImportSpecifier::Named { name, .. } = spec {
+                            exported.insert(name.to_string());
+                        }
+                    }
+                }
                 if let ExportDeclaration::Named(inner) = declaration.as_ref() {
                     match inner.as_ref() {
                         Statement::VarDecl { name, .. } | Statement::FunDecl { name, .. } => {
@@ -2049,7 +2065,15 @@ pub fn merge_modules(mut modules: Vec<ResolvedModule>) -> Result<MergedProgram, 
                             if let ImportSpecifier::Named { name, alias, .. } = spec {
                                 let export_name =
                                     alias.as_deref().unwrap_or(name.as_ref()).to_string();
-                                module_exports[idx].insert(export_name, name.to_string());
+                                // #653: the local binding may have been renamed for a collision.
+                                // `export_renames` is renamed -> original, so look the other way to
+                                // find the symbol this export name must now point at.
+                                let binding = export_renames[idx]
+                                    .iter()
+                                    .find(|(_, original)| original.as_str() == name.as_ref())
+                                    .map(|(renamed, _)| renamed.clone())
+                                    .unwrap_or_else(|| name.to_string());
+                                module_exports[idx].insert(export_name, binding);
                             }
                         }
                     }


### PR DESCRIPTION
Closes #653

## What actually reproduces

The exact repro in #653 no longer fires — #587 (PR #635) taught `isolate_private_top_level_bindings` to rename colliding *exported* names. But the hole is still open one form over, with the same silent-wrong-value outcome that cost two multi-hour debugging sessions in hyrule.

`collect_module_top_level_names` only recognised `export const A` / `export fn f` as exported. A binding exported through the #415 local-named-export form:

```tish
const HERO_WALK = 0
export { HERO_WALK }
```

looked module-**private**, so the isolation pass renamed it to `HERO_WALK__mN` while the export table still keyed off `HERO_WALK`. Every importer then resolved to whichever *other* module happened to declare that name.

Minimal case, no collision needed:

```tish
// f.tish
const A = 7
export { A }
// main.tish
import { A } from "./f.tish"
console.log(A)     // Error: Undefined variable: A
```

With a colliding name it is worse — no error, just the wrong constant, exactly #653's failure mode:

```
walk walk bomb bomb 1 1 1 1     // before: SLOT reads hero's 1, not frames' 0
walk idle bomb no  1 0 1 0      // after
```

## Fix

Two halves:

1. Record local named exports as exported, so isolation applies the #587 exported-collision policy (rename, and record in `export_renames`) rather than the private one.
2. Resolve the export table for that form through `export_renames`, so the export name still answers to the renamed symbol.

## Verification

interp / vm / native / js all agree on the repro above. `local_named_export_survives_collision_isolation` in `scope_merge.rs` asserts each module's binding stays its own; verified to fail without the change:

```
assertion `left == right` failed: `SLOT` must bind to frames.tish's own HERO_WALK
  left: "HERO_WALK"
 right: "HERO_WALK__m1"
```

Full workspace suite green (736 tests), including `test_mvp_programs_native`.

## Not verified

hyrule itself — `tish-gba` isn't checked out here.
