### PR TITLE
perf(native): #654 — immutable captured bindings need no VmRef cell

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -7129,11 +7129,24 @@ impl Codegen {
 
                 // Rebind outer vars to Rc<RefCell<>> with _cell suffix.
                 // If outer scope already has the var as RefCell, just clone it.
+                //
+                // #654: a READ-ONLY outer var is never assigned anywhere in the defining scope
+                // (that is exactly what keeps it out of `rc_cell_storage`), so the cell can never
+                // change and the indirection buys nothing — it cost a `VmRef` allocation per
+                // closure plus a `RefCell` borrow on EVERY call, to re-fetch a value that was
+                // already fixed. Snapshot it by value instead. This is invisible in the source: a
+                // fn that mentions six named constants was measurably slower than one that inlined
+                // the same six literals, which pushed authors toward magic numbers.
                 for outer_var in &outer_vars {
                     let var_escaped = Self::escape_ident(outer_var);
                     if self.rc_cell_storage_contains(outer_var) {
                         self.writeln(&format!(
                             "let {}_cell = {}.clone();",
+                            var_escaped, var_escaped
+                        ));
+                    } else if read_only_outer_vars.contains(outer_var) {
+                        self.writeln(&format!(
+                            "let {}_capt = {}.clone();",
                             var_escaped, var_escaped
                         ));
                     } else {
@@ -7146,12 +7159,20 @@ impl Codegen {
 
                 self.writeln(&format!("let {} = {{", name_str));
                 self.indent += 1;
-                // Clone RefCell for outer vars so closure can capture
+                // Clone RefCell for outer vars so closure can capture (#654: read-only vars carry
+                // their snapshot in instead — no cell exists for them).
                 for outer_var in &outer_vars {
                     let var_escaped = Self::escape_ident(outer_var);
+                    let suffix = if !self.rc_cell_storage_contains(outer_var)
+                        && read_only_outer_vars.contains(outer_var)
+                    {
+                        "capt"
+                    } else {
+                        "cell"
+                    };
                     self.writeln(&format!(
-                        "let {}_cell = {}_cell.clone();",
-                        var_escaped, var_escaped
+                        "let {}_{} = {}_{}.clone();",
+                        var_escaped, suffix, var_escaped, suffix
                     ));
                 }
                 // Clone the cell so the closure can reference the function recursively
@@ -7328,11 +7349,13 @@ impl Codegen {
                         var_escaped, var_escaped
                     ));
                 }
-                // Read-only outer vars: Value binding from borrow (avoids param-shadow issues)
+                // Read-only outer vars: bind from the captured snapshot (#654 — no cell, no borrow).
+                // `read_only_outer_vars` already excludes everything in `rc_cell_storage`, so every
+                // name here was given a `_capt` snapshot above.
                 for outer_var in &read_only_outer_vars {
                     let var_escaped = Self::escape_ident(outer_var);
                     self.writeln(&format!(
-                        "let {} = (*{}_cell.borrow()).clone();",
+                        "let {} = {}_capt.clone();",
                         var_escaped, var_escaped
                     ));
                 }

--- a/crates/tish_compile/tests/regr_654_readonly_capture.rs
+++ b/crates/tish_compile/tests/regr_654_readonly_capture.rs
@@ -1,0 +1,46 @@
+//! #654 — an immutable captured binding must not be re-read out of a `VmRef` cell on every call.
+//!
+//! A module-level `const` that is never reassigned was still lowered to a `VmRef` cell and
+//! re-borrowed + cloned out of it on EVERY call of any function mentioning it. For a per-frame
+//! function that is repeated work to fetch a value fixed at compile time, and the cost scales with
+//! how many constants the function happens to name — an invisible relationship that pushed authors
+//! toward magic numbers over named constants.
+//!
+//! A read-only captured var is never assigned anywhere in its defining scope (that is exactly what
+//! keeps it out of `rc_cell_storage`), so it is snapshot by value at closure creation instead.
+
+use std::fs;
+
+use tishlang_compile::{compile_project_full_emit, NativeEmitMode};
+
+#[test]
+fn immutable_capture_needs_no_cell() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(
+        root.join("hero.tish"),
+        "export const HERO_NAME = \"link\"\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("main.tish"),
+        "import { HERO_NAME } from \"./hero.tish\"\n\
+         fn heroAnim(t) { return HERO_NAME + t }\n\
+         fn main() { console.log(heroAnim(1)) }\n\
+         main()\n",
+    )
+    .unwrap();
+    let path = root.join("main.tish");
+    let rust = compile_project_full_emit(&path, path.parent(), &[], true, NativeEmitMode::Gba, None)
+        .expect("compile")
+        .0;
+
+    assert!(
+        !rust.contains("HERO_NAME_cell"),
+        "an immutable captured const must not get a VmRef cell (#654):\n{rust}"
+    );
+    assert!(
+        rust.contains("let HERO_NAME = HERO_NAME_capt.clone();"),
+        "the call body must bind from the captured snapshot, not a per-call cell borrow (#654)"
+    );
+}


### PR DESCRIPTION
Closes #654

A module-level `const` that is never reassigned was still lowered to a `VmRef` cell, and every call of any function mentioning it re-borrowed and re-cloned the value out of that cell:

```rust
let HERO_NAME_cell = VmRef::new(HERO_NAME.clone());
Value::native(move |args: &[Value]| {
    let HERO_NAME = (*HERO_NAME_cell.borrow()).clone();   // per call
```

## Fix

A read-only captured var is never assigned anywhere in its defining scope — that is exactly what keeps it out of `rc_cell_storage` — so the cell can never change and the indirection buys nothing. It is now snapshot by value at closure creation:

```rust
let HERO_NAME_capt = HERO_NAME.clone();
Value::native(move |args: &[Value]| {
    let HERO_NAME = HERO_NAME_capt.clone();
```

No `VmRef` allocation per closure, no `RefCell` borrow per call. This is the issue's item 3, and it removes the cell entirely for this case rather than only hoisting the read.

## Verification

Correct on GBA (mgba) and on the host. `regr_654_readonly_capture.rs` asserts no cell is emitted for an immutable capture; verified to fail without the change. Full workspace suite green (736 tests), including `test_mvp_programs_native`, which AOT-builds every fixture.

## Measurement — no host win

Raw `real` seconds, 5M calls through a function naming six constants, host native, two separately-built binaries:

```
pre:  0.84  0.56  0.56  0.67  0.69
post: 0.92  0.62  0.64  0.60  0.61
```

Run-to-run spread exceeds any difference between them. I have no GBA cycle measurement — that needs the `tools/gba-shot` harness in `tish-gba`, which isn't checked out here — so the frame-budget claim in the issue is unverified either way. This lands on the strength of removing an allocation and a per-call borrow, not on a measured host improvement.

## Scope note

Items 1 and 2 of the issue (never-reassigned scalar `const` → Rust `const` / inlined literal) are not done here. A separate promotion path already exists for numeric module consts (`G_*` `SingleCore<Cell<f64>>`), and it fired on every numeric repro I built — including `export const` across modules — so whatever disqualified hyrule's `HERO_WALK` / `HERO_STRIDE` from it is not reproduced. Worth a follow-up against the real ROM.
