### PR TITLE
fix(native): #675 — a declare-fn with a non-scalar parameter must not register a typed extern

### DIFF
--- a/crates/tish/tests/fixtures/cargo_example_project/crates/demo-shim/tish.d.tish
+++ b/crates/tish/tests/fixtures/cargo_example_project/crates/demo-shim/tish.d.tish
@@ -2,3 +2,9 @@
 // Declares the native signatures of exports so a call lowers to a DIRECT `demo_shim::<name>_typed(..)`
 // instead of the boxed `value_call` path — the consuming program never writes these declarations.
 declare fn add(a: number, b: number): number
+
+// #675 — an array parameter has no scalar ABI, so this declaration must NOT register a typed extern
+// (there is no `sink_typed` to call). It exists purely to carry the `readonly` marker (#672) to the
+// aliasing analysis, so the caller's array keeps its typed representation while the CALL stays on
+// the boxed namespace path.
+declare fn sink(n: number, readonly data: number[]): void

--- a/crates/tish/tests/fixtures/cargo_example_project/src/main.tish
+++ b/crates/tish/tests/fixtures/cargo_example_project/src/main.tish
@@ -1,7 +1,13 @@
-import { greet, add } from 'cargo:demo_shim'
+import { greet, add, sink } from 'cargo:demo_shim'
 
 console.log(greet('from cargo'))
 
 // `add` has a typed signature shipped in the crate's `tish.d.tish` (auto-loaded) — this call lowers
 // to a direct `demo_shim::add_typed(2, 3)`, not the boxed namespace-object dispatch.
 console.log(add(2, 3))
+
+// #675: `sink` takes an array, so its declaration must not route the call to a `sink_typed`
+// sibling that cannot exist — it stays on the boxed path.
+let buf: number[] = []
+buf.push(1)
+sink(1, buf)

--- a/crates/tish/tests/regr_typed_externs.rs
+++ b/crates/tish/tests/regr_typed_externs.rs
@@ -57,3 +57,31 @@ fn untyped_extern_call_stays_boxed() {
         "untyped extern `greet` must stay boxed (no `greet_typed` direct call).\n{rust}"
     );
 }
+
+/// #675 — a `declare fn` with a NON-SCALAR parameter must not register a typed extern.
+///
+/// `is_native()` only asks "is it not `Value`", so an array parameter passed the eligibility check,
+/// registered a typed extern, and routed the call to a `<name>_typed` sibling that cannot exist:
+///
+/// ```text
+/// error[E0425]: cannot find function `grid_from_gids_typed` in crate `tish_gba_game_engine`
+/// ```
+///
+/// That made #672's `readonly` unusable on exactly the natives it was built for — an array sink —
+/// because declaring the function to carry the marker also opted it into a dispatch it can never
+/// satisfy. Declaration (metadata for the aliasing analysis) and dispatch are now independent.
+#[test]
+fn array_param_declaration_does_not_register_a_typed_extern() {
+    let rust = emit_fixture();
+    assert!(
+        !rust.contains("sink_typed"),
+        "`sink(n: number, readonly data: number[])` has an array parameter, so there is no scalar \
+         ABI to generate a `sink_typed` sibling from — the call must stay on the boxed namespace \
+         path. Routing it to `sink_typed` is a hard E0425 in the generated program (#675).\n{rust}"
+    );
+    // ...and the scalar declaration in the same file must still lower directly.
+    assert!(
+        rust.contains("add_typed"),
+        "narrowing the eligibility check must not cost the scalar case its direct typed call.\n{rust}"
+    );
+}

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -3011,6 +3011,19 @@ impl Codegen {
             };
             // Every parameter must be a simple, explicitly-typed native scalar; a `Value` param (an
             // untyped one) means the direct call would gain nothing, so keep the whole fn boxed.
+            //
+            // #675 — "native" is not the same as "has a scalar ABI". `is_native()` is merely
+            // `!= Value`, so an `i32[]` parameter passed it, registered a typed extern, and the call
+            // was routed to a `<name>_typed` sibling that cannot exist:
+            //
+            //     error[E0425]: cannot find function `grid_from_gids_typed`
+            //
+            // That made #672's `readonly` unusable on exactly the natives it was built for — an
+            // array sink — because declaring the function to carry the marker also opted it into a
+            // dispatch it can never satisfy. The two are now independent: a declaration with a
+            // non-scalar parameter still contributes its `readonly` flags to the aliasing analysis,
+            // it just does not register a typed extern, so the CALL stays on the boxed namespace
+            // path it uses today (it runs once per level; nobody is trying to speed it up).
             let mut ptys = Vec::with_capacity(params.len());
             let mut ok = true;
             for p in params {
@@ -3018,7 +3031,7 @@ impl Codegen {
                     FunParam::Simple(tp) if tp.default.is_none() => match &tp.type_ann {
                         Some(ann) => {
                             let ty = RustType::from_annotation(ann);
-                            if ty.is_native() {
+                            if ty.is_native() && Self::has_scalar_extern_abi(&ty) {
                                 ptys.push(ty);
                             } else {
                                 ok = false;
@@ -19081,6 +19094,25 @@ impl Codegen {
     ///
     /// Over-approximating only costs an array its native lowering. Under-approximating brings back a
     /// silently wrong result, so the bias is deliberate.
+    /// #675 — does this type have a by-value scalar ABI a typed extern can be generated for?
+    ///
+    /// The numeric scalars, `Fixed`, `bool` and `String` cross the extern boundary as themselves.
+    /// An aggregate — an array (`Vec`), an object/struct, a tuple, an `Option`/`Boxed` wrapper —
+    /// does not: there is no `<name>_typed` sibling to call, and routing to one is a hard
+    /// `E0425` in the generated program. Distinct from [`RustType::is_native`], which only asks
+    /// "is it not `Value`" and therefore says yes to all of these.
+    fn has_scalar_extern_abi(ty: &RustType) -> bool {
+        matches!(
+            ty,
+            RustType::F64
+                | RustType::I32
+                | RustType::Fixed
+                | RustType::Bool
+                | RustType::String
+                | RustType::Unit
+        ) || ty.is_narrow_int()
+    }
+
     /// #672 — per-parameter `readonly` flags from each `declare fn`, keyed by function name.
     ///
     /// A `cargo:` native's body is invisible, so #663 has to assume the worst and box any array


### PR DESCRIPTION
Closes #675

`readonly` (#672) did the right thing to the aliasing analysis but was unusable on the natives it was built for: declaring the function to carry the marker also opted it into typed-extern dispatch, and an array parameter has no scalar ABI to generate a `_typed` sibling from.

```
error[E0425]: cannot find function `grid_from_gids_typed`
```

## Cause

The eligibility check asked `RustType::is_native()`, which is only `!= RustType::Value`. So `Vec`, objects, tuples and `Option`/`Boxed` wrappers all passed it and registered externs that cannot exist. Added `has_scalar_extern_abi`, which asks the question actually being decided — does this type cross the extern boundary as itself (numeric scalars, `Fixed`, `bool`, `String`) — rather than merely "is it not `Value`".

This is option (1) from the issue, the smallest of the three. Declaration and dispatch become independent, which is exactly what this case wants:

- the **declaration** still contributes its `readonly` flags, so the caller's array keeps its typed representation;
- the **call** stays on the boxed namespace path it already used — it runs once per level and nobody is trying to speed it up.

## Verification

Extended the existing `cargo_example_project` fixture with an array-taking native beside the scalar one, so a single compile covers both directions:

```
declare fn add(a: number, b: number): number              // scalar  -> add_typed, direct
declare fn sink(n: number, readonly data: number[]): void // array   -> no sink_typed, boxed call
```

`array_param_declaration_does_not_register_a_typed_extern` asserts both, and is confirmed to fail without the change. The `readonly` behaviour from #672 is unaffected — its own tests still pass, with the array staying typed at the read sites.

Ran `-p tishlang_compile` in full plus the typed-extern and scope-merge suites; all green.

Branch is based on current `main`.
