### PR TITLE
perf(gba): #663 — only box an escaping array when the callee can actually alias it

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1000,6 +1000,18 @@ struct ParamUse {
     /// could mutate the array, and a write to the caller's array would be lost on the owned copy.
     /// `classify_vec_param` ignores this field; only `native_arr_param_fns` reads it.
     forwarded: bool,
+    /// #663 — one entry per site that set `forwarded`, naming the callee and argument position
+    /// where determinable. Populated at the same place as `forwarded`, so it is exactly as complete.
+    forward_sites: Vec<ForwardSite>,
+}
+
+/// #663 — where a bare array argument was handed to a callee.
+#[derive(Debug, Clone, PartialEq)]
+enum ForwardSite {
+    /// `f(arr)` with `f` a plain identifier — the body may be inspectable.
+    Named(String, usize),
+    /// A method call, computed callee, or native-module member: the body is not visible.
+    Opaque,
 }
 
 /// #175 — kind of one parameter of a native-vec free fn (spectral_norm/queens shape).
@@ -19080,11 +19092,82 @@ impl Codegen {
             // is about. Using it deopted arrays that are legitimately native
             // (`numeric_returning_fn_keeps_pushed_array_native`). #597 is specifically "passed as a
             // call argument", which is what `forwarded` means.
-            if f.forwarded {
+            //
+            // #663: being forwarded is not by itself an aliasing hazard — it is a hazard only if
+            // the CALLEE can mutate the array or let it escape. When every forwarding site targets
+            // a local fn whose corresponding parameter provably does neither, boxing the array buys
+            // nothing and costs a boxed read on every OTHER access, which is usually a hot loop
+            // while the call that caused it may run once per level.
+            if f.forwarded && !Self::forward_sites_are_harmless(stmts, &f.forward_sites) {
                 out.insert(n.clone());
             }
         }
         out
+    }
+
+    /// #663 — can every call that received this array be trusted not to alias or mutate it?
+    ///
+    /// True only when EVERY recorded site names a locally-declared `fn` (so the body is visible)
+    /// and that fn's parameter in the receiving position is neither written, escaped, nor forwarded
+    /// onward. Anything opaque — a `cargo:` native, a method call, a value-position callee, an
+    /// unknown arity — is false, and the array keeps today's conservative boxing.
+    ///
+    /// Being forwarded is not by itself an aliasing hazard; it is one only if the callee can write
+    /// through the reference or let it escape. Boxing on the mere fact of a call costs a boxed read
+    /// on every OTHER access — usually a hot loop, while the call that caused it may run once.
+    fn forward_sites_are_harmless(stmts: &[Statement], sites: &[ForwardSite]) -> bool {
+        if sites.is_empty() {
+            return false; // `forwarded` was set but nothing was recorded — do not assume safety
+        }
+        for site in sites {
+            let ForwardSite::Named(callee, pos) = site else {
+                return false; // opaque callee
+            };
+            let Some((params, body)) = Self::find_local_fn(stmts, callee) else {
+                return false; // an import, a native, or a value-position closure
+            };
+            let Some(FunParam::Simple(tp)) = params.get(*pos) else {
+                return false; // rest/destructured param, or fewer params than args
+            };
+            let mut pu = ParamUse::default();
+            Self::for_each_stmt_expr(body, &mut |e| {
+                Self::scan_param_use(e, tp.name.as_ref(), false, &mut pu)
+            });
+            if pu.is_mut || pu.escaped || pu.forwarded {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// #663 — locate a top-level `fn NAME` so its parameter uses can be inspected. Only top-level
+    /// declarations: a nested one is not reliably the callee at an arbitrary call site.
+    fn find_local_fn<'a>(
+        stmts: &'a [Statement],
+        name: &str,
+    ) -> Option<(&'a [FunParam], &'a Statement)> {
+        for s in stmts {
+            let inner = match s {
+                Statement::Export { declaration, .. } => match declaration.as_ref() {
+                    tishlang_ast::ExportDeclaration::Named(inner) => inner.as_ref(),
+                    _ => continue,
+                },
+                other => other,
+            };
+            if let Statement::FunDecl {
+                name: fname,
+                params,
+                rest_param: None,
+                body,
+                ..
+            } = inner
+            {
+                if fname.as_ref() == name {
+                    return Some((params.as_slice(), body.as_ref()));
+                }
+            }
+        }
+        None
     }
 
     fn for_each_expr_root(stmts: &[Statement], f: &mut dyn FnMut(&Expr)) {
@@ -22035,6 +22118,23 @@ impl Codegen {
                         CallArg::Expr(Expr::Ident { name, .. }) if name.as_ref() == p => {
                             // forward (native-vec re-borrows; arr-param owned-copy must reject).
                             f.forwarded = true;
+                            // #663 — record WHERE it was forwarded, so a caller can ask whether the
+                            // callee could actually alias or mutate it. Recorded here, at the one
+                            // site that sets `forwarded`, so the record can never be less complete
+                            // than the flag itself — a separate AST walk could miss an expression
+                            // variant and silently call a real forward "harmless".
+                            match callee.as_ref() {
+                                Expr::Ident { name: cn, .. } => {
+                                    f.forward_sites.push(ForwardSite::Named(
+                                        cn.to_string(),
+                                        args.iter()
+                                            .position(|x| std::ptr::eq(x, a))
+                                            .unwrap_or(usize::MAX),
+                                    ));
+                                }
+                                // Method call, computed callee, native module member: body unknown.
+                                _ => f.forward_sites.push(ForwardSite::Opaque),
+                            }
                         }
                         CallArg::Expr(e) | CallArg::Spread(e) => {
                             Self::scan_param_use(e, p, false, f)

--- a/crates/tish_compile/tests/fixtures_663_array_escape.tish
+++ b/crates/tish_compile/tests/fixtures_663_array_escape.tish
@@ -1,0 +1,34 @@
+let C: i32[] = []
+let D: i32[] = []
+let E: i32[] = []
+let F: i32[] = []
+let keep = null
+let ci: i32 = 0
+while (ci < 4) { C.push(ci); ci = ci + 1 }
+let di: i32 = 0
+while (di < 4) { D.push(di); di = di + 1 }
+let ei: i32 = 0
+while (ei < 4) { E.push(ei); ei = ei + 1 }
+let fi: i32 = 0
+while (fi < 4) { F.push(fi); fi = fi + 1 }
+
+fn mutate(arr) { arr[0] = 99 }
+fn onward(arr) { return mutate(arr) }
+fn stash(arr) { keep = arr }
+fn readLen(arr) { return arr.length }
+
+export fn sumF(): i32 {
+  let acc: i32 = 0
+  let i: i32 = 0
+  while (i < 4) { acc = acc + F[i]; i = i + 1 }
+  return acc
+}
+
+fn main() {
+  mutate(C)
+  onward(D)
+  stash(E)
+  console.log("C0=" + C[0] + " D0=" + D[0] + " E0=" + E[0])
+  console.log("Flen=" + readLen(F) + " sumF=" + sumF())
+}
+main()

--- a/crates/tish_compile/tests/regr_663_array_escape.rs
+++ b/crates/tish_compile/tests/regr_663_array_escape.rs
@@ -1,0 +1,53 @@
+//! #663 — passing a typed module array to a call must not de-optimise EVERY read of it.
+//!
+//! `collect_escaping_array_names` (#597) boxed an annotated array as soon as it was passed as a call
+//! argument, to preserve aliasing. But being forwarded is only an aliasing hazard if the CALLEE can
+//! write through the reference or let it escape; when it cannot, boxing buys nothing and costs a
+//! boxed read on every OTHER access — usually a hot loop, while the call that caused it may run once
+//! per level. Measured at 3.8x per read in the report.
+//!
+//! These assert the SPLIT: a read-only callee leaves the array typed, and every aliasing shape still
+//! boxes. The aliasing half is the one that must not regress — getting it wrong is a silent wrong
+//! answer, not a slow one.
+
+use std::path::PathBuf;
+
+use tishlang_compile::{compile_project_full_emit, NativeEmitMode};
+
+fn gba_rust(fixture: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join(fixture);
+    compile_project_full_emit(&path, path.parent(), &[], true, NativeEmitMode::Gba, None)
+        .expect("compile for gba")
+        .0
+}
+
+/// `A.borrow()` + `.get(i).copied()` is the typed read; `get_index(&vm_read(&A), ..)` is the boxed one.
+fn is_typed(rust: &str, name: &str) -> bool {
+    rust.contains(&format!("let __bg = {name}.borrow()"))
+}
+
+#[test]
+fn readonly_callee_leaves_the_array_typed() {
+    let rust = gba_rust("fixtures_663_array_escape.tish");
+    assert!(
+        is_typed(&rust, "F"),
+        "F is passed only to a read-only callee (`arr.length`), so it must keep the typed read \
+         path — boxing it costs 3.8x on every read for a call that cannot alias it (#663)"
+    );
+}
+
+#[test]
+fn aliasing_callees_still_box() {
+    let rust = gba_rust("fixtures_663_array_escape.tish");
+    for (name, why) in [
+        ("C", "the callee WRITES an element (`arr[0] = 99`)"),
+        ("D", "the callee FORWARDS it to a mutating fn"),
+        ("E", "the callee lets it ESCAPE (stores it in a module var)"),
+    ] {
+        assert!(
+            !is_typed(&rust, name),
+            "{name} must stay boxed — {why}, so a typed (copied) representation would silently \
+             lose a caller-visible mutation (#663/#597)"
+        );
+    }
+}


### PR DESCRIPTION
Closes #663

`collect_escaping_array_names` (#597) boxed an annotated module array as soon as it was passed as a call argument, to preserve aliasing. But being forwarded is only an aliasing hazard if the **callee** can write through the reference or let it escape. Boxing on the mere fact of a call costs a boxed read on every *other* access — usually a hot loop, while the call that caused it may run once per level.

An array now stays typed when **every** forwarding site names a locally-declared `fn` whose receiving parameter is neither written, escaped, nor forwarded onward. Anything opaque — a `cargo:` native, a method call, a value-position callee, a rest/destructured param, an unknown arity — keeps today's conservative boxing.

## Where the sites are recorded, and why it matters

They are collected inside `scan_param_use`, at the one place that already sets `forwarded` — not by a second AST walk. A separate walker could miss an expression variant and silently classify a real forward as harmless, which is a *wrong answer* rather than a slow one. Recording at the same site makes the list exactly as complete as the flag.

## Verification

`tests/fixtures_663_array_escape.tish` exercises four arrays differing only in what their callee does:

| array | callee does | result |
|---|---|---|
| `F` | `arr.length` — read-only | **typed** (the win) |
| `C` | `arr[0] = 99` — writes | boxed |
| `D` | forwards to a mutating fn | boxed |
| `E` | stores it in a module var | boxed |

Ran on GBA under mgba and matched interp / vm / node exactly. Full workspace suite green — 740 tests, including `test_mvp_programs_native`.

## Two things worth flagging

**The trigger is broader than reported.** It is not specific to `cargo:` natives — passing the array to any ordinary tish function de-optimises it the same way. My repro uses a plain `fn takesArr(arr) { return arr.length }`.

**#597 was never fixed off-GBA, and the host is silently wrong.** The escape analysis is gated on `NativeEmitMode::Gba`, so on the host native backend an array passed to a mutating callee stays typed and the callee gets a copy — the mutation is lost:

```tish
let C: i32[] = [0, 1, 2, 3]
fn mutate(arr) { arr[0] = 99 }
mutate(C)
console.log(C[0])
```

interp / vm / node print `99`; host native prints `0`. Confirmed on `main` without this change, so it is pre-existing and out of scope here — I am filing it separately. It does mean the fixture cannot live in `tests/core` (which requires every backend to agree), so the regression test asserts the codegen split directly instead.

Branch is based on current `main` (96c71364a).
