### PR TITLE
perf(gba): #581 — stop paying fat LTO on every ROM build

### DIFF
--- a/crates/tish_native/src/build.rs
+++ b/crates/tish_native/src/build.rs
@@ -350,15 +350,90 @@ fn read_facade_agb_version(facade_path: &Path) -> Option<String> {
     None
 }
 
-/// Build a Game Boy Advance ROM from generated `#![no_std]` Rust.
+/// Cargo `[profile.*]` blocks for the nested GBA crate.
 ///
-/// Emits an agb-style cargo project (nightly + build-std + `thumbv4t-none-eabi` +
-/// `gba.ld`) that links the `tishlang_runtime_gba` facade under the `tishlang_runtime`
-/// name (the `package =` rename), builds it, then runs `agb-gbafix` on the ELF.
+/// #581 — the default used to be `lto = "fat"` + `codegen-units = 1`, which dominates wall-clock on
+/// the ~20k-line `run()` a real game generates, and every `tish build --target gba` paid it. Thin
+/// LTO across 8 CGUs keeps most of the size/speed win and lets rustc parallelize; fat LTO stays one
+/// env var away for a ship build.
 ///
-/// Runs its own `cargo build` (NOT `run_cargo_build`) so the `.cargo/config.toml`
-/// rustflags (`-Tgba.ld`, `-Ctarget-cpu=arm7tdmi`) apply — `run_cargo_build` sets a
-/// `RUSTFLAGS` env that would shadow them.
+/// Env knobs (checked here, not by cargo):
+/// - `TISH_FAST_NATIVE_BUILD=1` — iteration profile: no LTO, opt-level 1, many codegen-units.
+///   Same flag as desktop native; use this for day-to-day GBA work.
+/// - `TISH_GBA_FAT_LTO=1` — old ship profile: fat LTO + single CGU (slow; smallest/fastest ROM).
+/// - default — thin LTO, opt-level 3, 8 CGUs, no debuginfo. Much faster than fat LTO while still
+///   producing a solid ROM.
+/// - `TISH_GBA_DEBUG=1` — keep debuginfo in the release profile (slower link; for mgba backtraces).
+fn gba_cargo_profiles_toml() -> String {
+    let debug = if std::env::var("TISH_GBA_DEBUG").as_deref() == Ok("1") {
+        "true"
+    } else {
+        "false"
+    };
+    if std::env::var("TISH_FAST_NATIVE_BUILD").as_deref() == Ok("1") {
+        return format!(
+            r#"[profile.dev]
+opt-level = 1
+debug = {debug}
+
+[profile.dev.build-override]
+opt-level = 1
+
+[profile.release]
+opt-level = 1
+lto = false
+codegen-units = 16
+incremental = true
+debug = {debug}
+panic = "abort"
+
+[profile.release.build-override]
+opt-level = 1
+"#
+        );
+    }
+    if std::env::var("TISH_GBA_FAT_LTO").as_deref() == Ok("1") {
+        return format!(
+            r#"[profile.dev]
+opt-level = 3
+debug = {debug}
+
+[profile.dev.build-override]
+opt-level = 3
+
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+debug = {debug}
+panic = "abort"
+
+[profile.release.build-override]
+opt-level = 3
+"#
+        );
+    }
+    format!(
+        r#"[profile.dev]
+opt-level = 3
+debug = {debug}
+
+[profile.dev.build-override]
+opt-level = 3
+
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 8
+debug = {debug}
+panic = "abort"
+
+[profile.release.build-override]
+opt-level = 3
+"#
+    )
+}
+
 /// Read `version = "…"` from the `[package]` section of a crate's `Cargo.toml`.
 fn read_crate_version(crate_dir: &Path) -> Option<String> {
     let toml = fs::read_to_string(crate_dir.join("Cargo.toml")).ok()?;
@@ -475,6 +550,17 @@ tishlang_runtime = {{ path = {runtime:?}{version}{features} }}
     Ok(())
 }
 
+/// Build a Game Boy Advance ROM from generated `#![no_std]` Rust.
+///
+/// Emits an agb-style cargo project (nightly + build-std + `thumbv4t-none-eabi` +
+/// `gba.ld`) that links the `tishlang_runtime_gba` facade under the `tishlang_runtime`
+/// name (the `package =` rename), builds it, then runs `agb-gbafix` on the ELF.
+///
+/// Runs its own `cargo build` (NOT `run_cargo_build`) so the `.cargo/config.toml`
+/// rustflags (`-Tgba.ld`, `-Ctarget-cpu=arm7tdmi`) apply — `run_cargo_build` sets a
+/// `RUSTFLAGS` env that would shadow them.
+///
+/// Profiles come from [`gba_cargo_profiles_toml`].
 fn build_gba_rom(
     rust_code: &str,
     native_modules: Vec<ResolvedNativeModule>,
@@ -543,6 +629,7 @@ fn build_gba_rom(
     }
 
     let facade = facade_path.display().to_string().replace('\\', "/");
+    let profiles = gba_cargo_profiles_toml();
     let cargo_toml = format!(
         r#"[package]
 name = "tish_output"
@@ -561,20 +648,7 @@ path = "src/main.rs"
 tishlang_runtime = {{ package = "tishlang_runtime_gba", path = {facade:?} }}
 agb = "{agb_version}"
 {more_deps}
-[profile.dev]
-opt-level = 3
-debug = true
-
-[profile.dev.build-override]
-opt-level = 3
-
-[profile.release]
-opt-level = 3
-lto = "fat"
-debug = true
-
-[profile.release.build-override]
-opt-level = 3
+{profiles}
 "#,
     );
     fs::write(build_dir.join("Cargo.toml"), cargo_toml)
@@ -914,5 +988,68 @@ mod tests {
         // `full` expands to every RUNTIME_CARGO_FEATURES entry; redundant `http` must not duplicate.
         assert_eq!(f.len(), super::RUNTIME_CARGO_FEATURES.len());
         assert_eq!(f.iter().filter(|x| *x == "http").count(), 1);
+    }
+
+    // #581 — the GBA ROM profile policy. The default used to be fat LTO + 1 CGU, so every
+    // `tish build --target gba` paid a full fat-LTO link over the ~20k-line `run()` a real game
+    // generates. These assert the policy rather than the wall-clock (which is machine-dependent):
+    // thin by default, fat still reachable, and a genuinely fast iteration profile.
+    //
+    // Serialized because they mutate process-wide env; `gba_cargo_profiles_toml` reads it directly.
+    #[test]
+    fn gba_profiles_follow_581_policy() {
+        use std::sync::Mutex;
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let restore = |k: &str, v: Option<String>| match v {
+            Some(v) => std::env::set_var(k, v),
+            None => std::env::remove_var(k),
+        };
+        let keys = ["TISH_GBA_FAT_LTO", "TISH_FAST_NATIVE_BUILD", "TISH_GBA_DEBUG"];
+        let saved: Vec<_> = keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
+        for k in keys {
+            std::env::remove_var(k);
+        }
+
+        let default = super::gba_cargo_profiles_toml();
+        assert!(
+            default.contains(r#"lto = "thin""#) && default.contains("codegen-units = 8"),
+            "default ROM profile must be thin LTO across 8 CGUs, not fat + 1 (#581):\n{default}"
+        );
+        assert!(
+            !default.contains(r#"lto = "fat""#),
+            "fat LTO must be opt-in, not the default (#581):\n{default}"
+        );
+        assert!(
+            default.contains("debug = false"),
+            "release debuginfo must be opt-in via TISH_GBA_DEBUG (#581)"
+        );
+
+        std::env::set_var("TISH_GBA_FAT_LTO", "1");
+        let ship = super::gba_cargo_profiles_toml();
+        assert!(
+            ship.contains(r#"lto = "fat""#) && ship.contains("codegen-units = 1"),
+            "TISH_GBA_FAT_LTO=1 must still reach the smallest-ROM profile (#581):\n{ship}"
+        );
+        std::env::remove_var("TISH_GBA_FAT_LTO");
+
+        std::env::set_var("TISH_FAST_NATIVE_BUILD", "1");
+        let fast = super::gba_cargo_profiles_toml();
+        assert!(
+            fast.contains("lto = false") && fast.contains("opt-level = 1"),
+            "TISH_FAST_NATIVE_BUILD=1 is the iteration profile — no LTO, opt-level 1 (#581):\n{fast}"
+        );
+        std::env::remove_var("TISH_FAST_NATIVE_BUILD");
+
+        std::env::set_var("TISH_GBA_DEBUG", "1");
+        assert!(
+            super::gba_cargo_profiles_toml().contains("debug = true"),
+            "TISH_GBA_DEBUG=1 must keep release debuginfo (#581)"
+        );
+
+        for (k, v) in saved {
+            restore(k, v);
+        }
     }
 }

--- a/docs/gba-target.md
+++ b/docs/gba-target.md
@@ -74,7 +74,7 @@ serverless/desktop compile.
 | `tish_compile/src/lib.rs` | `NativeEmitMode::Gba` variant | An enum discriminant. |
 | `tish_compile/src/codegen.rs` | ~24 `emit_mode == Gba` sites: no_std header, the `#[agb::entry] agb_main` entry, `gba_no_std_rewrite` (std→core post-pass), scheme-module emission, perf-pass/PropIC/OnceLock gating | All **string** emission — no agb dependency. |
 | `tish_compile/src/types.rs` + `codegen.rs` | `RustType::Fixed` + the `fixed` lowering (emits the `tishlang_runtime::Fixed` alias) | Activates only on a `fixed` annotation. Emits the facade alias, not `agb::` directly. |
-| `tish_native/src/{config.rs,build.rs}` | `NativeBuildConfig::gba()`, `build_gba_rom` (thumbv4t scaffold, `gba.ld`, `agb-gbafix`) | The build driver. Shells out; links no agb into the compiler. The agb **version** is read from the facade's `Cargo.toml` (`read_facade_agb_version`), not hardcoded — one source of truth. |
+| `tish_native/src/{config.rs,build.rs}` | `NativeBuildConfig::gba()`, `build_gba_rom` (thumbv4t scaffold, `gba.ld`, `agb-gbafix`) | The build driver. Shells out; links no agb into the compiler. The agb **version** is read from the facade's `Cargo.toml` (`read_facade_agb_version`), not hardcoded — one source of truth. Nested GBA `Cargo.toml` profiles: default **thin** LTO; `TISH_FAST_NATIVE_BUILD=1` disables LTO for iteration; `TISH_GBA_FAT_LTO=1` restores fat LTO for ship builds; `TISH_GBA_DEBUG=1` keeps release debuginfo. |
 | `tish/src/main.rs` | `--target gba` CLI handling | Selects `NativeBuildConfig::gba()`. |
 
 ### Known couplings (candidates to push further out)
@@ -96,6 +96,40 @@ documented here so the boundary is honest; none breaks the "no agb dependency" i
    parameterizable from the emit mode when a second target appears.
 4. **Toolchain specifics** (`-Tgba.ld`, `-Ctarget-cpu=arm7tdmi`, `mgba-qt`, `agb-gbafix`) in
    `build_gba_rom`. Inherent to "produce a GBA ROM" — this is the compiler's build-driver job.
+
+## ROM build profiles (#581)
+
+`gba_cargo_profiles_toml` in `tish_native/src/build.rs` writes the nested crate's `[profile.*]`.
+Three profiles, selected by env var:
+
+| profile | selected by | `opt-level` / LTO / CGUs |
+|---|---|---|
+| **default** | — | 3 / thin / 8 |
+| ship | `TISH_GBA_FAT_LTO=1` | 3 / fat / 1 |
+| iteration | `TISH_FAST_NATIVE_BUILD=1` | 1 / none / 16, incremental |
+
+`TISH_GBA_DEBUG=1` keeps release debuginfo (for mgba backtraces); it is off by default.
+
+The default used to be the ship profile, so every `tish build --target gba` paid fat LTO over the
+single ~20k-line `run()` a real game generates.
+
+Measured on a synthetic 400-fn ROM (14,173-line generated `main.rs`), incremental rebuild after a
+source change, isolated build dir per profile — note this box was at load average 17, so the
+fat-vs-thin numbers are noise-dominated and only the fast profile separates cleanly:
+
+| profile | rebuild (median of 12 / 4 runs) | ROM bytes |
+|---|---:|---:|
+| fat | ~38 s | 1,386,536 |
+| thin (default) | ~34 s | 1,343,432 |
+| fast | **~1.0 s** | 1,481,024 |
+
+So: thin is not *measurably* faster than fat here — it is not slower either, and it produces a 3.1%
+smaller ROM. **If you want the build-time win, it is `TISH_FAST_NATIVE_BUILD=1`**, which is ~35×
+faster and is the flag to use for day-to-day work. It is deliberately not the default: `opt-level=1`
+would silently make every shipped ROM slow, which is the opposite of what the rest of the GBA perf
+work is for.
+
+All three profiles were verified to boot under mgba and produce identical program output.
 
 ## Server-stability note
 


### PR DESCRIPTION
Closes #581

`build_gba_rom` hardcoded `lto = "fat"` + `codegen-units = 1`, so every `tish build --target gba` paid a full fat-LTO link over the ~20k-line `run()` a real game generates.

> Note: this builds on WIP that was sitting in a local stash in this repo (`gba_cargo_profiles_toml` + the docs cell). I repaired a doc-comment split, added the measurements, and added a test.

## Profiles

One function, `gba_cargo_profiles_toml`, now drives all of them:

| profile | selected by | `opt-level` / LTO / CGUs |
|---|---|---|
| **default** | — | 3 / thin / 8 |
| ship | `TISH_GBA_FAT_LTO=1` | 3 / fat / 1 |
| iteration | `TISH_FAST_NATIVE_BUILD=1` | 1 / none / 16, incremental |

`TISH_GBA_DEBUG=1` keeps release debuginfo, which was previously `debug = true` unconditionally.

## Measurements — read these before assuming a win

Synthetic 400-fn ROM, 14,173-line generated `main.rs`, incremental rebuild after a source change, isolated build dir per profile (alternating profiles in one dir invalidates the cache and measures full rebuilds instead):

| profile | rebuild | ROM bytes |
|---|---:|---:|
| fat | ~38 s (median of 12) | 1,386,536 |
| thin (default) | ~34 s (median of 12) | 1,343,432 |
| fast | **~1.0 s** (median of 4) | 1,481,024 |

**This box was at load average 17**, and the fat/thin samples ranged 31–78 s. Thin is *not* measurably faster than fat on this data — it is not slower either, and its ROM is 3.1% smaller. The issue's acceptance criterion ("measurably faster wall-clock vs current fat LTO") is therefore **not met by my measurement**, and I would rather say so than publish a number the noise does not support. Someone with a quiet machine and a real game should re-run it.

The build-time win that *is* unambiguous is the fast profile at ~35×. It stays opt-in on purpose: defaulting to `opt-level = 1` would silently make every shipped ROM slow, which is the opposite of what the rest of the GBA perf backlog is for. That is issue item 4, deliberately not taken.

## Verification

All three profiles built and booted under mgba with identical program output (`T -253158`).

`gba_profiles_follow_581_policy` pins the policy — thin by default, fat reachable, fast genuinely fast, debuginfo opt-in — so the default cannot drift back.

Items 1, 2 and 3 of the issue are done (thin default, escape hatches, one policy function). Item 4 is declined as above.
