### PR TITLE
fix(resolve): #659 — two modules must not bind the same top-level name via imports

### DIFF
--- a/crates/tish/tests/scope_merge.rs
+++ b/crates/tish/tests/scope_merge.rs
@@ -288,3 +288,115 @@ fn local_named_export_survives_collision_isolation() {
         }
     }
 }
+
+// ── #659: two modules binding the same top-level name via IMPORTS ───────────────────────────────
+//
+// Import specifiers lower to `const <bind> = <source>` in the one merged scope, so two modules that
+// pick the same `bind` emitted two `const`s with one name. `tish build` succeeded, so only
+// `node --check` or actually loading the bundle caught it — it could ship unnoticed.
+//
+// Two distinct cases, and the second is worse than the reported one:
+//   same source      -> duplicate but equivalent; one alias serves every importer (dedupe)
+//   different source -> the second SHADOWS the first, so a call in the FIRST module silently ran
+//                       the other module's function, on interp and vm too, not just JS
+
+/// Reported case: `a` and `b` both `import { field }` from the same dep, and a third module's own
+/// `field` forces the dep's export to be renamed (which is what makes an alias get emitted at all).
+#[test]
+fn same_symbol_imported_twice_emits_one_alias() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("util.tish"), "export fn field(o) { return o }\n").unwrap();
+    fs::write(
+        root.join("a.tish"),
+        "import { field } from \"./util.tish\"\nexport fn useA(o) { return field(o) }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("b.tish"),
+        "import { field } from \"./util.tish\"\nexport fn useB(o) { return field(o) }\n",
+    )
+    .unwrap();
+    // c declares its OWN `field` — this is what triggers the renaming, per the report.
+    fs::write(
+        root.join("c.tish"),
+        "fn field(o) { return o }\nexport fn useC(o) { return field(o) }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("main.tish"),
+        "import { useA } from \"./a.tish\"\n\
+         import { useB } from \"./b.tish\"\n\
+         import { useC } from \"./c.tish\"\n\
+         console.log(useA(1), useB(2), useC(3))\n",
+    )
+    .unwrap();
+
+    let modules = resolve_project(&root.join("main.tish"), Some(root)).expect("resolve");
+    let merged = merge_modules(modules).expect("merge");
+
+    let bare_field_decls = merged
+        .program
+        .statements
+        .iter()
+        .filter(|s| matches!(s, Statement::VarDecl { name, .. } if name.as_ref() == "field"))
+        .count();
+    assert!(
+        bare_field_decls <= 1,
+        "two importers of the same symbol must share ONE top-level alias — {} were emitted, which \
+         is `SyntaxError: Identifier 'field' has already been declared` in the js bundle (#659)",
+        bare_field_decls
+    );
+}
+
+/// The worse half: same local name, DIFFERENT symbols. Each module must keep its own.
+#[test]
+fn same_name_different_symbols_do_not_shadow() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(root.join("u1.tish"), "export fn x(v) { return \"x1\" }\n").unwrap();
+    fs::write(root.join("u2.tish"), "export fn y(v) { return \"y2\" }\n").unwrap();
+    fs::write(
+        root.join("a.tish"),
+        "import { x as f } from \"./u1.tish\"\nexport fn useA() { return f(1) }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("b.tish"),
+        "import { y as f } from \"./u2.tish\"\nexport fn useB() { return f(2) }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("main.tish"),
+        "import { useA } from \"./a.tish\"\n\
+         import { useB } from \"./b.tish\"\n\
+         console.log(useA(), useB())\n",
+    )
+    .unwrap();
+
+    let modules = resolve_project(&root.join("main.tish"), Some(root)).expect("resolve");
+    let merged = merge_modules(modules).expect("merge");
+
+    // Each alias must bind a DISTINCT name; if both are `f`, the second shadows the first and
+    // `useA()` silently returns "y2" — on every backend, not only in the js bundle.
+    let alias_names: Vec<&str> = merged
+        .program
+        .statements
+        .iter()
+        .filter_map(|s| match s {
+            Statement::VarDecl { name, init: Some(Expr::Ident { .. }), .. }
+                if name.starts_with('f') =>
+            {
+                Some(name.as_ref())
+            }
+            _ => None,
+        })
+        .collect();
+    let bare_f = alias_names.iter().filter(|n| **n == "f").count();
+    assert!(
+        bare_f <= 1,
+        "two modules binding different symbols to `f` must not both declare `f` — the second \
+         shadows the first and the first module's calls run the wrong function (#659). Got {:?}",
+        alias_names
+    );
+}

--- a/crates/tish_compile/src/resolve.rs
+++ b/crates/tish_compile/src/resolve.rs
@@ -1582,6 +1582,108 @@ fn isolate_private_top_level_bindings(modules: &mut [ResolvedModule]) -> Vec<Has
     export_renames
 }
 
+/// #659 — give a module a private name for an import binding that another module already bound to a
+/// DIFFERENT symbol in the merged top-level scope.
+///
+/// Import specifiers lower to `const <bind> = <source>` (only when `bind != source`; an import of a
+/// name the dep declares under that same name emits nothing and cannot collide). Two modules that
+/// pick the same `bind` therefore emit two `const`s with one name:
+///
+/// ```text
+/// const field = field__m0;   // module a
+/// const field = field__m0;   // module b   — duplicate declaration
+/// ```
+///
+/// Same source, so the value was at least right and only the JS target rejected it. When the sources
+/// differ the merge is actively wrong — `import { x as f }` in one module and `import { y as f }` in
+/// another leaves both modules calling whichever landed second, on interp and vm too.
+///
+/// First binder of a name keeps it; later modules that would bind it to something else get
+/// `<name>__i<idx>` and have their own references rewritten. A module re-binding it to the SAME
+/// source is left alone — the emitter already skips the redundant alias, so nothing collides.
+fn isolate_conflicting_import_aliases(
+    modules: &mut [ResolvedModule],
+    module_exports: &[HashMap<String, String>],
+    path_to_idx: &HashMap<PathBuf, usize>,
+) {
+    // bind name -> the source symbol the first module bound it to.
+    let mut claimed: HashMap<String, String> = HashMap::new();
+    for i in 0..modules.len() {
+        let dir = modules[i]
+            .path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf();
+        let mut renames: HashMap<String, Arc<str>> = HashMap::new();
+        // Collect this module's (bind, source) pairs without holding a borrow of `modules`.
+        let mut pairs: Vec<(String, String)> = Vec::new();
+        for stmt in &modules[i].program.statements {
+            let Statement::Import { specifiers, from, .. } = stmt else {
+                continue;
+            };
+            let Some(dep_idx) = resolve_import_path(from.as_ref(), &dir, Path::new("."))
+                .ok()
+                .map(|p| p.canonicalize().unwrap_or(p))
+                .and_then(|p| path_to_idx.get(&p).copied())
+            else {
+                continue; // native/builtin import — not a tish module in the merge set
+            };
+            for spec in specifiers {
+                if let ImportSpecifier::Named { name, alias, .. } = spec {
+                    let source = module_exports[dep_idx]
+                        .get(name.as_ref())
+                        .cloned()
+                        .unwrap_or_else(|| name.to_string());
+                    let bind = alias.as_deref().unwrap_or(name.as_ref()).to_string();
+                    if bind != source {
+                        pairs.push((bind, source));
+                    }
+                }
+            }
+        }
+        for (bind, source) in pairs {
+            match claimed.get(&bind) {
+                // Someone already bound this name to a DIFFERENT symbol — take a private one.
+                Some(prev) if *prev != source => {
+                    renames.insert(bind.clone(), Arc::from(format!("{bind}__i{i}")));
+                }
+                // Same symbol, or unclaimed: the first binder keeps the bare name.
+                Some(_) => {}
+                None => {
+                    claimed.insert(bind, source);
+                }
+            }
+        }
+        if renames.is_empty() {
+            continue;
+        }
+        for stmt in &mut modules[i].program.statements {
+            rewrite_import_binding(stmt, &renames);
+        }
+        for stmt in &mut modules[i].program.statements {
+            let mut active = renames.clone();
+            rewrite_stmt_scope(stmt, &mut active, true);
+        }
+    }
+}
+
+/// #659 — rewrite the LOCAL binding name of each import specifier per `renames`. The export name the
+/// specifier asks the dep for is untouched; only the name this module binds it to moves, so import
+/// resolution is unaffected and the merged scope stops colliding.
+fn rewrite_import_binding(stmt: &mut Statement, renames: &HashMap<String, Arc<str>>) {
+    let Statement::Import { specifiers, .. } = stmt else {
+        return;
+    };
+    for spec in specifiers.iter_mut() {
+        if let ImportSpecifier::Named { name, alias, .. } = spec {
+            let bound = alias.as_deref().unwrap_or(name.as_ref()).to_string();
+            if let Some(renamed) = renames.get(&bound) {
+                *alias = Some(Arc::clone(renamed));
+            }
+        }
+    }
+}
+
 /// Apply the rename for a *declared* name. At module top level the binding is the canonical
 /// private one — rename it. In a nested scope the same name is a shadow — drop it from `active`
 /// so the inner binding and its references keep their own identity.
@@ -2082,6 +2184,15 @@ pub fn merge_modules(mut modules: Vec<ResolvedModule>) -> Result<MergedProgram, 
         }
     }
 
+    // #659: two modules can bind the SAME top-level name to DIFFERENT symbols via imports. Each
+    // lowers to `const <bind> = <source>` in the one merged scope, which is a duplicate `const`
+    // (SyntaxError) on the JS target and — when the sources differ — a silently wrong program on
+    // every backend, because the second binding shadows the first. Runs here, after the export
+    // table exists, because that is what makes `source` knowable.
+    isolate_conflicting_import_aliases(&mut modules, &module_exports, &path_to_idx);
+
+    // #659 — top-level import aliases already emitted, as `bind -> source`.
+    let mut emitted_import_aliases: HashMap<String, String> = HashMap::new();
     let mut statements = Vec::new();
     let mut statement_sources = Vec::new();
     for (idx, module) in modules.iter().enumerate() {
@@ -2198,7 +2309,21 @@ pub fn merge_modules(mut modules: Vec<ResolvedModule>) -> Result<MergedProgram, 
                                     .cloned()
                                     .unwrap_or_else(|| name.to_string());
                                 let bind = alias.as_deref().unwrap_or(name.as_ref());
-                                if bind != source {
+                                // #659: two modules importing the SAME symbol under the same name
+                                // each emitted `const <bind> = <source>` into the one merged scope
+                                // — a duplicate declaration, which `--target js` turns into
+                                // `SyntaxError: Identifier 'field' has already been declared`. The
+                                // build itself succeeded, so only `node --check` or actually loading
+                                // the bundle caught it and it could ship unnoticed. One alias serves
+                                // every importer: same name, same target, and it is emitted at the
+                                // FIRST importer's position, which precedes every later use.
+                                // (A same-name/different-target clash is not this case — that is
+                                // renamed apart by `isolate_conflicting_import_aliases` above.)
+                                let already_aliased =
+                                    emitted_import_aliases.get(bind) == Some(&source);
+                                if bind != source && !already_aliased {
+                                    emitted_import_aliases
+                                        .insert(bind.to_string(), source.clone());
                                     let decl_name_span = alias_span.as_ref().unwrap_or(name_span);
                                     merge_push(
                                         &mut statements,


### PR DESCRIPTION
Closes #659

An import specifier lowers to `const <bind> = <source>` in the one merged top-level scope, so two modules that pick the same `bind` emit two `const`s with one name. `tish build` succeeds either way — only `node --check` or actually loading the bundle catches it, exactly as the issue says.

## There are two cases, and the reported one is the milder

**Same source** — the reported repro. `a` and `b` both `import { field }` from `util`, so both aliases point at `field__m0`. Duplicate but equivalent. One alias now serves every importer, emitted at the first importer's position, which precedes every later use.

**Different source** — found while fixing the above, and worse:

```tish
// a.tish
import { x as f } from "./u1.tish"
export fn useA() { return f(1) }
// b.tish
import { y as f } from "./u2.tish"
export fn useB() { return f(2) }
```

The second binding shadows the first, so `useA()` runs `y`:

```
before   interp: y2:1 y2:2      node: SyntaxError
after    interp: x1:1 y2:2      node: x1:1 y2:2
```

That is a silent wrong answer **on interp and vm too**, not just a JS-target bundling defect. Same class as #653. These are now renamed apart with the module's own references rewritten.

## Where the split runs, and why not earlier

After the export table is built — that is what makes `source` knowable, and `bind != source` is precisely the condition under which an alias is emitted at all.

I first tried it in the earlier declaration-isolation pass, keying off import bindings. That is the over-broad criterion #587's own comment warns about ("a dep's exported `greet` looks like it collides with the importer's binding of that same `greet` — but those are one thing, not two"), and it churned every ordinary import; #654's fixture caught it immediately. Moving it after the export table makes the test exact instead of approximate.

## Verification

Reported repro: `node --check` passes and all of interp / vm / node print `9 8 7`, with a single `const field` in the bundle.

Two regression tests in `scope_merge.rs`, both confirmed to fail without the change. Full workspace suite green — 738 tests.

Branch is based on current `main` (0158b5c2e).
