### PR TITLE
perf(gba): #658 — keep the bounds-checked promoted-array read in the integer domain

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -25882,26 +25882,55 @@ impl Codegen {
                                         .map(|v| v.len())
                                 })
                                 .unwrap_or(0);
-                            // OUT-OF-RANGE STAYS f64. An unproven index still has to be able to
-                            // answer `NaN`, and there is no `i32` that means "absent" — picking a
-                            // sentinel here would silently turn a missing element into a real value.
-                            // So the bounds-checked form keeps today's exact semantics and only the
-                            // STORAGE narrows; the integer win is claimed above, where the index is
-                            // proven and no sentinel is reachable.
-                            let elem = if is_int {
-                                format!("{}[_i] as f64", static_name)
-                            } else {
-                                format!("{}[_i]", static_name)
-                            };
+                            // #658 — THE BOUNDS-CHECKED FALLBACK STAYS IN THE INTEGER DOMAIN TOO.
+                            //
+                            // The previous note here reasoned that out-of-range "still has to be
+                            // able to answer NaN, and there is no i32 that means absent". The
+                            // premise does not survive checking what the other backends answer:
+                            //
+                            //     let LIT: i32[] = [...]
+                            //     console.log(LIT[999999])
+                            //     interp / vm / node -> null      native -> NaN
+                            //
+                            // So `NaN` is not a semantic being preserved — it is already a
+                            // native-only divergence, and no backend agrees with it. Keeping the
+                            // f64 round trip to protect it bought nothing and cost two soft-float
+                            // calls per element on a chip with no FPU: `G_LIT[_i] as f64` widening
+                            // on the way out and `as i32` narrowing at the consumer. Measured in
+                            // the report at ~25 ticks/element against ~0.4 for the identical read
+                            // behind a mask, where the index happens to be provably in range.
+                            //
+                            // An integer consumer is unaffected either way — `f64::NAN as i32` is
+                            // already 0 in Rust, which is exactly the sentinel used here, so the
+                            // common case is byte-identical and simply loses the conversions. Only
+                            // a read that reaches a BOXED context can tell the difference, and
+                            // there it trades one wrong answer (NaN) for another (0); neither
+                            // matches the `null` every other backend gives. That divergence is
+                            // pre-existing and tracked separately — it is not what this path is
+                            // for, and it is not made worse by removing the conversions.
+                            if is_int {
+                                let access = if const_len > 0 {
+                                    format!(
+                                        "{{ let _i = {}; if _i < {} {{ {}[_i] }} else {{ 0 }} }}",
+                                        idx_usize, const_len, static_name
+                                    )
+                                } else {
+                                    format!(
+                                        "{{ let _i = {}; if _i < {}.len() {{ {}[_i] }} else {{ 0 }} }}",
+                                        idx_usize, static_name, static_name
+                                    )
+                                };
+                                return Ok((access, RustType::I32));
+                            }
                             let access = if const_len > 0 {
                                 format!(
-                                    "{{ let _i = {}; if _i < {} {{ {} }} else {{ f64::NAN }} }}",
-                                    idx_usize, const_len, elem
+                                    "{{ let _i = {}; if _i < {} {{ {}[_i] }} else {{ f64::NAN }} }}",
+                                    idx_usize, const_len, static_name
                                 )
                             } else {
                                 format!(
-                                    "{{ let _i = {}; if _i < {}.len() {{ {} }} else {{ f64::NAN }} }}",
-                                    idx_usize, static_name, elem
+                                    "{{ let _i = {}; if _i < {}.len() {{ {}[_i] }} else {{ f64::NAN }} }}",
+                                    idx_usize, static_name, static_name
                                 )
                             };
                             return Ok((access, RustType::F64));

--- a/crates/tish_compile/tests/fixtures_658_int_index.tish
+++ b/crates/tish_compile/tests/fixtures_658_int_index.tish
@@ -1,0 +1,18 @@
+let LIT: i32[] = [10, 20, 30, 40, 50, 60, 70, 80]
+let WARM: i32[] = [0, 0, 0, 0]
+
+export fn addIndex(base: i32, n: i32) {
+  let i: i32 = 0
+  while (i < n) { WARM[i] = LIT[base + i]; i = i + 1 }
+}
+export fn maskIndex(base: i32, n: i32) {
+  let i: i32 = 0
+  while (i < n) { WARM[i] = LIT[(base + i) & 7]; i = i + 1 }
+}
+fn main() {
+  addIndex(2, 4)
+  console.log("add=" + WARM[0] + "," + WARM[3])
+  maskIndex(2, 4)
+  console.log("mask=" + WARM[0] + "," + WARM[3])
+}
+main()

--- a/crates/tish_compile/tests/regr_658_int_bounds_fallback.rs
+++ b/crates/tish_compile/tests/regr_658_int_bounds_fallback.rs
@@ -1,0 +1,55 @@
+//! #658 — the BOUNDS-CHECKED read of a promoted integer array must stay in the integer domain.
+//!
+//! #645 gave the masked/provably-in-range read a direct `G_LIT[i]` load. The fallback emitted for
+//! every other index shape stayed `f64`, so a merely-computed index paid two soft-float calls per
+//! element on a chip with no FPU — `G_LIT[_i] as f64` on the way out and `as i32` at the consumer.
+//! The report measures ~25 ticks/element against ~0.4 for the identical read behind a mask.
+//!
+//! The `f64::NAN` sentinel that shape existed to preserve is not a semantic any backend agrees
+//! with: interp/vm/node all answer `null` for an out-of-range read, and only native answered `NaN`.
+//! An integer consumer cannot tell the difference either way, since `f64::NAN as i32` is already 0.
+
+use std::path::PathBuf;
+
+use tishlang_compile::{compile_project_full_emit, NativeEmitMode};
+
+fn gba_rust(fixture: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join(fixture);
+    compile_project_full_emit(&path, path.parent(), &[], true, NativeEmitMode::Gba, None)
+        .expect("compile for gba")
+        .0
+}
+
+#[test]
+fn computed_index_read_has_no_f64_round_trip() {
+    let rust = gba_rust("fixtures_658_int_index.tish");
+    let lit = rust
+        .lines()
+        .filter(|l| l.contains("G_LIT[_i]"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !lit.is_empty(),
+        "expected a bounds-checked read of the promoted array:\n{rust}"
+    );
+    assert!(
+        !lit.contains("G_LIT[_i] as f64"),
+        "the bounds-checked read must not widen the element to f64 — on ARM7TDMI that is a \
+         soft-float call per element, and the `as i32` at the consumer is a second one (#658):\n{lit}"
+    );
+    assert!(
+        !lit.contains("f64::NAN"),
+        "an integer array's fallback must use an integer sentinel, not NaN — the NaN branch is \
+         what forced the whole expression back into the f64 domain (#658):\n{lit}"
+    );
+}
+
+/// The proven-in-range form (#645) must still be the bare load — this must not regress it.
+#[test]
+fn masked_index_read_stays_a_direct_load() {
+    let rust = gba_rust("fixtures_658_int_index.tish");
+    assert!(
+        rust.contains("G_LIT[((("),
+        "the masked index must remain a direct integer-domain load (#645):\n{rust}"
+    );
+}


### PR DESCRIPTION
Closes #658

#645 gave the masked / provably-in-range read a direct `G_LIT[i]` load. The **bounds-checked fallback** emitted for every other index shape stayed `f64`:

```rust
{ let _i = ...; if _i < 2304 { G_LIT[_i] as f64 } else { f64::NAN } } as i32
```

Two soft-float calls per element on a chip with no FPU — one widening on the way out, one narrowing at the consumer. Now:

```rust
{ let _i = ...; if _i < 2304 { G_LIT[_i] } else { 0 } }
```

## The NaN sentinel was not protecting a semantic

The comment on that branch reasoned that an unproven index "still has to be able to answer NaN, and there is no i32 that means absent". I checked what the other backends actually answer for an out-of-range read of a promoted `i32[]`:

| backend | `LIT[999999]` |
|---|---|
| interp | `null` |
| vm | `null` |
| node | `null` |
| **native** | **`NaN`** |

`NaN` was already a native-only divergence that nothing agrees with, so the f64 round trip was preserving nothing. This is what removes the objection the issue itself anticipated ("it would be worth gating on the declared element type").

An integer consumer cannot tell the difference either way — `f64::NAN as i32` is already `0` in Rust, which is exactly the sentinel used here — so the common case is byte-identical and simply loses the conversions.

**What does change:** an out-of-range read that reaches a *boxed* context now yields `0` where it used to yield `NaN`. Neither matches the `null` every other backend gives, so this trades one wrong answer for another rather than introducing a new divergence. I'd rather state that plainly than claim it is a no-op. Non-integer promoted arrays keep the f64/NaN form untouched.

## Verification

On GBA under mgba, the additive-index result now matches the masked one and matches interp/vm/node:

```
add=30,60
mask=30,60
```

Two regression tests: one pins the absence of the `as f64` / `f64::NAN` round trip on the computed index (confirmed to fail without the change), one pins that #645's direct masked load has not regressed.

Full workspace suite green — 738 tests, including `test_mvp_programs_native`.

Branch is based on current `main` (0158b5c2e).
