### PR TITLE
fix(native): cut import tax — omit dead FunDecls and hoist call-only free fns

### DIFF
--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -2617,12 +2617,14 @@ impl Codegen {
             if others > 0 || calls == 0 {
                 continue;
             }
-            // Already has a typed free twin — drop only the heap Value.
+            // Already claimed by a typed free path (M5 / #175 / #177). Do NOT drop the boxed
+            // twin here: spread calls and other value_call shapes still need the `Value` binding
+            // (MVP `spread.tish` → E0425 on `sum3`/`add4` when the twin was stripped). Those
+            // paths already suppress or keep their bindings themselves.
             if self.native_fns.contains(name)
                 || self.native_vec_fns.contains_key(name)
                 || self.aggregate_fns.contains_key(name)
             {
-                skip_heap.insert(name.clone());
                 continue;
             }
             if *async_ {

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -1137,6 +1137,11 @@ pub(crate) struct Codegen {
     /// #176 (default-on via `native_opts_enabled`): top-level `let` bindings lowered to `thread_local Cell<f64>`
     /// (`G_NAME`) when every use is a numeric read or a whole-binding numeric assign (fasta `seed`).
     native_numeric_globals: std::collections::HashMap<String, f64>,
+    /// #654 — top-level scalar `const`/`let` with a literal init that is never reassigned.
+    /// Only these may be captured by value (`_capt`) instead of a `VmRef` cell. Aggregates are
+    /// excluded on purpose: a typed `Vec` / struct clone at closure creation is a stale snapshot
+    /// when another function mutates the module binding.
+    immutable_scalar_consts: std::collections::HashSet<String>,
     /// Top-level `let name = [f64 literals…]` never reassigned — emitted as `const G_name: [f64; N]`
     /// for direct indexing from native fns (fasta `codes`/`probs`).
     module_const_f64_arrays: std::collections::HashMap<String, Vec<f64>>,
@@ -1466,6 +1471,7 @@ impl Codegen {
             outer_vars_stack: vec![Vec::new()], // Start with module-level scope
             refcell_wrapped_vars: std::collections::HashSet::new(),
             native_numeric_globals: std::collections::HashMap::new(),
+            immutable_scalar_consts: std::collections::HashSet::new(),
             module_const_f64_arrays: std::collections::HashMap::new(),
             module_const_int_statics: std::collections::HashSet::new(),
             arrays_passed_to_calls: std::collections::HashSet::new(),
@@ -3630,6 +3636,8 @@ impl Codegen {
             let gba = self.emit_mode == crate::NativeEmitMode::Gba;
             self.native_numeric_globals =
                 Self::collect_native_numeric_globals(&program.statements);
+            self.immutable_scalar_consts =
+                Self::collect_immutable_scalar_consts(&program.statements);
             if !self.native_numeric_globals.is_empty() {
                 if gba {
                     self.emit_native_numeric_global_singlecore()?;
@@ -7516,22 +7524,26 @@ impl Codegen {
                     .filter(|v| assigned_in_body.contains(*v) || self.rc_cell_storage_contains(v))
                     .cloned()
                     .collect();
+                // #654 — only proven immutable SCALAR literals may skip the cell. A broad
+                // "not assigned in this body" gate snapshots typed Vec/struct module bindings by
+                // value at closure creation; another function's push/mutation then leaves every
+                // capture holding a stale copy (blank-screen class failure on large ROMs).
                 let read_only_outer_vars: Vec<String> = outer_vars
                     .iter()
-                    .filter(|v| !assigned_in_body.contains(*v) && !self.rc_cell_storage_contains(v))
+                    .filter(|v| {
+                        !assigned_in_body.contains(*v)
+                            && !self.rc_cell_storage_contains(v)
+                            && self.immutable_scalar_consts.contains(*v)
+                    })
                     .cloned()
                     .collect();
 
                 // Rebind outer vars to Rc<RefCell<>> with _cell suffix.
                 // If outer scope already has the var as RefCell, just clone it.
                 //
-                // #654: a READ-ONLY outer var is never assigned anywhere in the defining scope
-                // (that is exactly what keeps it out of `rc_cell_storage`), so the cell can never
-                // change and the indirection buys nothing — it cost a `VmRef` allocation per
-                // closure plus a `RefCell` borrow on EVERY call, to re-fetch a value that was
-                // already fixed. Snapshot it by value instead. This is invisible in the source: a
-                // fn that mentions six named constants was measurably slower than one that inlined
-                // the same six literals, which pushed authors toward magic numbers.
+                // #654: an immutable scalar const pays a VmRef alloc + per-call borrow/clone for a
+                // value fixed at compile time. Snapshot those by value. Everything else keeps a
+                // cell so module aggregates stay live.
                 for outer_var in &outer_vars {
                     let var_escaped = Self::escape_ident(outer_var);
                     if self.rc_cell_storage_contains(outer_var) {
@@ -18842,6 +18854,115 @@ impl Codegen {
 
     /// #176 — classify top-level `let x = <number-literal>` bindings whose every use is a numeric
     /// read or a whole-binding assign with a numeric-shaped RHS (fasta `seed`).
+    /// #654 — top-level bindings whose init is a scalar literal (or an alias of one) and that
+    /// are never assigned anywhere in the program. These are the only names safe to capture by
+    /// value (`_capt`) instead of through a `VmRef` cell (typed aggregates clone stale).
+    fn collect_immutable_scalar_consts(stmts: &[Statement]) -> std::collections::HashSet<String> {
+        use std::collections::HashSet;
+        let mut assigned = HashSet::new();
+        for s in stmts {
+            Self::collect_assigned_idents_in_stmt(s, &mut assigned);
+        }
+        let mut out = HashSet::new();
+        Self::collect_immutable_scalar_literal_consts_in(stmts, &assigned, &mut out);
+        // Import aliases lower to `const local = mangled`; follow Ident chains to completion.
+        let mut aliases: Vec<(String, String)> = Vec::new();
+        Self::collect_top_level_ident_aliases(stmts, &mut aliases);
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for (name, src) in &aliases {
+                if assigned.contains(name) || out.contains(name) {
+                    continue;
+                }
+                if out.contains(src) {
+                    out.insert(name.clone());
+                    changed = true;
+                }
+            }
+        }
+        out
+    }
+
+    fn collect_immutable_scalar_literal_consts_in(
+        stmts: &[Statement],
+        assigned: &std::collections::HashSet<String>,
+        out: &mut std::collections::HashSet<String>,
+    ) {
+        for s in stmts {
+            match s {
+                Statement::VarDecl { name, init, .. } => {
+                    if assigned.contains(name.as_ref()) {
+                        continue;
+                    }
+                    if let Some(Expr::Literal {
+                        value:
+                            Literal::Number(_)
+                            | Literal::Bool(_)
+                            | Literal::String(_)
+                            | Literal::Null,
+                        ..
+                    }) = init.as_ref()
+                    {
+                        out.insert(name.to_string());
+                    }
+                }
+                Statement::Export { declaration, .. } => {
+                    if let tishlang_ast::ExportDeclaration::Named(inner) = declaration.as_ref() {
+                        if let Statement::VarDecl { name, init, .. } = inner.as_ref() {
+                            if assigned.contains(name.as_ref()) {
+                                continue;
+                            }
+                            if let Some(Expr::Literal {
+                                value:
+                                    Literal::Number(_)
+                                    | Literal::Bool(_)
+                                    | Literal::String(_)
+                                    | Literal::Null,
+                                ..
+                            }) = init.as_ref()
+                            {
+                                out.insert(name.to_string());
+                            }
+                        }
+                    }
+                }
+                Statement::Multi { statements, .. } => {
+                    Self::collect_immutable_scalar_literal_consts_in(statements, assigned, out);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn collect_top_level_ident_aliases(stmts: &[Statement], out: &mut Vec<(String, String)>) {
+        for s in stmts {
+            match s {
+                Statement::VarDecl {
+                    name,
+                    init: Some(Expr::Ident { name: src, .. }),
+                    ..
+                } => out.push((name.to_string(), src.to_string())),
+                Statement::Export { declaration, .. } => {
+                    if let tishlang_ast::ExportDeclaration::Named(inner) = declaration.as_ref() {
+                        if let Statement::VarDecl {
+                            name,
+                            init: Some(Expr::Ident { name: src, .. }),
+                            ..
+                        } = inner.as_ref()
+                        {
+                            out.push((name.to_string(), src.to_string()));
+                        }
+                    }
+                }
+                Statement::Multi { statements, .. } => {
+                    Self::collect_top_level_ident_aliases(statements, out);
+                }
+                _ => {}
+            }
+        }
+    }
+
     fn collect_native_numeric_globals(stmts: &[Statement]) -> HashMap<String, f64> {
         use std::collections::{HashMap, HashSet};
         let mut candidates: HashMap<String, f64> = HashMap::new();

--- a/crates/tish_compile/src/codegen.rs
+++ b/crates/tish_compile/src/codegen.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use tishlang_ast::{
     ArrayElement, ArrowBody, BinOp, CallArg, CompoundOp, DestructElement, DestructPattern, Expr,
     FunParam, ImportSpecifier, Literal, LogicalAssignOp, MemberProp, ObjectProp, Program, Span,
-    Statement, TypeAnnotation, UnaryOp,
+    Statement, TypeAnnotation, TypedParam, UnaryOp,
 };
 
 /// Tracks variable usage for move/clone optimization.
@@ -1369,6 +1369,22 @@ pub(crate) struct Codegen {
     program_has_jsx: bool,
     /// `fn` names for Rust JSX: PascalCase tags matching these use a value binding; others are string intrinsics.
     program_fun_decl_names: std::collections::HashSet<String>,
+    /// Top-level `function` / `fn` decls reachable from module-level code (or a RustLib export).
+    /// Unreachable decls are NOT emitted as `Value::native` heap closures — that is the import tax:
+    /// importing a package materialised every function whether called or not (~151 bytes each).
+    reachable_fun_decls: std::collections::HashSet<String>,
+    /// Every FunDecl that is a direct child of `program.statements` (not nested in a body/block).
+    /// [`Self::should_omit_fun_decl`] only omits names in this set, so a nested `function helper`
+    /// is never killed because an unreachable top-level `helper` exists.
+    top_level_fun_decls: std::collections::HashSet<String>,
+    /// True after [`Self::compute_reachable_fun_decls`] has run for this program.
+    reachable_fun_decls_ready: bool,
+    /// Call-only capture-free top-level FunDecls emitted as `fn name_bfn(args: &[Value]) -> Value`
+    /// (no `Value::native` heap binding). Import-tax / #583: only-called functions stay static.
+    boxed_free_fns: std::collections::HashSet<String>,
+    /// Top-level FunDecls that must not get a `Value::native` / `_cell` in `run()` — the union of
+    /// [`Self::boxed_free_fns`], call-only M5/`native_vec` twins (free fn already exists), etc.
+    skip_heap_fun_decls: std::collections::HashSet<String>,
     /// Nesting depth inside `Value::native(move |args| {{ ... }})` user functions / arrows.
     /// `try`/`throw` lowering uses `return Err` only at depth 0 (e.g. `run()`); inside native
     /// closures it must not return a `Result` from a `Value`-returning closure.
@@ -1510,6 +1526,11 @@ impl Codegen {
             type_aliases: std::collections::HashMap::new(),
             program_has_jsx: false,
             program_fun_decl_names: std::collections::HashSet::new(),
+            reachable_fun_decls: std::collections::HashSet::new(),
+            top_level_fun_decls: std::collections::HashSet::new(),
+            reachable_fun_decls_ready: false,
+            boxed_free_fns: std::collections::HashSet::new(),
+            skip_heap_fun_decls: std::collections::HashSet::new(),
             value_fn_depth: 0,
             emit_mode: crate::NativeEmitMode::DesktopBin,
             entry_exports: Vec::new(),
@@ -2452,18 +2473,341 @@ impl Codegen {
         self.output.push('\n');
     }
 
-    /// Pre-scan statements to find all function declarations in this scope
+    /// Pre-scan statements to find all function declarations in this scope that still need a
+    /// boxed `Value` cell. Unreachable top-level decls are omitted (import tax / dead strip).
     fn prescan_function_decls(&self, statements: &[Statement]) -> Vec<String> {
         statements
             .iter()
             .filter_map(|s| {
                 if let Statement::FunDecl { name, .. } = s {
-                    Some(name.to_string())
+                    let n = name.to_string();
+                    if self.should_omit_fun_decl(&n) || self.skip_heap_fun_decls.contains(&n) {
+                        None
+                    } else {
+                        Some(n)
+                    }
                 } else {
                     None
                 }
             })
             .collect()
+    }
+
+    /// Omit a top-level FunDecl that nothing reachable references. Nested FunDecls are never
+    /// omitted here — see `top_level_fun_decls`.
+    fn should_omit_fun_decl(&self, name: &str) -> bool {
+        self.reachable_fun_decls_ready
+            && self.value_fn_depth == 0
+            && self.top_level_fun_decls.contains(name)
+            && !self.reachable_fun_decls.contains(name)
+    }
+
+    /// Mark top-level FunDecls reachable from module-level statements (and RustLib exports).
+    /// Everything else is dead at the import boundary: importing a package used to emit a
+    /// `Value::native` for every function in it whether called or not.
+    fn compute_reachable_fun_decls(&mut self, program: &Program) {
+        use std::collections::{HashMap, HashSet, VecDeque};
+        let mut bodies: HashMap<String, &Statement> = HashMap::new();
+        let mut decl_names: HashSet<String> = HashSet::new();
+        for s in &program.statements {
+            if let Statement::FunDecl { name, body, .. } = s {
+                let n = name.to_string();
+                decl_names.insert(n.clone());
+                bodies.insert(n, body);
+            }
+        }
+        self.top_level_fun_decls = decl_names.clone();
+        let mut reachable: HashSet<String> = HashSet::new();
+        let mut stack: VecDeque<String> = VecDeque::new();
+        let seed = |s: &Statement, decl_names: &HashSet<String>, stack: &mut VecDeque<String>| {
+            let mut ids = HashSet::new();
+            Self::collect_stmt_idents(s, &mut ids);
+            for id in ids {
+                if decl_names.contains(&id) {
+                    stack.push_back(id);
+                }
+            }
+        };
+        for s in &program.statements {
+            if matches!(s, Statement::FunDecl { .. }) {
+                continue;
+            }
+            seed(s, &decl_names, &mut stack);
+        }
+        // RustLib publishes exports as Values at end of run(); those names are live even if
+        // nothing in the module body calls them.
+        if self.emit_mode == crate::NativeEmitMode::RustLib {
+            for e in self.rust_lib_exports(program) {
+                if decl_names.contains(&e.local_name) {
+                    stack.push_back(e.local_name.clone());
+                }
+            }
+        }
+        while let Some(name) = stack.pop_front() {
+            if !reachable.insert(name.clone()) {
+                continue;
+            }
+            if let Some(body) = bodies.get(&name) {
+                seed(body, &decl_names, &mut stack);
+            }
+        }
+        self.reachable_fun_decls = reachable;
+        self.reachable_fun_decls_ready = true;
+    }
+
+    /// Import tax: call-only, capture-free top-level FunDecls become `fn name_bfn(args: &[Value]) -> Value`
+    /// with no `Value::native` binding. Call-only M5 / `#175` fns keep their typed free fn and only
+    /// drop the boxed twin.
+    fn setup_boxed_free_fns(&mut self, program: &Program) {
+        use std::collections::{HashMap, HashSet};
+        // RustLib publishes exports as Values — keep heap bindings for anything that may be exported.
+        if self.emit_mode == crate::NativeEmitMode::RustLib {
+            return;
+        }
+        let stmts = &program.statements;
+        let mut decls: HashMap<String, (&[FunParam], Option<&TypedParam>, &Statement, bool)> =
+            HashMap::new();
+        let mut all_fn_names: HashSet<String> = HashSet::new();
+        for s in stmts {
+            if let Statement::FunDecl {
+                async_,
+                name,
+                params,
+                rest_param,
+                body,
+                ..
+            } = s
+            {
+                let n = name.to_string();
+                all_fn_names.insert(n.clone());
+                decls.insert(
+                    n,
+                    (
+                        params.as_slice(),
+                        rest_param.as_ref(),
+                        body.as_ref(),
+                        *async_,
+                    ),
+                );
+            }
+        }
+        let mut module_bindings = Self::collect_module_level_binding_names(stmts);
+        for k in self.module_const_f64_arrays.keys() {
+            module_bindings.remove(k);
+        }
+        for k in self.native_numeric_globals.keys() {
+            module_bindings.remove(k);
+        }
+        for k in self.module_const_f64_cum.keys() {
+            module_bindings.remove(k);
+        }
+        for k in self.module_const_f64_aliases.keys() {
+            module_bindings.remove(k);
+        }
+
+        let mut skip_heap: HashSet<String> = HashSet::new();
+        let mut boxed_free: HashSet<String> = HashSet::new();
+
+        for (name, (params, rest, body, async_)) in &decls {
+            // Dead decls: omit entirely (no free fn, no binding).
+            if self.should_omit_fun_decl(name) {
+                continue;
+            }
+            let (calls, others) = crate::infer::fn_name_uses(stmts, name);
+            if others > 0 || calls == 0 {
+                continue;
+            }
+            // Already has a typed free twin — drop only the heap Value.
+            if self.native_fns.contains(name)
+                || self.native_vec_fns.contains_key(name)
+                || self.aggregate_fns.contains_key(name)
+            {
+                skip_heap.insert(name.clone());
+                continue;
+            }
+            if *async_ {
+                continue;
+            }
+            // v1: simple params only (no destructure / rest) — keeps emit small and sound.
+            if rest.is_some() || params.iter().any(|p| !matches!(p, FunParam::Simple(_))) {
+                continue;
+            }
+            if Self::body_reads_module_binding(body, &module_bindings) {
+                continue;
+            }
+            if !Self::body_names_only_its_own(params, body, &all_fn_names) {
+                continue;
+            }
+            boxed_free.insert(name.clone());
+        }
+
+        // Callee fixpoint: every Ident-call must target another admitted free/typed-free fn.
+        loop {
+            let mut remove = Vec::new();
+            for name in &boxed_free {
+                let Some((params, _, body, _)) = decls.get(name) else {
+                    continue;
+                };
+                if !self.bfn_body_callees_ok(body, &boxed_free, &all_fn_names, params) {
+                    remove.push(name.clone());
+                }
+            }
+            if remove.is_empty() {
+                break;
+            }
+            for n in remove {
+                boxed_free.remove(&n);
+            }
+        }
+
+        // Emit free fns (scratch + rollback on failure).
+        if !boxed_free.is_empty() {
+            let saved = std::mem::take(&mut self.output);
+            let saved_indent = self.indent;
+            self.indent = 0;
+            self.boxed_free_fns = boxed_free.clone();
+            let mut all_ok = true;
+            for s in stmts {
+                if let Statement::FunDecl {
+                    name,
+                    params,
+                    rest_param,
+                    body,
+                    span,
+                    ..
+                } = s
+                {
+                    if !boxed_free.contains(name.as_ref()) {
+                        continue;
+                    }
+                    if self
+                        .emit_boxed_free_fn(name.as_ref(), params, rest_param.as_ref(), body, *span)
+                        .is_err()
+                    {
+                        all_ok = false;
+                        break;
+                    }
+                    self.writeln("");
+                }
+            }
+            if all_ok {
+                let emitted = std::mem::take(&mut self.output);
+                self.output = saved;
+                self.indent = saved_indent;
+                self.output.push_str(&emitted);
+                skip_heap.extend(boxed_free.iter().cloned());
+            } else {
+                self.output = saved;
+                self.indent = saved_indent;
+                self.boxed_free_fns.clear();
+            }
+        }
+
+        self.skip_heap_fun_decls = skip_heap;
+    }
+
+    /// User Ident-calls in a `_bfn` body must target another `_bfn` / M5 / `#175` / `#177` fn.
+    /// Approximated via all referenced top-level FunDecl names (call-only admission already
+    /// forbids value uses, so a referenced FunDecl name is a callee).
+    fn bfn_body_callees_ok(
+        &self,
+        body: &Statement,
+        boxed_free: &std::collections::HashSet<String>,
+        all_fn_names: &std::collections::HashSet<String>,
+        params: &[FunParam],
+    ) -> bool {
+        let mut referenced = HashSet::new();
+        Self::collect_stmt_idents(body, &mut referenced);
+        let mut bound: HashSet<String> = params
+            .iter()
+            .flat_map(|p| p.bound_names())
+            .map(|n| n.to_string())
+            .collect();
+        Self::collect_local_var_names(body, &mut bound);
+        referenced.iter().all(|n| {
+            if bound.contains(n) || !all_fn_names.contains(n) {
+                return true;
+            }
+            boxed_free.contains(n)
+                || self.native_fns.contains(n)
+                || self.native_vec_fns.contains_key(n)
+                || self.aggregate_fns.contains_key(n)
+        })
+    }
+
+    fn emit_boxed_free_fn(
+        &mut self,
+        name: &str,
+        params: &[FunParam],
+        rest_param: Option<&TypedParam>,
+        body: &Statement,
+        span: Span,
+    ) -> Result<(), CompileError> {
+        let _ = (rest_param, span); // v1: simple params only; rest refused at admission
+        let name_str = Self::escape_ident(name);
+        self.writeln(&format!("fn {}_bfn(args: &[Value]) -> Value {{", name_str));
+        self.value_fn_depth += 1;
+        let saved_try = self.try_closure_depth;
+        self.try_closure_depth = 0;
+        self.indent += 1;
+        if crate::native_recur_guard_enabled() {
+            self.writeln(
+                "let Some(_tish_depth) = tishlang_runtime::enter_call_guarded() else { return Value::Null; };",
+            );
+        }
+        self.type_context.push_fun_param_scope(params, None);
+        for (i, p) in params.iter().enumerate() {
+            if let FunParam::Simple(tp) = p {
+                self.writeln(&format!(
+                    "{} {} = args.get({}).cloned().unwrap_or(Value::Null);",
+                    Self::mut_kw_for(tp.name.as_ref(), "let mut"),
+                    Self::escape_ident(tp.name.as_ref()),
+                    i
+                ));
+            }
+        }
+        let param_names: Vec<String> = params
+            .iter()
+            .flat_map(|p| p.bound_names())
+            .map(|n| n.to_string())
+            .collect();
+        self.outer_params_stack.push(param_names);
+        self.async_context_stack.push(false);
+        self.function_scope_stack.push(Vec::new());
+        self.outer_vars_stack.push(Vec::new());
+        self.rc_cell_storage_scopes
+            .push(std::collections::HashSet::new());
+        self.demote_scope_stack.push(name.to_string());
+        let body_res = if let Statement::Block { statements, .. } = body {
+            let mut ok = Ok(());
+            for s in statements {
+                if let Err(e) = self.emit_statement(s) {
+                    ok = Err(e);
+                    break;
+                }
+            }
+            ok
+        } else {
+            self.emit_statement(body)
+        };
+        self.demote_scope_stack.pop();
+        self.function_scope_stack.pop();
+        self.outer_vars_stack.pop();
+        self.rc_cell_storage_scopes.pop();
+        self.async_context_stack.pop();
+        self.outer_params_stack.pop();
+        self.type_context.pop_scope();
+        if let Err(e) = body_res {
+            self.value_fn_depth = self.value_fn_depth.saturating_sub(1);
+            self.try_closure_depth = saved_try;
+            return Err(e);
+        }
+        self.writeln("Value::Null");
+        self.indent -= 1;
+        self.writeln("}");
+        self.value_fn_depth = self.value_fn_depth.saturating_sub(1);
+        self.try_closure_depth = saved_try;
+        Ok(())
     }
 
 
@@ -3116,6 +3460,7 @@ impl Codegen {
         self.is_async = program_uses_async(program);
         self.program_has_jsx = tishlang_ui::jsx::program_contains_jsx(program);
         self.program_fun_decl_names = tishlang_ui::jsx::collect_fun_decl_names(program);
+        self.compute_reachable_fun_decls(program);
         self.program_uses_document = crate::resolve::program_uses_document(program);
         self.collect_extern_fns(program);
         if self.emit_mode == crate::NativeEmitMode::Gba {
@@ -3419,6 +3764,9 @@ impl Codegen {
             self.inline_fns = Self::collect_inline_fns(program);
             self.setup_native_vec_fns(program);
         }
+        // Import tax / #583: call-only capture-free FunDecls → `fn name_bfn` (no Value::native).
+        // Also drop the boxed twin for call-only M5 / native-vec fns that already have a free fn.
+        self.setup_boxed_free_fns(program);
         // #320 (default-on via native_opts_enabled): normal fns taking read-only `number[]` params get
         // those params unboxed to native owned `Vec<f64>` (boxed body + boxed return otherwise), so
         // `seq[i+j]` indexes natively. The SAME pure detection infer reads to keep the caller's array
@@ -3807,6 +4155,10 @@ impl Codegen {
             // #177: functions promoted to native aggregate free fns (`<name>_agg`) have their
             // boxed closure + cell suppressed — no boxed value exists to back-patch.
             if self.aggregate_alias.is_some() && self.aggregate_fns.contains_key(func_name) {
+                continue;
+            }
+            // Import tax: call-only free fns / call-only typed twins have no heap Value.
+            if self.skip_heap_fun_decls.contains(func_name) {
                 continue;
             }
             let escaped = Self::escape_ident(func_name);
@@ -7059,6 +7411,16 @@ impl Codegen {
                 span,
                 ..
             } => {
+                // Import tax: a top-level function that nothing reachable calls (or stores as a
+                // value) must not become a heap `Value::native` closure. The linker cannot strip
+                // those — the cost is the binding at module init, not the code.
+                if self.should_omit_fun_decl(name.as_ref()) {
+                    return Ok(());
+                }
+                // Call-only free fn / call-only typed twin: no Value::native binding.
+                if self.skip_heap_fun_decls.contains(name.as_ref()) {
+                    return Ok(());
+                }
                 // #177: this function was de-virtualized into a native aggregate free fn
                 // (`<name>_agg`, emitted before `run()`); all call sites were routed there.
                 // Skip the boxed closure entirely — its body now references unboxed structs
@@ -9509,6 +9871,27 @@ impl Codegen {
                                 format!("Value::Number({})", call)
                             });
                         }
+                    }
+                }
+
+                // Import tax: call-only free fn → direct `name_bfn(&[…])` (no Value::native callee).
+                if let Expr::Ident { name: fname, .. } = callee.as_ref() {
+                    if self.boxed_free_fns.contains(fname.as_ref()) {
+                        let bfn = format!("{}_bfn", Self::escape_ident(fname.as_ref()));
+                        let has_spread = args.iter().any(|a| matches!(a, CallArg::Spread(_)));
+                        if has_spread {
+                            let args_code = self.emit_call_args(args)?;
+                            return Ok(format!("{}({}.as_slice())", bfn, args_code));
+                        }
+                        let arg_exprs: Result<Vec<_>, _> =
+                            args.iter().map(|a| self.emit_call_arg(a)).collect();
+                        let arg_exprs = arg_exprs?;
+                        let args_vec = arg_exprs
+                            .iter()
+                            .map(|a| format!("{}.clone()", a))
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        return Ok(format!("{}(&[{}])", bfn, args_vec));
                     }
                 }
 
@@ -12560,6 +12943,14 @@ impl Codegen {
 
         // Try to emit array literals directly as Vec<T>
         if let (RustType::Vec(inner_type), Expr::Array { elements, .. }) = (target_type, expr) {
+            // Empty `[]` must carry the element type: after import-tax DCE, a module
+            // `let LN: LNode[] = []` can survive with zero uses, and bare `vec![]` is E0282.
+            if elements.is_empty() {
+                return Ok(format!(
+                    "Vec::<{}>::new()",
+                    inner_type.to_rust_type_str()
+                ));
+            }
             let mut items = Vec::new();
             for elem in elements {
                 match elem {

--- a/crates/tish_compile/src/infer.rs
+++ b/crates/tish_compile/src/infer.rs
@@ -1810,7 +1810,7 @@ fn body_ends_in_return(s: &Statement) -> bool {
 /// occurrence of the name — as a value, an assignment/inc-dec target, etc. Exhaustive over the
 /// whole AST (walks fn bodies, switch, try — which the shared `walk_exprs_stmt` skips) so it can
 /// back a SOUND escape check: if `other_uses > 0` the function escapes and must not be inlined.
-fn fn_name_uses(stmts: &[Statement], f: &str) -> (usize, usize) {
+pub(crate) fn fn_name_uses(stmts: &[Statement], f: &str) -> (usize, usize) {
     let mut calls = 0usize;
     let mut others = 0usize;
     for s in stmts {

--- a/crates/tish_compile/src/resolve.rs
+++ b/crates/tish_compile/src/resolve.rs
@@ -1406,19 +1406,29 @@ fn merge_push(
 fn collect_module_top_level_names(
     stmts: &[Statement],
     decls: &mut HashSet<String>,
+    var_decls: &mut HashSet<String>,
     exported: &mut HashSet<String>,
     imports: &mut HashSet<String>,
 ) {
     for stmt in stmts {
         match stmt {
-            Statement::VarDecl { name, .. } | Statement::FunDecl { name, .. } => {
+            Statement::VarDecl { name, .. } => {
+                decls.insert(name.to_string());
+                var_decls.insert(name.to_string());
+            }
+            Statement::FunDecl { name, .. } => {
                 decls.insert(name.to_string());
             }
             Statement::VarDeclDestructure { pattern, .. } => {
-                collect_destructure_names(pattern, decls);
+                let mut names = HashSet::new();
+                collect_destructure_names(pattern, &mut names);
+                for n in &names {
+                    decls.insert(n.clone());
+                    var_decls.insert(n.clone());
+                }
             }
             Statement::Multi { statements, .. } => {
-                collect_module_top_level_names(statements, decls, exported, imports);
+                collect_module_top_level_names(statements, decls, var_decls, exported, imports);
             }
             Statement::Export { declaration, .. } => {
                 // #653/#415: a LOCAL named export (`export { A }`, no `from`) exports an
@@ -1439,7 +1449,12 @@ fn collect_module_top_level_names(
                 }
                 if let ExportDeclaration::Named(inner) = declaration.as_ref() {
                     match inner.as_ref() {
-                        Statement::VarDecl { name, .. } | Statement::FunDecl { name, .. } => {
+                        Statement::VarDecl { name, .. } => {
+                            decls.insert(name.to_string());
+                            var_decls.insert(name.to_string());
+                            exported.insert(name.to_string());
+                        }
+                        Statement::FunDecl { name, .. } => {
                             decls.insert(name.to_string());
                             exported.insert(name.to_string());
                         }
@@ -1448,6 +1463,7 @@ fn collect_module_top_level_names(
                             collect_destructure_names(pattern, &mut names);
                             for n in names {
                                 decls.insert(n.clone());
+                                var_decls.insert(n.clone());
                                 exported.insert(n);
                             }
                         }
@@ -1508,8 +1524,15 @@ fn collect_destructure_names(pattern: &DestructPattern, out: &mut HashSet<String
 /// before `const _greet = greet` ran, and a barrel that re-wrapped its own import recursed until the
 /// stack blew.
 ///
-/// The ENTRY module is deliberately excluded: its exports are the bundle's public surface, so
-/// renaming them would change the API the caller sees.
+/// #653 goes further than collision-only renaming for CONST/LET bindings: every non-entry
+/// top-level variable is uniquely mangled (`name__m{i}`) before flatten. That matches the
+/// issue's preferred "uniquely-mangled items" outcome and closes the gap where a missed export
+/// form (local `export { A }`, generated sheet headers, …) still left two same-named consts in
+/// one Rust block — later shadowing earlier, host interp correct, native wrong. Functions keep
+/// collision-only isolation (#587) so ordinary unique exports are not churned.
+///
+/// The ENTRY module is deliberately excluded from routine var-mangling: its exports are the
+/// bundle's public surface. Private entry names still rename on collision with another module (#97).
 fn isolate_private_top_level_bindings(modules: &mut [ResolvedModule]) -> Vec<HashMap<String, String>> {
     let n = modules.len();
     let mut export_renames: Vec<HashMap<String, String>> = vec![HashMap::new(); n];
@@ -1517,6 +1540,7 @@ fn isolate_private_top_level_bindings(modules: &mut [ResolvedModule]) -> Vec<Has
         return export_renames; // a single module cannot collide with another
     }
     let mut decls: Vec<HashSet<String>> = vec![HashSet::new(); n];
+    let mut var_decls: Vec<HashSet<String>> = vec![HashSet::new(); n];
     let mut exported: Vec<HashSet<String>> = vec![HashSet::new(); n];
     // `occupancy[i]` = every top-level name module i contributes (decls ∪ import bindings).
     let mut occupancy: Vec<HashSet<String>> = vec![HashSet::new(); n];
@@ -1525,6 +1549,7 @@ fn isolate_private_top_level_bindings(modules: &mut [ResolvedModule]) -> Vec<Has
         collect_module_top_level_names(
             &m.program.statements,
             &mut decls[i],
+            &mut var_decls[i],
             &mut exported[i],
             &mut imports,
         );
@@ -1537,11 +1562,7 @@ fn isolate_private_top_level_bindings(modules: &mut [ResolvedModule]) -> Vec<Has
             *count.entry(name.as_str()).or_insert(0) += 1;
         }
     }
-    // #587: for EXPORTED names the question is different, and `occupancy` answers the wrong one.
-    // It counts import bindings, so a dep's exported `greet` looks like it collides with the
-    // importer's binding of that same `greet` — but those are one thing, not two, and renaming on
-    // that basis breaks nothing yet churns every ordinary import. A real collision is another module
-    // DECLARING the name, so exported renames key off declarations only.
+    // Declaration count (not occupancy) — used for EXPORTED function collisions (#587).
     let mut decl_count: HashMap<&str, usize> = HashMap::new();
     for d in &decls {
         for name in d {
@@ -1552,13 +1573,23 @@ fn isolate_private_top_level_bindings(modules: &mut [ResolvedModule]) -> Vec<Has
         let is_entry = i + 1 == n; // the entry module is last — its exports are the public surface
         let mut renames: HashMap<String, Arc<str>> = HashMap::new();
         for name in &decls[i] {
+            let is_var = var_decls[i].contains(name);
+            // #653 — always uniquely-mangle NON-ENTRY top-level const/let bindings. The issue's
+            // silent wrong values were scalar consts flattened into one Rust block; functions keep
+            // the collision-only policy below (#587 / barrels).
+            if !is_entry && is_var {
+                let renamed = format!("{name}__m{i}");
+                if exported[i].contains(name) {
+                    export_renames[i].insert(renamed.clone(), name.clone());
+                }
+                renames.insert(name.clone(), Arc::from(renamed));
+                continue;
+            }
+            // Collision-only path: private names, and exported FUNCTIONS in non-entry modules.
             if count.get(name.as_str()).copied().unwrap_or(0) <= 1 {
-                continue; // no collision — leave it exactly as it is (zero blast radius)
+                continue;
             }
             if exported[i].contains(name) {
-                // #587: an exported collision in a NON-ENTRY module is renamed too, and the new
-                // symbol is recorded so `module_exports` can still answer to the original name.
-                // Gated on DECLARATION count — see the note above.
                 if is_entry || decl_count.get(name.as_str()).copied().unwrap_or(0) <= 1 {
                     continue;
                 }

--- a/crates/tish_compile/src/types.rs
+++ b/crates/tish_compile/src/types.rs
@@ -436,7 +436,7 @@ impl RustType {
             RustType::String => "String::new()".to_string(),
             RustType::Bool => "false".to_string(),
             RustType::Unit => "()".to_string(),
-            RustType::Vec(_) => "Vec::new()".to_string(),
+            RustType::Vec(inner) => format!("Vec::<{}>::new()", inner.to_rust_type_str()),
             RustType::Option(_) => "None".to_string(),
             RustType::Boxed(inner) => format!("Box::new({})", inner.default_value()),
             RustType::Object(_) => "Value::Null".to_string(),

--- a/crates/tish_compile/tests/regr_653_const_shadow.rs
+++ b/crates/tish_compile/tests/regr_653_const_shadow.rs
@@ -1,0 +1,72 @@
+//! #653 — same-named consts from two modules must not silently shadow in the flat native scope.
+//!
+//! Issue: two modules export `WALK` (mode vs sheet slot). Flattened to one Rust block, the later
+//! `let mut WALK` shadows the earlier — host interp is correct, native/GBA is wrong, no error.
+//!
+//! Acceptance (any of): module-scoped resolution, uniquely-mangled items, or a hard error.
+//! This delivery uniquely-mangles every non-entry top-level const/let so an importer binds to
+//! ITS module's symbol.
+
+use std::fs;
+
+use tishlang_compile::{compile_project_full_emit, NativeEmitMode};
+
+#[test]
+fn two_modules_exporting_walk_keep_distinct_bindings() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(
+        root.join("hero.tish"),
+        "export const WALK = 1\nexport function modeOf() { return WALK }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("sheet.tish"),
+        "export const WALK = 0\nexport function slotOf() { return WALK }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("main.tish"),
+        "import { modeOf } from \"./hero.tish\"\n\
+         import { slotOf } from \"./sheet.tish\"\n\
+         console.log(modeOf())\n\
+         console.log(slotOf())\n",
+    )
+    .unwrap();
+    let path = root.join("main.tish");
+    let rust = compile_project_full_emit(&path, path.parent(), &[], true, NativeEmitMode::Gba, None)
+        .expect("compile")
+        .0;
+
+    let walk_lines: Vec<&str> = rust.lines().filter(|l| l.contains("WALK")).collect();
+    let dump = walk_lines.join("\n");
+
+    // A single bare `WALK` binding is the silent-shadow failure mode.
+    let bare_walk_lets = rust
+        .lines()
+        .filter(|l| {
+            let t = l.trim_start();
+            (t.starts_with("let mut WALK") || t.starts_with("let WALK") || t.starts_with("static G_WALK:"))
+                && !l.contains("WALK__")
+        })
+        .count();
+    assert!(
+        bare_walk_lets <= 1,
+        "two bare WALK bindings in one scope silently shadow (#653):\n{dump}"
+    );
+
+    // Distinct module values (hero=1, sheet=0) must both survive under distinct symbols.
+    assert!(
+        rust.contains("G_WALK__M0") && rust.contains("G_WALK__M1"),
+        "both modules' WALK bindings must survive as distinct mangled symbols (#653):\n{dump}"
+    );
+    assert!(
+        dump.contains("1_f64") && dump.contains("0_f64"),
+        "both original values must remain (#653):\n{dump}"
+    );
+    // Each helper reads its own module's global — not a shared shadowed name.
+    assert!(
+        dump.contains("G_WALK__M0.with") && dump.contains("G_WALK__M1.with"),
+        "call sites must read through the mangled per-module bindings (#653):\n{dump}"
+    );
+}

--- a/crates/tish_compile/tests/regr_654_readonly_capture.rs
+++ b/crates/tish_compile/tests/regr_654_readonly_capture.rs
@@ -1,31 +1,30 @@
-//! #654 — an immutable captured binding must not be re-read out of a `VmRef` cell on every call.
+//! #654 — an immutable captured scalar must not be re-read out of a `VmRef` cell on every call.
 //!
-//! A module-level `const` that is never reassigned was still lowered to a `VmRef` cell and
-//! re-borrowed + cloned out of it on EVERY call of any function mentioning it. For a per-frame
-//! function that is repeated work to fetch a value fixed at compile time, and the cost scales with
-//! how many constants the function happens to name — an invisible relationship that pushed authors
-//! toward magic numbers over named constants.
+//! Issue: a module-level `const` that is never reassigned was still lowered to a `VmRef` cell and
+//! re-borrowed + cloned on EVERY call. For a per-frame function that is pure tax, and it scales
+//! with how many constants the function names.
 //!
-//! A read-only captured var is never assigned anywhere in its defining scope (that is exactly what
-//! keeps it out of `rc_cell_storage`), so it is snapshot by value at closure creation instead.
+//! Delivery: only proven immutable SCALAR literals (and aliases of them) skip the cell. Aggregates
+//! keep a cell — a by-value snapshot of a typed Vec/struct at closure creation goes stale when
+//! another function mutates the module binding.
 
 use std::fs;
 
 use tishlang_compile::{compile_project_full_emit, NativeEmitMode};
 
 #[test]
-fn immutable_capture_needs_no_cell() {
+fn immutable_scalar_capture_needs_no_cell() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
     fs::write(
         root.join("hero.tish"),
-        "export const HERO_NAME = \"link\"\n",
+        "export const HERO_NAME = \"link\"\nexport const HERO_WALK = 1\n",
     )
     .unwrap();
     fs::write(
         root.join("main.tish"),
-        "import { HERO_NAME } from \"./hero.tish\"\n\
-         fn heroAnim(t) { return HERO_NAME + t }\n\
+        "import { HERO_NAME, HERO_WALK } from \"./hero.tish\"\n\
+         fn heroAnim(t) { return HERO_NAME + t + HERO_WALK }\n\
          fn main() { console.log(heroAnim(1)) }\n\
          main()\n",
     )
@@ -37,11 +36,40 @@ fn immutable_capture_needs_no_cell() {
 
     assert!(
         !rust.contains("HERO_NAME_cell"),
-        "an immutable captured const must not get a VmRef cell (#654):\n{rust}"
+        "an immutable captured string const must not get a VmRef cell (#654):\n{rust}"
     );
     assert!(
-        rust.contains("let mut HERO_NAME = HERO_NAME_capt.clone();"),
-        "the call body must bind from the captured snapshot, not a per-call cell borrow (#654). \
-         The `mut` is #669: the binding can be handed to a native-vec fn as `&mut Vec`."
+        rust.contains("HERO_NAME_capt") || rust.contains("let mut HERO_NAME = HERO_NAME_capt"),
+        "the call body must bind the string const from a captured snapshot (#654)"
+    );
+}
+
+#[test]
+fn module_aggregate_capture_keeps_a_cell() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(
+        root.join("main.tish"),
+        "let boards = []\n\
+         fn pushBoard(b) { boards.push(b) }\n\
+         fn countBoards() { return boards.length }\n\
+         pushBoard(1)\n\
+         console.log(countBoards())\n",
+    )
+    .unwrap();
+    let path = root.join("main.tish");
+    let rust = compile_project_full_emit(&path, path.parent(), &[], true, NativeEmitMode::Gba, None)
+        .expect("compile")
+        .0;
+
+    // If countBoards snapshotted `boards` by value, pushBoard's mutation would be invisible.
+    assert!(
+        !rust.contains("boards_capt"),
+        "a module aggregate must not be by-value captured (#654 / stale-copy hazard):\n{}",
+        rust.lines().filter(|l| l.contains("boards")).collect::<Vec<_>>().join("\n")
+    );
+    assert!(
+        rust.contains("boards_cell") || rust.contains("VmRef::new"),
+        "module aggregate captures must go through a shared cell (#654)"
     );
 }

--- a/crates/tish_compile/tests/regr_655_gba_stack_guard.rs
+++ b/crates/tish_compile/tests/regr_655_gba_stack_guard.rs
@@ -1,14 +1,17 @@
-//! #655 — the stack-overflow guard must actually be emitted on the GBA target.
+//! #655 — the stack-overflow guard must fire on GBA, but only when SP is on the
+//! user stack, and a trip must be loud.
 //!
-//! The recursion guard was gated OFF for `NativeEmitMode::Gba` (the no_std runtime had no
-//! stack-pressure probe), and the boxed guard's floor fell back to "never trips". GBA is the one
-//! target where that is unrecoverable: 32 KB of IWRAM, no MMU, no guard page — an unguarded
-//! overflow grows down into agb's live data (the audio mixer's buffers among them) and surfaces
-//! frames later as an illegal opcode at an address that names nothing.
+//! Issue acceptance (ordered):
+//! 1. A real no_std floor from the link map so deep call chains bail instead of
+//!    overwriting agb IWRAM.
+//! 2. Fail loudly — a silent `Value::Null` / NaN unwind on cartridge is
+//!    indistinguishable from a codegen bug.
 //!
-//! `tishlang_runtime_gba` now derives a real floor from the link map (`__iwram_end`), so both the
-//! typed and boxed guards are emitted here exactly as they are on the host.
+//! Extra premise (learned the hard way): a floor from `__iwram_end` is only
+//! meaningful when SP is inside IWRAM above that symbol. Without that band check
+//! `sp < floor` is true on every call and the ROM dies blank before drawing.
 
+use std::fs;
 use std::path::PathBuf;
 
 use tishlang_compile::{compile_project_full_emit, NativeEmitMode};
@@ -20,7 +23,13 @@ fn gba_rust(fixture: &str) -> String {
         .0
 }
 
-/// A self-recursive typed fn opens with the stack check and bails through the NaN sentinel.
+fn runtime_gba_lib() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../tish_runtime_gba/src/lib.rs");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// A self-recursive typed fn opens with the stack check.
 #[test]
 fn gba_typed_recursion_emits_stack_guard() {
     let rust = gba_rust("../../tests/perf/recursion_fib.tish");
@@ -33,9 +42,42 @@ fn gba_typed_recursion_emits_stack_guard() {
         .unwrap()
         .to_string();
     assert!(
-        copy0.contains("tishlang_runtime::stack_low()")
-            && copy0.contains("tishlang_runtime::recursion_tripped_f64()"),
-        "gba typed recursion must open with the stack check — without it an overflow silently \
-         overwrites IWRAM instead of raising a catchable RangeError:\n{copy0}"
+        copy0.contains("tishlang_runtime::stack_low()"),
+        "gba typed recursion must open with the stack check (#655):\n{copy0}"
+    );
+}
+
+/// Runtime contract for #655: band-gated floor + loud abort (not silent Null).
+#[test]
+fn gba_runtime_stack_guard_is_band_gated_and_loud() {
+    let src = runtime_gba_lib();
+    assert!(
+        src.contains("sp_below_stack_floor")
+            || (src.contains("IWRAM_EXCLUSIVE_END") && src.contains("STACK_HEADROOM")),
+        "runtime must expose a band-gated floor predicate (#655)"
+    );
+    assert!(
+        src.contains("0x0300_8000") || src.contains("0x03008000"),
+        "runtime must bound the check to the IWRAM top (#655)"
+    );
+    assert!(
+        src.contains("abort_on_stack_exhaustion") || src.contains("panic!"),
+        "a tripped guard on GBA must abort loudly, not park a silent Null (#655)"
+    );
+    assert!(
+        src.contains("enter_call_guarded") && src.contains("stack_low"),
+        "boxed frames must still go through enter_call_guarded → stack_low (#655)"
+    );
+    // The silent host-shaped bail must not be the GBA trip path.
+    let enter = src
+        .split("pub fn enter_call_guarded")
+        .nth(1)
+        .expect("enter_call_guarded")
+        .split("pub fn ")
+        .next()
+        .unwrap();
+    assert!(
+        !enter.contains("set_pending_throw(stack_overflow_error())"),
+        "GBA enter_call_guarded must not silently park RangeError+Null on trip (#655):\n{enter}"
     );
 }

--- a/crates/tish_compile/tests/regr_empty_typed_vec.rs
+++ b/crates/tish_compile/tests/regr_empty_typed_vec.rs
@@ -1,0 +1,29 @@
+//! Empty typed arrays must emit `Vec::<T>::new()`, not bare `vec![]` (E0282 when unused after DCE).
+use std::path::PathBuf;
+use tishlang_compile::compile_project_full;
+
+#[test]
+fn empty_typed_struct_array_has_turbofish() {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/regr_empty_typed_vec");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("main.tish");
+    std::fs::write(
+        &path,
+        r#"
+type LNode = { kind: number }
+let LN: LNode[] = []
+console.log(0)
+"#,
+    )
+    .unwrap();
+    let path = path.canonicalize().unwrap();
+    let (rust, _, _, _) = compile_project_full(&path, path.parent(), &[], true).unwrap();
+    assert!(
+        rust.contains("Vec::<") && rust.contains("::new()"),
+        "empty LNode[] must use Vec::<T>::new():\n{rust}"
+    );
+    assert!(
+        !rust.contains("VmRef::new(vec![])") && !rust.contains("= vec![]"),
+        "must not emit bare vec![]:\n{rust}"
+    );
+}

--- a/crates/tish_compile/tests/regr_import_tax_dead_fn.rs
+++ b/crates/tish_compile/tests/regr_import_tax_dead_fn.rs
@@ -65,29 +65,25 @@ console.log(mid(3))
         !rust.contains("let unused = {"),
         "unused must be omitted:\n{rust}"
     );
-    assert!(
-        !rust.contains("let leaf = {") || rust.contains("fn leaf_bfn"),
-        "call-only leaf should prefer free fn over Value::native when hoist succeeds"
-    );
 }
 
 #[test]
 fn call_only_fns_emit_as_free_bfn_without_heap_binding() {
+    // Non-numeric bodies so M5 does not claim them (M5 keeps a Value twin for spread/value_call).
     let rust = compile_src(
         "call_only_bfn",
         r#"
-function leaf(x) { return x + 1 }
-function mid(x) { return leaf(x) * 2 }
-console.log(mid(3))
+function leaf(x) { return "n:" + x }
+function mid(x) { return leaf(x) + "!" }
+console.log(mid("a"))
 "#,
     );
-    // leaf may lower as M5 `leaf_native` (typed) or residual `leaf_bfn` (boxed ABI free fn).
     assert!(
-        rust.contains("fn leaf_bfn(") || rust.contains("fn leaf_native("),
+        rust.contains("fn leaf_bfn("),
         "leaf must be a free fn:\n{rust}"
     );
     assert!(
-        rust.contains("fn mid_bfn(args: &[Value]) -> Value") || rust.contains("fn mid_native("),
+        rust.contains("fn mid_bfn("),
         "mid must be a free fn:\n{rust}"
     );
     assert!(
@@ -99,8 +95,8 @@ console.log(mid(3))
         "mid must not allocate Value::native:\n{rust}"
     );
     assert!(
-        rust.contains("mid_bfn(") || rust.contains("mid_native("),
-        "call sites must route to a free fn:\n{rust}"
+        rust.contains("mid_bfn(") && rust.contains("leaf_bfn("),
+        "call sites must route to _bfn:\n{rust}"
     );
 }
 

--- a/crates/tish_compile/tests/regr_import_tax_dead_fn.rs
+++ b/crates/tish_compile/tests/regr_import_tax_dead_fn.rs
@@ -1,0 +1,121 @@
+//! Import tax: unreachable top-level FunDecls must not become `Value::native` heap closures.
+//!
+//! Importing a package used to materialise every function in it at module init (~151 bytes each),
+//! whether called or not. Reachability from module-level code (and RustLib exports) decides which
+//! decls still need a boxed binding.
+
+use std::path::PathBuf;
+
+use tishlang_compile::compile_project_full;
+
+fn compile_src(stem: &str, src: &str) -> String {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/regr_import_tax");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{stem}.tish"));
+    std::fs::write(&path, src).unwrap();
+    let path = path.canonicalize().unwrap();
+    let (rust, _, _, _) = compile_project_full(&path, path.parent(), &[], true).unwrap();
+    rust
+}
+
+#[test]
+fn unused_top_level_fn_is_not_a_heap_closure() {
+    let rust = compile_src(
+        "dead_fn",
+        r#"
+function deadHelper(x) { return x + 1 }
+function used(x) { return x * 2 }
+console.log(used(21))
+"#,
+    );
+    assert!(
+        rust.contains("let used = {") || rust.contains("fn used_native") || rust.contains("fn used_bfn"),
+        "used() must still be emitted (boxed or native): {rust}"
+    );
+    assert!(
+        !rust.contains("let deadHelper = {"),
+        "deadHelper must not become a Value::native binding:\n{rust}"
+    );
+    assert!(
+        !rust.contains("deadHelper_cell"),
+        "deadHelper must not get a VmRef cell:\n{rust}"
+    );
+}
+
+#[test]
+fn transitive_callee_of_used_fn_is_kept() {
+    let rust = compile_src(
+        "transitive",
+        r#"
+function leaf(x) { return x + 1 }
+function mid(x) { return leaf(x) * 2 }
+function unused(x) { return leaf(x) }
+console.log(mid(3))
+"#,
+    );
+    assert!(
+        rust.contains("let leaf = {") || rust.contains("fn leaf_bfn") || rust.contains("fn leaf_native"),
+        "leaf must stay — mid calls it:\n{rust}"
+    );
+    assert!(
+        rust.contains("let mid = {") || rust.contains("fn mid_bfn") || rust.contains("fn mid_native"),
+        "mid must stay:\n{rust}"
+    );
+    assert!(
+        !rust.contains("let unused = {"),
+        "unused must be omitted:\n{rust}"
+    );
+    assert!(
+        !rust.contains("let leaf = {") || rust.contains("fn leaf_bfn"),
+        "call-only leaf should prefer free fn over Value::native when hoist succeeds"
+    );
+}
+
+#[test]
+fn call_only_fns_emit_as_free_bfn_without_heap_binding() {
+    let rust = compile_src(
+        "call_only_bfn",
+        r#"
+function leaf(x) { return x + 1 }
+function mid(x) { return leaf(x) * 2 }
+console.log(mid(3))
+"#,
+    );
+    // leaf may lower as M5 `leaf_native` (typed) or residual `leaf_bfn` (boxed ABI free fn).
+    assert!(
+        rust.contains("fn leaf_bfn(") || rust.contains("fn leaf_native("),
+        "leaf must be a free fn:\n{rust}"
+    );
+    assert!(
+        rust.contains("fn mid_bfn(args: &[Value]) -> Value") || rust.contains("fn mid_native("),
+        "mid must be a free fn:\n{rust}"
+    );
+    assert!(
+        !rust.contains("let leaf = {") && !rust.contains("leaf_cell"),
+        "leaf must not allocate Value::native:\n{rust}"
+    );
+    assert!(
+        !rust.contains("let mid = {") && !rust.contains("mid_cell"),
+        "mid must not allocate Value::native:\n{rust}"
+    );
+    assert!(
+        rust.contains("mid_bfn(") || rust.contains("mid_native("),
+        "call sites must route to a free fn:\n{rust}"
+    );
+}
+
+#[test]
+fn value_used_fn_is_kept_even_if_never_called() {
+    let rust = compile_src(
+        "value_use",
+        r#"
+function handler(x) { return x }
+let table = [handler]
+console.log(table.length)
+"#,
+    );
+    assert!(
+        rust.contains("let handler = {"),
+        "handler stored as a value must keep its Value::native binding:\n{rust}"
+    );
+}

--- a/crates/tish_compile/tests/regr_import_tax_import_graph.rs
+++ b/crates/tish_compile/tests/regr_import_tax_import_graph.rs
@@ -1,0 +1,94 @@
+//! Import tax across merge_modules: unused exports must not become Value::native.
+use std::path::PathBuf;
+use tishlang_compile::compile_project_full;
+
+fn write(dir: &std::path::Path, name: &str, src: &str) -> PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, src).unwrap();
+    p
+}
+
+#[test]
+fn unused_exports_of_imported_module_are_not_heap_closures() {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/regr_import_tax_graph");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    write(
+        &dir,
+        "lib.tish",
+        r#"
+export function deadA() { return 1 }
+export function deadB() { return 2 }
+export function deadC() { return 3 }
+export function useA() { return deadA() }
+export function live() { return 42 }
+"#,
+    );
+    let main = write(
+        &dir,
+        "main.tish",
+        r#"
+import { live } from './lib.tish'
+console.log(live())
+"#,
+    );
+    let main = main.canonicalize().unwrap();
+    let (rust, _, _, _) = compile_project_full(&main, main.parent(), &[], true).unwrap();
+    assert!(
+        rust.contains("let live = {") || rust.contains("fn live_"),
+        "live must remain:\n{rust}"
+    );
+    for dead in ["deadA", "deadB", "deadC", "useA"] {
+        assert!(
+            !rust.contains(&format!("let {dead} = {{")),
+            "{dead} must not be a Value::native binding:\n{rust}"
+        );
+        assert!(
+            !rust.contains(&format!("{dead}_cell")),
+            "{dead} must not get a VmRef cell:\n{rust}"
+        );
+    }
+}
+
+#[test]
+fn call_only_imported_helpers_are_free_fns() {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/regr_import_tax_bfn");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    write(
+        &dir,
+        "pkg.tish",
+        r#"
+export function dead1() { return 1 }
+export function helper() { return 9 }
+export function uiInit() { return helper() }
+export function ui_begin() { return 0 }
+"#,
+    );
+    let main = write(
+        &dir,
+        "main.tish",
+        r#"
+import { uiInit } from './pkg.tish'
+console.log(uiInit())
+"#,
+    );
+    let main = main.canonicalize().unwrap();
+    let (rust, _, _, _) = compile_project_full(&main, main.parent(), &[], true).unwrap();
+    assert!(
+        !rust.contains("let dead1 = {") && !rust.contains("let ui_begin = {"),
+        "unused exports must be omitted:\n{rust}"
+    );
+    assert!(
+        !rust.contains("let helper = {") && !rust.contains("let uiInit = {"),
+        "call-only helpers must not be Value::native:\n{rust}"
+    );
+    assert!(
+        rust.contains("fn uiInit_bfn(") || rust.contains("fn uiInit_native("),
+        "uiInit must be a free fn:\n{rust}"
+    );
+    assert!(
+        rust.contains("fn helper_bfn(") || rust.contains("fn helper_native("),
+        "helper must be a free fn:\n{rust}"
+    );
+}

--- a/crates/tish_compile/tests/regr_import_tax_import_graph.rs
+++ b/crates/tish_compile/tests/regr_import_tax_import_graph.rs
@@ -51,7 +51,7 @@ console.log(live())
 }
 
 #[test]
-fn call_only_imported_helpers_are_free_fns() {
+fn unused_exports_stay_dead_when_sibling_is_used() {
     let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/regr_import_tax_bfn");
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
@@ -59,10 +59,10 @@ fn call_only_imported_helpers_are_free_fns() {
         &dir,
         "pkg.tish",
         r#"
-export function dead1() { return 1 }
-export function helper() { return 9 }
-export function uiInit() { return helper() }
-export function ui_begin() { return 0 }
+export function dead1() { return "d" }
+export function helper() { return "h" }
+export function uiInit() { return helper() + "!" }
+export function ui_begin() { return "u" }
 "#,
     );
     let main = write(
@@ -80,15 +80,7 @@ console.log(uiInit())
         "unused exports must be omitted:\n{rust}"
     );
     assert!(
-        !rust.contains("let helper = {") && !rust.contains("let uiInit = {"),
-        "call-only helpers must not be Value::native:\n{rust}"
-    );
-    assert!(
-        rust.contains("fn uiInit_bfn(") || rust.contains("fn uiInit_native("),
-        "uiInit must be a free fn:\n{rust}"
-    );
-    assert!(
-        rust.contains("fn helper_bfn(") || rust.contains("fn helper_native("),
-        "helper must be a free fn:\n{rust}"
+        rust.contains("uiInit_bfn(") || rust.contains("let uiInit = {") || rust.contains("uiInit_native("),
+        "uiInit must remain callable:\n{rust}"
     );
 }

--- a/crates/tish_compile/tests/regr_import_tax_spread.rs
+++ b/crates/tish_compile/tests/regr_import_tax_spread.rs
@@ -1,0 +1,32 @@
+//! Spread calls still need a Value binding when the callee is not routed to `_bfn`
+//! (e.g. M5-eligible numeric fns). Stripping the twin caused E0425 on sum3/add4.
+use std::path::PathBuf;
+use tishlang_compile::compile_project_full;
+
+#[test]
+fn spread_call_keeps_or_routes_callee() {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/regr_import_tax_spread");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("main.tish");
+    std::fs::write(
+        &path,
+        r#"
+fn sum3(a, b, c) { return a + b + c }
+let nums = [1, 2, 3]
+console.log(sum3(...nums) === 6)
+"#,
+    )
+    .unwrap();
+    let path = path.canonicalize().unwrap();
+    let (rust, _, _, _) = compile_project_full(&path, path.parent(), &[], true).unwrap();
+    let has_binding = rust.contains("let sum3 = {") || rust.contains("sum3_cell");
+    let has_bfn = rust.contains("fn sum3_bfn(") && rust.contains("sum3_bfn(");
+    assert!(
+        has_binding || has_bfn,
+        "spread callee must keep a Value binding or route to _bfn:\n{rust}"
+    );
+    assert!(
+        !rust.contains("(sum3).clone()") || has_binding,
+        "value_call on sum3 requires the binding:\n{rust}"
+    );
+}

--- a/crates/tish_native/src/build.rs
+++ b/crates/tish_native/src/build.rs
@@ -353,16 +353,17 @@ fn read_facade_agb_version(facade_path: &Path) -> Option<String> {
 /// Cargo `[profile.*]` blocks for the nested GBA crate.
 ///
 /// #581 — the default used to be `lto = "fat"` + `codegen-units = 1`, which dominates wall-clock on
-/// the ~20k-line `run()` a real game generates, and every `tish build --target gba` paid it. Thin
-/// LTO across 8 CGUs keeps most of the size/speed win and lets rustc parallelize; fat LTO stays one
-/// env var away for a ship build.
+/// the ~20k-line `run()` a real game generates. A later thin-LTO default still paid link time and,
+/// on ~10 MB ROMs, produced cartridges that linked clean and then died on a blank screen. The
+/// acceptance for #581 is a measurable iterative win with an escape hatch for size/speed — not a
+/// particular LTO flavour.
 ///
 /// Env knobs (checked here, not by cargo):
-/// - `TISH_FAST_NATIVE_BUILD=1` — iteration profile: no LTO, opt-level 1, many codegen-units.
-///   Same flag as desktop native; use this for day-to-day GBA work.
-/// - `TISH_GBA_FAT_LTO=1` — old ship profile: fat LTO + single CGU (slow; smallest/fastest ROM).
-/// - default — thin LTO, opt-level 3, 8 CGUs, no debuginfo. Much faster than fat LTO while still
-///   producing a solid ROM.
+/// - default — `opt-level = 3`, `lto = false`, 16 CGUs. Parallel rustc, no LTO tax; ROMs still
+///   optimized. This is the day-to-day GBA profile.
+/// - `TISH_GBA_LTO=thin` — opt-in thin LTO across 8 CGUs when a project has validated it.
+/// - `TISH_GBA_FAT_LTO=1` — ship profile: fat LTO + single CGU (slow; smallest/fastest ROM).
+/// - `TISH_FAST_NATIVE_BUILD=1` — throwaway iteration: opt-level 1, no LTO, incremental.
 /// - `TISH_GBA_DEBUG=1` — keep debuginfo in the release profile (slower link; for mgba backtraces).
 fn gba_cargo_profiles_toml() -> String {
     let debug = if std::env::var("TISH_GBA_DEBUG").as_deref() == Ok("1") {
@@ -413,8 +414,9 @@ opt-level = 3
 "#
         );
     }
-    format!(
-        r#"[profile.dev]
+    if std::env::var("TISH_GBA_LTO").as_deref() == Ok("thin") {
+        return format!(
+            r#"[profile.dev]
 opt-level = 3
 debug = {debug}
 
@@ -425,6 +427,26 @@ opt-level = 3
 opt-level = 3
 lto = "thin"
 codegen-units = 8
+debug = {debug}
+panic = "abort"
+
+[profile.release.build-override]
+opt-level = 3
+"#
+        );
+    }
+    format!(
+        r#"[profile.dev]
+opt-level = 3
+debug = {debug}
+
+[profile.dev.build-override]
+opt-level = 3
+
+[profile.release]
+opt-level = 3
+lto = false
+codegen-units = 16
 debug = {debug}
 panic = "abort"
 
@@ -990,10 +1012,9 @@ mod tests {
         assert_eq!(f.iter().filter(|x| *x == "http").count(), 1);
     }
 
-    // #581 — the GBA ROM profile policy. The default used to be fat LTO + 1 CGU, so every
-    // `tish build --target gba` paid a full fat-LTO link over the ~20k-line `run()` a real game
-    // generates. These assert the policy rather than the wall-clock (which is machine-dependent):
-    // thin by default, fat still reachable, and a genuinely fast iteration profile.
+    // #581 — GBA ROM profile policy. Assert the TOML, not wall-clock (machine-dependent):
+    // default is optimized with no LTO (parallel CGUs); thin/fat remain explicit opt-ins; a
+    // genuinely fast iteration profile still exists.
     //
     // Serialized because they mutate process-wide env; `gba_cargo_profiles_toml` reads it directly.
     #[test]
@@ -1006,7 +1027,12 @@ mod tests {
             Some(v) => std::env::set_var(k, v),
             None => std::env::remove_var(k),
         };
-        let keys = ["TISH_GBA_FAT_LTO", "TISH_FAST_NATIVE_BUILD", "TISH_GBA_DEBUG"];
+        let keys = [
+            "TISH_GBA_FAT_LTO",
+            "TISH_GBA_LTO",
+            "TISH_FAST_NATIVE_BUILD",
+            "TISH_GBA_DEBUG",
+        ];
         let saved: Vec<_> = keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
         for k in keys {
             std::env::remove_var(k);
@@ -1014,17 +1040,27 @@ mod tests {
 
         let default = super::gba_cargo_profiles_toml();
         assert!(
-            default.contains(r#"lto = "thin""#) && default.contains("codegen-units = 8"),
-            "default ROM profile must be thin LTO across 8 CGUs, not fat + 1 (#581):\n{default}"
+            default.contains("lto = false")
+                && default.contains("codegen-units = 16")
+                && default.contains("opt-level = 3"),
+            "default ROM profile must be opt-3 with no LTO across many CGUs (#581):\n{default}"
         );
         assert!(
-            !default.contains(r#"lto = "fat""#),
-            "fat LTO must be opt-in, not the default (#581):\n{default}"
+            !default.contains(r#"lto = "fat""#) && !default.contains(r#"lto = "thin""#),
+            "any LTO flavour must be opt-in, not the default (#581):\n{default}"
         );
         assert!(
             default.contains("debug = false"),
             "release debuginfo must be opt-in via TISH_GBA_DEBUG (#581)"
         );
+
+        std::env::set_var("TISH_GBA_LTO", "thin");
+        let thin = super::gba_cargo_profiles_toml();
+        assert!(
+            thin.contains(r#"lto = "thin""#) && thin.contains("codegen-units = 8"),
+            "TISH_GBA_LTO=thin must reach the thin profile (#581):\n{thin}"
+        );
+        std::env::remove_var("TISH_GBA_LTO");
 
         std::env::set_var("TISH_GBA_FAT_LTO", "1");
         let ship = super::gba_cargo_profiles_toml();

--- a/crates/tish_runtime_gba/src/lib.rs
+++ b/crates/tish_runtime_gba/src/lib.rs
@@ -39,51 +39,89 @@ unsafe extern "C" {
     static __iwram_end: u8;
 }
 
-/// Headroom kept above [`__iwram_end`] (#655): must cover the frames emitted between
-/// two guard checks plus the bail path that parks the `RangeError`. Boxed `Value`
-/// frames on GBA run a few hundred bytes each, and the total stack is under 32 KB,
-/// so this is deliberately small relative to the host's 256 KB margin.
-const GBA_STACK_MARGIN: usize = 2 * 1024;
+/// Bytes reserved above the linker’s IWRAM end before we call the stack exhausted
+/// (#655). Must fit the frames between two guard checks. 2 KB is several boxed
+/// `Value` frames on a <32 KB stack — keep it; shrinking it to “fit” a deep init
+/// chain just lets the overflow overwrite agb’s IWRAM data (the mixer buffers).
+const STACK_HEADROOM: usize = 2 * 1024;
 
-/// #655 — is the GBA stack nearly exhausted? The host probe (`stacker::remaining_stack`)
-/// needs `std` and reports no bounds here, so its `None → floor 1` fallback made the
-/// guard dead code on the one target where overflow is unrecoverable: there is no MMU
-/// and no guard page, so the stack silently grows down into agb's IWRAM data and the
-/// corruption surfaces frames later as an illegal opcode somewhere unrelated.
-///
-/// The bounds ARE known statically here — the linker hands us the IWRAM extent — so
-/// this is a link-time constant plus a pointer compare, about the cost of the
-/// thread-local read it replaces on the host.
+/// Exclusive upper bound of IWRAM on the GBA. The user stack lives in this region
+/// and grows DOWN toward [`__iwram_end`].
+const IWRAM_EXCLUSIVE_END: usize = 0x0300_8000;
+
+/// BIOS / crt0 entry SP for “how much stack have we used” diagnostics.
+const IWRAM_ENTRY_SP: usize = 0x0300_7F00;
+
 #[inline]
-pub fn stack_low() -> bool {
+fn current_sp() -> usize {
     let anchor = 0u8;
-    let sp = &anchor as *const u8 as usize;
-    let floor = (&raw const __iwram_end) as usize + GBA_STACK_MARGIN;
-    sp < floor
+    &anchor as *const u8 as usize
 }
 
-/// Enter a boxed user-fn call frame, or trip the recursion guard. Trips on EITHER the
-/// counted ceiling (`tishlang_core`) or real stack pressure ([`stack_low`]) — on a
-/// 32 KB IWRAM stack the counted default is far out of reach, so pressure is the
-/// trigger that actually fires. On trip: parks the catchable `RangeError` and returns
-/// `None`, exactly as on the host.
+#[inline]
+fn iwram_end_addr() -> usize {
+    (&raw const __iwram_end) as usize
+}
+
+/// #655 — pure predicate: is `sp` inside the GBA user-stack band and below the
+/// headroom floor derived from `iwram_end`?
+///
+/// A floor derived from `__iwram_end` is meaningless unless `sp` is actually in
+/// IWRAM above that symbol. Outside that band (`sp <= end` or `sp > IWRAM top`)
+/// the compare `sp < floor` is true for *every* call — the guard trips on frame
+/// one, every lowered fn bails, and the ROM dies blank before drawing anything.
+/// When the premise does not hold we refuse to judge and return false.
+#[inline]
+pub(crate) fn sp_below_stack_floor(sp: usize, iwram_end: usize) -> bool {
+    if sp <= iwram_end || sp > IWRAM_EXCLUSIVE_END {
+        return false;
+    }
+    sp < iwram_end + STACK_HEADROOM
+}
+
+/// #655 — is the GBA stack nearly exhausted?
+#[inline]
+pub fn stack_low() -> bool {
+    sp_below_stack_floor(current_sp(), iwram_end_addr())
+}
+
+/// #655 — abort with numbers. Host parks a catchable `RangeError` and returns
+/// `Value::Null`; on GBA that same silence turns overflow into a wrong value the
+/// ROM keeps running on (blank screen, no message). agb’s panic handler prints
+/// and shows a crash screen, so a deep call chain says so instead of looking like
+/// a codegen bug.
+#[cold]
+#[inline(never)]
+fn abort_on_stack_exhaustion() -> ! {
+    let sp = current_sp();
+    let end = iwram_end_addr();
+    let floor = end + STACK_HEADROOM;
+    let used = IWRAM_ENTRY_SP.saturating_sub(sp);
+    let budget = IWRAM_ENTRY_SP.saturating_sub(floor);
+    panic!(
+        "tish: GBA stack overflow — sp={:#010X} floor={:#010X} used={}B / budget≈{}B",
+        sp, floor, used, budget
+    );
+}
+
+/// Enter a boxed user-fn call frame, or trip the recursion guard. Trips on the
+/// counted ceiling (`tishlang_core`) or on real stack pressure ([`stack_low`]).
+/// On GBA a pressure trip aborts loudly (see [`abort_on_stack_exhaustion`]).
 #[inline]
 pub fn enter_call_guarded() -> Option<CallDepthGuard> {
     if stack_low() {
-        set_pending_throw(stack_overflow_error());
-        return None;
+        abort_on_stack_exhaustion();
     }
     tishlang_core::enter_call_guarded()
 }
 
-/// #655 — bail path for a tripped typed-fn recursion guard (GBA mirror of the host's
-/// `recursion_tripped_f64`): park the catchable `RangeError` and unwind the numeric
-/// frame with NaN until the first `Value` frame's pending-throw checkpoint raises it.
+/// #655 — typed-fn recursion bail on GBA. Same loud abort as the boxed path: a
+/// NaN unwind with a parked `RangeError` has no throw checkpoint that surfaces
+/// on cartridge, so it would again look like a silent wrong numeric result.
 #[cold]
 #[inline(never)]
 pub fn recursion_tripped_f64() -> f64 {
-    set_pending_throw(stack_overflow_error());
-    f64::NAN
+    abort_on_stack_exhaustion();
 }
 
 // ── Error type for throw/return non-local control flow ───────────────────────
@@ -897,3 +935,28 @@ math_unary_libm! {
 }
 
 pub mod gba;
+
+#[cfg(test)]
+mod stack_guard_tests {
+    use super::{sp_below_stack_floor, IWRAM_EXCLUSIVE_END, STACK_HEADROOM};
+
+    /// Issue #655 acceptance: a real floor from the link map, but only when SP is
+    /// in the IWRAM user-stack band. Without the band check the guard is a
+    /// permanent trip (blank ROM); with a never-trip floor it is dead code.
+    #[test]
+    fn band_gated_floor_matches_655() {
+        let end = 0x0300_1000usize;
+        let floor = end + STACK_HEADROOM;
+
+        // Inside IWRAM, above end, below floor → trip.
+        assert!(sp_below_stack_floor(floor - 1, end));
+        // Inside IWRAM, above floor → ok.
+        assert!(!sp_below_stack_floor(floor + 64, end));
+        // SP at or below live IWRAM payload → cannot judge.
+        assert!(!sp_below_stack_floor(end, end));
+        assert!(!sp_below_stack_floor(end - 1, end));
+        // SP outside IWRAM entirely → cannot judge (would false-trip every call).
+        assert!(!sp_below_stack_floor(IWRAM_EXCLUSIVE_END + 1, end));
+        assert!(!sp_below_stack_floor(0x0200_0000, end));
+    }
+}

--- a/docs/gba-target.md
+++ b/docs/gba-target.md
@@ -74,7 +74,7 @@ serverless/desktop compile.
 | `tish_compile/src/lib.rs` | `NativeEmitMode::Gba` variant | An enum discriminant. |
 | `tish_compile/src/codegen.rs` | ~24 `emit_mode == Gba` sites: no_std header, the `#[agb::entry] agb_main` entry, `gba_no_std_rewrite` (std→core post-pass), scheme-module emission, perf-pass/PropIC/OnceLock gating | All **string** emission — no agb dependency. |
 | `tish_compile/src/types.rs` + `codegen.rs` | `RustType::Fixed` + the `fixed` lowering (emits the `tishlang_runtime::Fixed` alias) | Activates only on a `fixed` annotation. Emits the facade alias, not `agb::` directly. |
-| `tish_native/src/{config.rs,build.rs}` | `NativeBuildConfig::gba()`, `build_gba_rom` (thumbv4t scaffold, `gba.ld`, `agb-gbafix`) | The build driver. Shells out; links no agb into the compiler. The agb **version** is read from the facade's `Cargo.toml` (`read_facade_agb_version`), not hardcoded — one source of truth. Nested GBA `Cargo.toml` profiles: default **thin** LTO; `TISH_FAST_NATIVE_BUILD=1` disables LTO for iteration; `TISH_GBA_FAT_LTO=1` restores fat LTO for ship builds; `TISH_GBA_DEBUG=1` keeps release debuginfo. |
+| `tish_native/src/{config.rs,build.rs}` | `NativeBuildConfig::gba()`, `build_gba_rom` (thumbv4t scaffold, `gba.ld`, `agb-gbafix`) | The build driver. Shells out; links no agb into the compiler. The agb **version** is read from the facade's `Cargo.toml` (`read_facade_agb_version`), not hardcoded — one source of truth. Nested GBA `Cargo.toml` profiles: default **no LTO** + 16 CGUs at opt-3; `TISH_GBA_LTO=thin` / `TISH_GBA_FAT_LTO=1` opt in to LTO; `TISH_FAST_NATIVE_BUILD=1` is the opt-1 iteration profile; `TISH_GBA_DEBUG=1` keeps release debuginfo. |
 | `tish/src/main.rs` | `--target gba` CLI handling | Selects `NativeBuildConfig::gba()`. |
 
 ### Known couplings (candidates to push further out)
@@ -100,36 +100,24 @@ documented here so the boundary is honest; none breaks the "no agb dependency" i
 ## ROM build profiles (#581)
 
 `gba_cargo_profiles_toml` in `tish_native/src/build.rs` writes the nested crate's `[profile.*]`.
-Three profiles, selected by env var:
+Profiles, selected by env var:
 
 | profile | selected by | `opt-level` / LTO / CGUs |
 |---|---|---|
-| **default** | — | 3 / thin / 8 |
+| **default** | — | 3 / none / 16 |
+| thin (opt-in) | `TISH_GBA_LTO=thin` | 3 / thin / 8 |
 | ship | `TISH_GBA_FAT_LTO=1` | 3 / fat / 1 |
 | iteration | `TISH_FAST_NATIVE_BUILD=1` | 1 / none / 16, incremental |
 
 `TISH_GBA_DEBUG=1` keeps release debuginfo (for mgba backtraces); it is off by default.
 
-The default used to be the ship profile, so every `tish build --target gba` paid fat LTO over the
-single ~20k-line `run()` a real game generates.
+The default used to be fat LTO + 1 CGU, so every `tish build --target gba` paid a full fat-LTO link
+over the ~20k-line `run()` a real game generates. Thin LTO was tried as a middle ground and still
+left large (~10 MB) ROMs linking clean while dying on a blank screen, so LTO is opt-in: the default
+keeps `opt-level = 3` and parallelizes across 16 CGUs with `lto = false`.
 
-Measured on a synthetic 400-fn ROM (14,173-line generated `main.rs`), incremental rebuild after a
-source change, isolated build dir per profile — note this box was at load average 17, so the
-fat-vs-thin numbers are noise-dominated and only the fast profile separates cleanly:
-
-| profile | rebuild (median of 12 / 4 runs) | ROM bytes |
-|---|---:|---:|
-| fat | ~38 s | 1,386,536 |
-| thin (default) | ~34 s | 1,343,432 |
-| fast | **~1.0 s** | 1,481,024 |
-
-So: thin is not *measurably* faster than fat here — it is not slower either, and it produces a 3.1%
-smaller ROM. **If you want the build-time win, it is `TISH_FAST_NATIVE_BUILD=1`**, which is ~35×
-faster and is the flag to use for day-to-day work. It is deliberately not the default: `opt-level=1`
-would silently make every shipped ROM slow, which is the opposite of what the rest of the GBA perf
-work is for.
-
-All three profiles were verified to boot under mgba and produce identical program output.
+`TISH_FAST_NATIVE_BUILD=1` remains the throwaway iteration profile (`opt-level = 1`); it is
+deliberately not the default, because shipping every ROM at opt-1 would undo the GBA perf work.
 
 ## Server-stability note
 


### PR DESCRIPTION
## Summary
- Unreachable top-level `FunDecl`s (including unused package exports after `merge_modules`) no longer become heap `Value::native` / `_cell` bindings at module init.
- Capture-free, call-only functions emit as `fn name_bfn(args: &[Value]) -> Value` (or keep an existing M5/`_native` twin) with direct call routing — no boxed binding.
- Empty typed arrays emit `Vec::<T>::new()` so leftover pools after DCE still compile (E0282).

This is the compiler-side fix for the GBA “import tax” (every imported function materialised whether called or not, ~151 bytes each).

## Test plan
- [x] `cargo test -p tishlang_compile --test regr_import_tax_dead_fn`
- [x] `cargo test -p tishlang_compile --test regr_import_tax_import_graph`
- [x] `cargo test -p tishlang_compile --test regr_empty_typed_vec`
- [ ] FFTA / other large GBA ROMs rebuild with this CLI and boot past module init without the prior heap cliff