### PR TITLE
GBA: branch from v3.7.1 — the stack guard, done so it can be diagnosed

### DIFF
--- a/crates/tish/tests/scope_merge.rs
+++ b/crates/tish/tests/scope_merge.rs
@@ -198,3 +198,93 @@ fn colliding_exported_names_are_isolated_across_modules() {
         );
     }
 }
+
+// ── #653: a LOCAL named export (`export { A }`) of a top-level binding ───────────────────────────
+//
+// `collect_module_top_level_names` only treated `export const A` / `export fn f` as exported, so a
+// binding exported via the `export { A }` (no `from`) form looked module-PRIVATE. The isolation pass
+// then renamed it to `A__m0` while the export table still keyed off `A`, pointing every importer at
+// a symbol that no longer existed — "Undefined variable: A" at best, and on the native target the
+// same class of mismatch that #653 saw as a silently wrong constant.
+
+/// Two modules exporting the same constant name, one of them via `export { … }`. Every importer
+/// must land on ITS OWN module's value.
+#[test]
+fn local_named_export_survives_collision_isolation() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(
+        root.join("frames.tish"),
+        "const HERO_WALK = 0\nconst ITEM_BOMB = 0\nexport { HERO_WALK, ITEM_BOMB as IFRAME_BOMB }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("hero.tish"),
+        "export const HERO_WALK = 1\nexport const ITEM_BOMB = 1\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("main.tish"),
+        "import { HERO_WALK, ITEM_BOMB } from \"./hero.tish\"\n\
+         import { HERO_WALK as SLOT, IFRAME_BOMB } from \"./frames.tish\"\n\
+         console.log(HERO_WALK, SLOT, ITEM_BOMB, IFRAME_BOMB)\n",
+    )
+    .unwrap();
+
+    let modules = resolve_project(&root.join("main.tish"), Some(root)).expect("resolve");
+    let merged = merge_modules(modules).expect("merge");
+
+    // Collect top-level declarations and the alias bindings the imports lowered to.
+    let mut declared: Vec<String> = Vec::new();
+    for s in &merged.program.statements {
+        match s {
+            Statement::VarDecl { name, .. } | Statement::FunDecl { name, .. } => {
+                declared.push(name.to_string())
+            }
+            Statement::Export { declaration, .. } => {
+                if let tishlang_ast::ExportDeclaration::Named(inner) = declaration.as_ref() {
+                    if let Statement::VarDecl { name, .. } | Statement::FunDecl { name, .. } =
+                        inner.as_ref()
+                    {
+                        declared.push(name.to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    for s in &merged.program.statements {
+        if let Statement::VarDecl {
+            name,
+            init: Some(Expr::Ident { name: src, .. }),
+            ..
+        } = s
+        {
+            if matches!(name.as_ref(), "HERO_WALK" | "SLOT" | "ITEM_BOMB" | "IFRAME_BOMB") {
+                assert!(
+                    declared.iter().any(|d| d == src.as_ref()),
+                    "import alias `{}` binds to `{}`, which is not declared in the merged program \
+                     (#653: a locally-named export was renamed out from under its export table)",
+                    name,
+                    src
+                );
+            }
+            // The `export { … }` module's bindings must NOT collapse onto the other module's
+            // symbol — that is #653's silent wrong value (`SLOT` reading hero's 1, not frames' 0).
+            if name.as_ref() == "SLOT" {
+                assert_eq!(
+                    src.as_ref(),
+                    "HERO_WALK__m1",
+                    "`SLOT` must bind to frames.tish's own HERO_WALK, not to hero.tish's"
+                );
+            }
+            if name.as_ref() == "IFRAME_BOMB" {
+                assert_eq!(
+                    src.as_ref(),
+                    "ITEM_BOMB__m1",
+                    "`IFRAME_BOMB` must bind to frames.tish's own ITEM_BOMB, not to hero.tish's"
+                );
+            }
+        }
+    }
+}

--- a/crates/tish_compile/src/resolve.rs
+++ b/crates/tish_compile/src/resolve.rs
@@ -1421,6 +1421,22 @@ fn collect_module_top_level_names(
                 collect_module_top_level_names(statements, decls, exported, imports);
             }
             Statement::Export { declaration, .. } => {
+                // #653/#415: a LOCAL named export (`export { A }`, no `from`) exports an
+                // already-declared top-level binding. Without this the binding looks module-private,
+                // gets renamed by the isolation pass below, and the export table — which keys off the
+                // ORIGINAL name — points at a symbol that no longer exists.
+                if let ExportDeclaration::ReExport {
+                    specifiers,
+                    from: None,
+                    ..
+                } = declaration.as_ref()
+                {
+                    for spec in specifiers {
+                        if let ImportSpecifier::Named { name, .. } = spec {
+                            exported.insert(name.to_string());
+                        }
+                    }
+                }
                 if let ExportDeclaration::Named(inner) = declaration.as_ref() {
                     match inner.as_ref() {
                         Statement::VarDecl { name, .. } | Statement::FunDecl { name, .. } => {
@@ -2049,7 +2065,15 @@ pub fn merge_modules(mut modules: Vec<ResolvedModule>) -> Result<MergedProgram, 
                             if let ImportSpecifier::Named { name, alias, .. } = spec {
                                 let export_name =
                                     alias.as_deref().unwrap_or(name.as_ref()).to_string();
-                                module_exports[idx].insert(export_name, name.to_string());
+                                // #653: the local binding may have been renamed for a collision.
+                                // `export_renames` is renamed -> original, so look the other way to
+                                // find the symbol this export name must now point at.
+                                let binding = export_renames[idx]
+                                    .iter()
+                                    .find(|(_, original)| original.as_str() == name.as_ref())
+                                    .map(|(renamed, _)| renamed.clone())
+                                    .unwrap_or_else(|| name.to_string());
+                                module_exports[idx].insert(export_name, binding);
                             }
                         }
                     }

--- a/crates/tish_runtime_gba/src/lib.rs
+++ b/crates/tish_runtime_gba/src/lib.rs
@@ -30,11 +30,83 @@ pub use tishlang_core::{
     has_pending_throw, set_pending_throw, stack_overflow_error, take_pending_throw, CallDepthGuard,
 };
 
-/// Enter a boxed user-fn call frame or trip the recursion guard. On GBA there is
-/// no stack-pressure probe (no `std`), so this is just the counted-depth guard.
+unsafe extern "C" {
+    /// End of the `.iwram` output section (agb's `gba.ld`). IWRAM is
+    /// 0x0300_0000..0x0300_8000; agb's code/data sits at the bottom and the user stack
+    /// grows DOWN from ~0x0300_7F00 toward this address. Below it is live agb data —
+    /// the audio mixer's buffers among them.
+    static __iwram_end: u8;
+}
+
+/// Top of IWRAM. The user stack must be below this; anything else is not our stack.
+const IWRAM_TOP: usize = 0x0300_8000;
+
+/// Headroom above [`__iwram_end`]: must cover the frames between two guard checks plus
+/// the bail path. Boxed `Value` frames run a few hundred bytes, so 2 KB is several of
+/// them — deliberately small against the host's 256 KB, which is sized for an 8 MB stack.
+const GBA_STACK_MARGIN: usize = 2 * 1024;
+
+/// #655 — is the GBA stack nearly exhausted?
+///
+/// The host probe (`stacker::remaining_stack`) needs `std` and reports nothing here, so its
+/// `None -> floor 1` fallback made this dead code on the one target where overflow is
+/// unrecoverable: no MMU, no guard page, so the stack grows silently into agb's IWRAM data
+/// and surfaces frames later as an illegal opcode that names nothing.
+///
+/// ⚠️⚠️ THE RANGE CHECK IS NOT DEFENSIVE PADDING. A floor derived from a link symbol is only
+/// meaningful if the stack really is in IWRAM above it. If it is not — a different linker
+/// script, a game that moves the stack to EWRAM, a probe taken on some other stack — then
+/// `sp < floor` is trivially TRUE FOR EVERY CALL, the guard trips on the first one, and every
+/// guarded fn returns the bail value. That is not a subtle failure: it kills the ROM before it
+/// draws a frame, with no message, and it is indistinguishable from a codegen bug. When the
+/// assumption does not hold we must say "cannot judge" and let the call through.
+#[inline]
+pub fn stack_low() -> bool {
+    let anchor = 0u8;
+    let sp = &anchor as *const u8 as usize;
+    let end = (&raw const __iwram_end) as usize;
+    if sp <= end || sp > IWRAM_TOP {
+        return false;
+    }
+    sp < end + GBA_STACK_MARGIN
+}
+
+/// Enter a boxed user-fn call frame, or trip the recursion guard. Trips on the counted
+/// ceiling or on real stack pressure ([`stack_low`]) — on a 32 KB stack the counted default
+/// (20000 frames) is far out of reach, so pressure is what actually fires.
+///
+/// ⚠️⚠️ ON GBA A TRIP PANICS INSTEAD OF PARKING A CATCHABLE THROW, and that difference is the
+/// whole lesson of this bug. The host bails by parking a `RangeError` and returning `None`,
+/// whereupon the generated body returns `Value::Null` — fine where a throw checkpoint will
+/// raise it. On GBA the same silence turned a stack overflow into a wrong VALUE: the ROM kept
+/// running on nulls, drew nothing, said nothing, and cost a full day of bisecting a compiler
+/// that was working correctly. agb's panic handler prints and shows a crash screen, so a game
+/// that recurses too deep now says so.
 #[inline]
 pub fn enter_call_guarded() -> Option<CallDepthGuard> {
+    if stack_low() {
+        let anchor = 0u8;
+        let sp = &anchor as *const u8 as usize;
+        let end = (&raw const __iwram_end) as usize;
+        stack_overflow_panic(sp, end);
+    }
     tishlang_core::enter_call_guarded()
+}
+
+#[cold]
+#[inline(never)]
+fn stack_overflow_panic(sp: usize, end: usize) -> ! {
+    // ⚠️ The NUMBERS matter, not just the fact. "Stack overflow" alone cannot tell you whether a
+    // game is legitimately deep or the probe is reading a stack that is not where it was assumed
+    // to be — and those want opposite fixes. `used` is measured from the BIOS entry SP.
+    let used = 0x0300_7F00usize.saturating_sub(sp);
+    panic!(
+        "tish: GBA stack overflow - sp={:#010X} floor={:#010X} used={}B of ~{}B",
+        sp,
+        end + GBA_STACK_MARGIN,
+        used,
+        0x0300_7F00usize - (end + GBA_STACK_MARGIN)
+    );
 }
 
 // ── Error type for throw/return non-local control flow ───────────────────────


### PR DESCRIPTION
**Branched from `v3.7.1`, not from `main`, and deliberately.** `v3.7.1` builds working ROMs.
Everything after it does not: three separate commits in that window each kill every large game,
and each produces a cartridge that **builds clean and then dies silently**. Anything layered on
top of them is layered on broken behaviour, so this starts from the last good point and adds two
changes.

## What is in here

| commit | what |
|---|---|
| `565540f8e` | **#653** — `#661` re-applied unchanged. Bisected and confirmed clean; the only commit in that batch that is. |
| `ca6b8576b` | **#655** — the stack-overflow guard, reimplemented. |

Nothing else. No `#660`, no `#662`, no thin-LTO profile change.

## #655 — the premise was right, the implementation was not

The guard was compiled in but dead: `stack_low()` derives its floor from
`stacker::remaining_stack()`, which needs std and reports nothing on `no_std`, so the floor fell
back to `1` and an SP could never be below it. On the one target where overflow is unrecoverable —
32 KB of IWRAM, no MMU, no guard page — the stack grew into agb's live data (the mixer's buffers
among them) and surfaced frames later as an illegal opcode at an address that named nothing.

`#660` turned it on. Two faults made that unusable:

**It never checked its own premise.** A floor derived from `__iwram_end` is meaningful only if the
stack really is in IWRAM above it. If it is not, `sp < floor` is trivially true *for every call* —
the guard trips on the first one, every guarded fn returns its bail value, and the ROM dies before
drawing a frame. Now it judges only when `__iwram_end < sp <= 0x0300_8000`, and says nothing
otherwise.

**It failed silently.** The host bails by parking a catchable `RangeError` and returning
`Value::Null`, which is correct where a throw checkpoint will raise it. On GBA the same path turns
a stack overflow into a *wrong value*: the ROM keeps running on nulls, draws nothing, says nothing.
It is indistinguishable from a codegen bug, and it was diagnosed as one for a full day. It now
panics, and the panic carries the numbers — because "stack overflow" alone cannot tell you whether
a game is legitimately deep or the probe is reading the wrong stack, and those want opposite fixes:

```
tish: GBA stack overflow - sp=0x030012A8 floor=0x03001438 used=27736B of ~27336B
```

## Validation

Built and **inspected visually** — not scored by a heuristic (see below):

| ROM | before | this branch |
|---|---|---|
| `akari` | white screen | title screen: logo, `Continue / New Game / Attack Debug` |
| `hyrule` | white screen | title screen: `NEW GAME / CONTINUE / QUEST 2 / DEBUG HUB / SPRITE GALLERY` |
| `example-zelda` | white screen | in-game: HUD, dungeon floor, sprites |
| `examples/ffta` | white screen | reports its own bug: 232 B over a 27 KB stack |

FFTA's overrun is real — a ~92-frame boxed init chain — and is a game problem, not a compiler one.
It is now a one-line diagnosis instead of a silent death.

## Deliberately NOT included

**`#662` (#654).** Snapshots a read-only capture by value instead of reading its cell.
`assigned_in_body` is scoped to ONE closure, so a module array that a *different* function
`push`es to still looks read-only at the capture site, and every closure gets a stale copy taken at
creation time. Kills every large program while small demos pass, because the damage scales with how
many module aggregates a program has.
⚠️ Do not "fix" it by testing the declaration — a scalar-literal gate was tried and hyrule still
died, because the rebind scan does not descend into fn bodies. It needs real escape analysis. And
do not simply delete it either: it saves **heap** as well as time (each read-only capture becomes a
`VmRef::new` allocation), and without it `ffta` at 162 boards dies in module init.

**`#664` (#581), the thin-LTO profile.** A genuine 2.2x build-time win (288s -> 129s on ffta) that
**kills the ROM**: `3.7.1 + #661 + that commit alone` boots to a dead flat screen. `hyrule` (3.6 MB)
and `akari` survive; whatever it does only shows up at ~10 MB. Speed must be opt-in until that is
understood.

## Two traps this cost, recorded so they are not repeated

**`GBA_STACK_MARGIN` stays at 2 KB.** Lowering it to 1 KB to let ffta through its overrun was tried:
the ROM stopped reporting and started rendering agb's crash screen — it ran past the guard into
agb's IWRAM data, which is precisely the corruption this guard exists to prevent. The band is not
spare stack; it is agb's.

**A screenshot heuristic that scores "many colours + dense ink" passes agb's crash screen.** It
scored one as `ok(49 colours, 55% ink)`. Every verdict in this PR was re-checked by looking at the
image.

Refs #653, #654, #655, #581, #658, #659, #663, #665, #669, #672, #675